### PR TITLE
[BE] feat: 테스트 메서드별 격리

### DIFF
--- a/backend/src/test/java/reviewme/config/TestConfig.java
+++ b/backend/src/test/java/reviewme/config/TestConfig.java
@@ -1,0 +1,14 @@
+package reviewme.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import reviewme.support.DatabaseCleaner;
+
+@TestConfiguration
+public class TestConfig {
+
+    @Bean
+    public DatabaseCleaner databaseCleaner() {
+        return new DatabaseCleaner();
+    }
+}

--- a/backend/src/test/java/reviewme/review/ReviewServiceTest.java
+++ b/backend/src/test/java/reviewme/review/ReviewServiceTest.java
@@ -6,16 +6,15 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import reviewme.keyword.Keyword;
 import reviewme.keyword.KeywordRepository;
 import reviewme.member.Member;
 import reviewme.member.MemberRepository;
 import reviewme.member.ReviewerGroup;
 import reviewme.member.ReviewerGroupRepository;
+import reviewme.support.ServiceTest;
 
-@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+@ServiceTest
 class ReviewServiceTest {
 
     @Autowired

--- a/backend/src/test/java/reviewme/support/DatabaseCleaner.java
+++ b/backend/src/test/java/reviewme/support/DatabaseCleaner.java
@@ -1,0 +1,42 @@
+package reviewme.support;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Table;
+import jakarta.persistence.metamodel.EntityType;
+import jakarta.transaction.Transactional;
+
+import java.util.List;
+import java.util.Set;
+
+public class DatabaseCleaner {
+
+    private static final String TRUNCATE_FORMAT = "TRUNCATE TABLE %s";
+    private static final String ALTER_FORMAT = "ALTER TABLE %s ALTER COLUMN ID RESTART WITH 1";
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private List<String> tableNames;
+
+    @PostConstruct
+    public void afterPropertiesSet() {
+        Set<EntityType<?>> entities = entityManager.getMetamodel().getEntities();
+        tableNames = entities.stream()
+                .filter(entity -> entity.getJavaType().isAnnotationPresent(Table.class))
+                .map(entity -> entity.getJavaType().getAnnotation(Table.class).name())
+                .toList();
+    }
+
+    @Transactional
+    public void execute() {
+        entityManager.flush();
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+        for (String tableName : tableNames) {
+            entityManager.createNativeQuery(TRUNCATE_FORMAT.formatted(tableName)).executeUpdate();
+            entityManager.createNativeQuery(ALTER_FORMAT.formatted(tableName)).executeUpdate();
+        }
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+    }
+}

--- a/backend/src/test/java/reviewme/support/DatabaseCleanerExtension.java
+++ b/backend/src/test/java/reviewme/support/DatabaseCleanerExtension.java
@@ -1,0 +1,15 @@
+package reviewme.support;
+
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+public class DatabaseCleanerExtension implements BeforeEachCallback {
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) {
+        SpringExtension.getApplicationContext(extensionContext)
+                .getBean(DatabaseCleaner.class)
+                .execute();
+    }
+}

--- a/backend/src/test/java/reviewme/support/ServiceTest.java
+++ b/backend/src/test/java/reviewme/support/ServiceTest.java
@@ -1,0 +1,17 @@
+package reviewme.support;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import reviewme.config.TestConfig;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@SpringBootTest(webEnvironment = WebEnvironment.NONE, classes = TestConfig.class)
+@ExtendWith(DatabaseCleanerExtension.class)
+public @interface ServiceTest {
+}


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #13

---

### 🚀 어떤 기능을 구현했나요 ?
- 테스트간 격리를 구현했습니다.

### 🔥 어떻게 해결했나요 ?
- JUnit5의 Extension을 활용했습니다
- `@Component`로 적용하지 않은 이유는, 실제 프로덕션 레벨에서 DB 클리너가 등록되지 않게 하기 위함입니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 궁금한 부분이 있다면 리뷰를 달아주세요
- 불필요한 코드나 컨벤션이 지켜졌는지 궁금해요

### 📚 참고 자료, 할 말
([Reference](https://blog.hoony.me/2024/05/27/woowacourse-level-2-week-6/))