### PR TITLE
[BE] feat: 리뷰어 그룹 설명 작성, 마감 기한 및 검증 로직 추가

### DIFF
--- a/backend/src/main/java/reviewme/global/exception/BadRequestException.java
+++ b/backend/src/main/java/reviewme/global/exception/BadRequestException.java
@@ -1,0 +1,8 @@
+package reviewme.global.exception;
+
+public abstract class BadRequestException extends ReviewMeException {
+
+    protected BadRequestException(String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/backend/src/main/java/reviewme/member/domain/ReviewerGroup.java
+++ b/backend/src/main/java/reviewme/member/domain/ReviewerGroup.java
@@ -8,16 +8,23 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import reviewme.member.domain.exception.DescriptionLengthExceedException;
+import reviewme.member.domain.exception.InvalidGroupNameLengthException;
 
 @Entity
 @Table(name = "reviewer_group")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class ReviewerGroup {
+
+    private static final Duration DEADLINE_DURATION = Duration.ofDays(7);
+    private static final int MAX_DESCRIPTION_LENGTH = 50;
+    private static final int MAX_GROUP_NAME_LENGTH = 100;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -30,12 +37,30 @@ public class ReviewerGroup {
     @Column(name = "group_name", nullable = false)
     private String groupName;
 
-    @Column(name = "deadline", nullable = false)
-    private LocalDateTime deadline;
+    @Column(name = "description", nullable = false)
+    private String description;
 
-    public ReviewerGroup(Member reviewee, String groupName, LocalDateTime deadline) {
+    @Column(name = "createdAt", nullable = false)
+    private LocalDateTime createdAt;
+
+    public ReviewerGroup(Member reviewee, String groupName, String description, LocalDateTime createdAt) {
+        if (groupName.isBlank() || groupName.length() > MAX_GROUP_NAME_LENGTH) {
+            throw new InvalidGroupNameLengthException(MAX_GROUP_NAME_LENGTH);
+        }
+        if (description.length() > MAX_DESCRIPTION_LENGTH) {
+            throw new DescriptionLengthExceedException(MAX_DESCRIPTION_LENGTH);
+        }
         this.reviewee = reviewee;
         this.groupName = groupName;
-        this.deadline = deadline;
+        this.description = description;
+        this.createdAt = createdAt;
+    }
+
+    public boolean isDeadlineExceeded(LocalDateTime now) {
+        return now.isAfter(getDeadline());
+    }
+
+    public LocalDateTime getDeadline() {
+        return createdAt.plus(DEADLINE_DURATION);
     }
 }

--- a/backend/src/main/java/reviewme/member/domain/exception/DescriptionLengthExceedException.java
+++ b/backend/src/main/java/reviewme/member/domain/exception/DescriptionLengthExceedException.java
@@ -1,0 +1,10 @@
+package reviewme.member.domain.exception;
+
+import reviewme.global.exception.BadRequestException;
+
+public class DescriptionLengthExceedException extends BadRequestException {
+
+    public DescriptionLengthExceedException(int maxLength) {
+        super("리뷰어 그룹 설명은 %d자 이하로 작성해야 합니다.".formatted(maxLength));
+    }
+}

--- a/backend/src/main/java/reviewme/member/domain/exception/InvalidGroupNameLengthException.java
+++ b/backend/src/main/java/reviewme/member/domain/exception/InvalidGroupNameLengthException.java
@@ -1,0 +1,10 @@
+package reviewme.member.domain.exception;
+
+import reviewme.global.exception.BadRequestException;
+
+public class InvalidGroupNameLengthException extends BadRequestException {
+
+    public InvalidGroupNameLengthException(int maxLength) {
+        super("리뷰 그룹 이름은 1글자 이상 %d글자 이하여야 합니다.".formatted(maxLength));
+    }
+}

--- a/backend/src/test/java/reviewme/member/domain/ReviewerGroupTest.java
+++ b/backend/src/test/java/reviewme/member/domain/ReviewerGroupTest.java
@@ -1,0 +1,49 @@
+package reviewme.member.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import reviewme.member.domain.exception.DescriptionLengthExceedException;
+import reviewme.member.domain.exception.InvalidGroupNameLengthException;
+
+class ReviewerGroupTest {
+
+    @Test
+    void 리뷰_그룹이_올바르게_생성된다() {
+        // given
+        Member sancho = new Member("산초");
+        String groupName = "a".repeat(100);
+        String description = "a".repeat(50);
+        LocalDateTime createdAt = LocalDateTime.of(2024, 7, 17, 12, 0);
+
+        // when, then
+        assertDoesNotThrow(() -> new ReviewerGroup(sancho, groupName, description, createdAt));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 101})
+    void 리뷰_그룹_이름_길이_제한을_벗어나는_경우_예외를_발생한다(int length) {
+        // given
+        String groupName = "a".repeat(length);
+        Member sancho = new Member("산초");
+        LocalDateTime createdAt = LocalDateTime.of(2024, 7, 17, 12, 0);
+        // when, then
+        assertThatThrownBy(() -> new ReviewerGroup(sancho, groupName, "설명", createdAt))
+                .isInstanceOf(InvalidGroupNameLengthException.class);
+    }
+
+    @Test
+    void 리뷰_그룹_설명_길이_제한을_벗어나는_경우_예외를_발생한다() {
+        // given
+        String description = "a".repeat(51);
+        Member sancho = new Member("산초");
+        LocalDateTime createdAt = LocalDateTime.of(2024, 7, 17, 12, 0);
+        // when, then
+        assertThatThrownBy(() -> new ReviewerGroup(sancho, "그룹 이름", description, createdAt))
+                .isInstanceOf(DescriptionLengthExceedException.class);
+    }
+}

--- a/backend/src/test/java/reviewme/review/ReviewServiceTest.java
+++ b/backend/src/test/java/reviewme/review/ReviewServiceTest.java
@@ -43,7 +43,9 @@ class ReviewServiceTest {
         // given
         memberRepository.save(new Member("산초"));
         Member reviewee = memberRepository.save(new Member("아루"));
-        reviewerGroupRepository.save(new ReviewerGroup(reviewee, "그룹A", LocalDateTime.of(2024, 1, 1, 1, 1)));
+        reviewerGroupRepository.save(
+                new ReviewerGroup(reviewee, "그룹A", "그룹 설명", LocalDateTime.of(2024, 1, 1, 1, 1))
+        );
         Keyword keyword1 = keywordRepository.save(new Keyword("꼼꼼해요"));
         Keyword keyword2 = keywordRepository.save(new Keyword("친절해요"));
 
@@ -77,6 +79,7 @@ class ReviewServiceTest {
         ReviewerGroup reviewerGroup = reviewerGroupRepository.save(new ReviewerGroup(
                 reviewee,
                 "그룹A",
+                "그룹 설명",
                 LocalDateTime.of(2024, 1, 1, 1, 1))
         );
         Review review = reviewRepository.save(new Review(reviewer, reviewerGroup));


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->
related: #21

### 🚀 어떤 기능을 구현했나요 ?
- 리뷰어 그룹의 설명 필드를 추가했어요.
- 그룹 이름, 설명 필드의 검증을 추가했어요.

### 🔥 어떻게 해결했나요 ?

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 마감 기한을 이전에 설명한 것과 다르게 구현했어요. 확인해 주세요.
- 픽스처 도입이 필요하다고 생각해요.
- VO 검증에 대한 논의가 필요합니다. 이전에는 Null/Empty 검증을 따로 뺐었는데, 이를 어떤 방식으로 처리해야 할까요? 도메인 자체로만 보았을 때에는 검증이 필요하지만, 어플리케이션 전반적으로 보았을 때에는 굳이 필요하지 않은 사항이기도 합니다. 제 의견은 전자인데, 그 경우에 예외 클래스가 양산된다는 단점이 있어요.