### PR TITLE
[FE] msw 모킹을 위한 리뷰 데이터 하드코딩

### DIFF
--- a/frontend/src/apis/review.ts
+++ b/frontend/src/apis/review.ts
@@ -70,7 +70,7 @@ export const getReviewListApi = async ({
   if (!response.ok) {
     throw new Error('리뷰 리스트를 불러오는 데 실패했습니다.');
   }
-  console.log(response);
+
   const data = await response.json();
   return data;
 };

--- a/frontend/src/mocks/handlers/review.ts
+++ b/frontend/src/mocks/handlers/review.ts
@@ -7,7 +7,7 @@ import { REVIEW_PREVIEW_LIST } from '../mockData/reviewPreviewList';
 import { REVIEW_WRITING_DATA } from '../mockData/reviewWritingData';
 
 const getDetailedReview = () =>
-  http.get(endPoint.gettingDetailedReview(0, 1), async ({ request }) => {
+  http.get(endPoint.gettingDetailedReview(123456, 123456), async ({ request }) => {
     return HttpResponse.json(DETAILED_REVIEW_MOCK_DATA);
   });
 

--- a/frontend/src/pages/ReviewPreviewListPage/index.tsx
+++ b/frontend/src/pages/ReviewPreviewListPage/index.tsx
@@ -9,7 +9,7 @@ import SearchSection from './components/SearchSection';
 import * as S from './styles';
 
 const USER_SEARCH_PLACE_HOLDER = '레포지토리명을 검색하세요.';
-const options = ['최신순', '오래된순'];
+const OPTIONS = ['최신순', '오래된순'];
 
 const ReviewPreviewListPage = () => {
   const [reviews, setReviews] = useState<ReviewPreview[]>([]);
@@ -34,13 +34,14 @@ const ReviewPreviewListPage = () => {
   }, []);
 
   const handleReviewClick = (id: number) => {
-    navigate(`/user/detailed-review/${id}?memberId=${4}`);
+    //navigate(`/user/detailed-review/${id}?memberId=${4}`);
+    navigate(`/user/detailed-review/${123456}?memberId=${123456}`); // NOTE: MSW용 하드코딩
   };
 
   return (
     <>
       <S.Layout>
-        <SearchSection onChange={() => {}} options={options} placeholder={USER_SEARCH_PLACE_HOLDER} />
+        <SearchSection onChange={() => {}} options={OPTIONS} placeholder={USER_SEARCH_PLACE_HOLDER} />
         <S.ReviewSection>
           {loading && <p>로딩 중...</p>}
           {error && <p>{error}</p>}

--- a/frontend/src/pages/ReviewPreviewListPage/index.tsx
+++ b/frontend/src/pages/ReviewPreviewListPage/index.tsx
@@ -10,6 +10,7 @@ import * as S from './styles';
 
 const USER_SEARCH_PLACE_HOLDER = '레포지토리명을 검색하세요.';
 const OPTIONS = ['최신순', '오래된순'];
+const MEMBER_ID = 2;
 
 const ReviewPreviewListPage = () => {
   const [reviews, setReviews] = useState<ReviewPreview[]>([]);
@@ -21,7 +22,7 @@ const ReviewPreviewListPage = () => {
   useEffect(() => {
     const fetchReviews = async () => {
       try {
-        const data = await getReviewListApi({ revieweeId: 1, lastReviewId: 3, memberId: 1 });
+        const data = await getReviewListApi({ revieweeId: 1, lastReviewId: 5, memberId: MEMBER_ID });
         setReviews(data.reviews);
         setLoading(false);
       } catch (error) {
@@ -34,8 +35,8 @@ const ReviewPreviewListPage = () => {
   }, []);
 
   const handleReviewClick = (id: number) => {
-    //navigate(`/user/detailed-review/${id}?memberId=${4}`);
-    navigate(`/user/detailed-review/${123456}?memberId=${123456}`); // NOTE: MSW용 하드코딩
+    navigate(`/user/detailed-review/${id}?memberId=${MEMBER_ID}`);
+    // navigate(`/user/detailed-review/${123456}?memberId=${123456}`); // NOTE: MSW용 하드코딩
   };
 
   return (


### PR DESCRIPTION
- resolves #125 

---

### 🚀 어떤 기능을 구현했나요 ?
- 리뷰 목록 페이지에서 리뷰를 클릭했을 때, 상세 페이지 정보를 받아오는 api를 msw를 사용해 모킹한다.

### 🔥 어떻게 해결했나요 ?
- msw 핸들러 목 데이터에 맞게 id 수정
```ts
  http.get(endPoint.gettingDetailedReview(123456, 123456), async ({ request }) => {
    return HttpResponse.json(DETAILED_REVIEW_MOCK_DATA);
  });
```

리뷰 목록 페이지에서 상세 페이지로 넘어갈 때, 그에 맞게 navigate url 변경
```ts
  const handleReviewClick = (id: number) => {
    //navigate(`/user/detailed-review/${id}?memberId=${4}`);
    navigate(`/user/detailed-review/${123456}?memberId=${123456}`); // NOTE: MSW용 하드코딩
  };
```

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- msw 모킹은 제대로 되고는 있지만 그래도 확인 부탁드립니다^^

### 📚 참고 자료, 할 말
- 오늘 하루 정말 열심히 사는 것 같아용~^^