### PR TITLE
[FE] 사이드바 및 모달 사용성 개선

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,7 +9,7 @@ const App = () => {
   return (
     <PageLayout>
       {isSidebarModalOpen && (
-        <SideModal isSidebarHidden={isSidebarHidden}>
+        <SideModal isSidebarHidden={isSidebarHidden} closeModal={closeSidebar}>
           <Sidebar closeSidebar={closeSidebar} />
         </SideModal>
       )}

--- a/frontend/src/components/common/modals/ModalBackground/index.tsx
+++ b/frontend/src/components/common/modals/ModalBackground/index.tsx
@@ -1,9 +1,22 @@
-import React from 'react';
+import React, { PropsWithChildren, useRef } from 'react';
+
+import { useModalClose } from '@/hooks';
 
 import * as S from './styles';
 
-const ModalBackground = ({ children }: React.PropsWithChildren) => {
-  return <S.ModalBackground>{children}</S.ModalBackground>;
+interface ModalBackgroundProps {
+  closeModal: () => void;
+}
+
+const ModalBackground: React.FC<PropsWithChildren<ModalBackgroundProps>> = ({ children, closeModal }) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+  useModalClose(closeModal, modalRef);
+
+  return (
+    <S.ModalBackground>
+      <div ref={modalRef}>{children}</div>
+    </S.ModalBackground>
+  );
 };
 
 export default ModalBackground;

--- a/frontend/src/components/common/modals/ModalBackground/index.tsx
+++ b/frontend/src/components/common/modals/ModalBackground/index.tsx
@@ -9,14 +9,10 @@ interface ModalBackgroundProps {
 }
 
 const ModalBackground: React.FC<PropsWithChildren<ModalBackgroundProps>> = ({ children, closeModal }) => {
-  const modalRef = useRef<HTMLDivElement>(null);
-  useModalClose(closeModal, modalRef);
+  const modalBackgroundRef = useRef<HTMLDivElement>(null);
+  useModalClose(closeModal, modalBackgroundRef);
 
-  return (
-    <S.ModalBackground>
-      <div ref={modalRef}>{children}</div>
-    </S.ModalBackground>
-  );
+  return <S.ModalBackground ref={modalBackgroundRef}>{children}</S.ModalBackground>;
 };
 
 export default ModalBackground;

--- a/frontend/src/components/common/modals/SideModal/index.tsx
+++ b/frontend/src/components/common/modals/SideModal/index.tsx
@@ -1,6 +1,7 @@
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, useRef } from 'react';
 
 import ModalPortal from '@/components/common/modals/ModalPortal';
+import useModalClose from '@/hooks/useModalClose';
 
 import ModalBackground from '../ModalBackground';
 
@@ -8,13 +9,19 @@ import * as S from './styles';
 
 interface SideModalProps {
   isSidebarHidden: boolean;
+  closeModal: () => void;
 }
 
-const SideModal: React.FC<PropsWithChildren<SideModalProps>> = ({ children: Sidebar, isSidebarHidden }) => {
+const SideModal: React.FC<PropsWithChildren<SideModalProps>> = ({ children: Sidebar, isSidebarHidden, closeModal }) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+  useModalClose(closeModal, modalRef);
+
   return (
     <ModalPortal id="sidebarModal-portal">
       <ModalBackground>
-        <S.SidebarWrapper $isSidebarHidden={isSidebarHidden}>{Sidebar}</S.SidebarWrapper>
+        <S.SidebarWrapper ref={modalRef} $isSidebarHidden={isSidebarHidden}>
+          {Sidebar}
+        </S.SidebarWrapper>
       </ModalBackground>
     </ModalPortal>
   );

--- a/frontend/src/components/common/modals/SideModal/index.tsx
+++ b/frontend/src/components/common/modals/SideModal/index.tsx
@@ -1,7 +1,6 @@
-import React, { PropsWithChildren, useRef } from 'react';
+import React, { PropsWithChildren } from 'react';
 
 import ModalPortal from '@/components/common/modals/ModalPortal';
-import { useModalClose } from '@/hooks';
 
 import ModalBackground from '../ModalBackground';
 
@@ -13,15 +12,10 @@ interface SideModalProps {
 }
 
 const SideModal: React.FC<PropsWithChildren<SideModalProps>> = ({ children: Sidebar, isSidebarHidden, closeModal }) => {
-  const modalRef = useRef<HTMLDivElement>(null);
-  useModalClose(closeModal, modalRef);
-
   return (
     <ModalPortal id="sidebarModal-portal">
-      <ModalBackground>
-        <S.SidebarWrapper ref={modalRef} $isSidebarHidden={isSidebarHidden}>
-          {Sidebar}
-        </S.SidebarWrapper>
+      <ModalBackground closeModal={closeModal}>
+        <S.SidebarWrapper $isSidebarHidden={isSidebarHidden}>{Sidebar}</S.SidebarWrapper>
       </ModalBackground>
     </ModalPortal>
   );

--- a/frontend/src/components/common/modals/SideModal/index.tsx
+++ b/frontend/src/components/common/modals/SideModal/index.tsx
@@ -1,7 +1,7 @@
 import React, { PropsWithChildren, useRef } from 'react';
 
 import ModalPortal from '@/components/common/modals/ModalPortal';
-import useModalClose from '@/hooks/useModalClose';
+import { useModalClose } from '@/hooks';
 
 import ModalBackground from '../ModalBackground';
 

--- a/frontend/src/components/common/modals/SideModal/styles.ts
+++ b/frontend/src/components/common/modals/SideModal/styles.ts
@@ -8,5 +8,5 @@ export const SidebarWrapper = styled.div<SidebarWrapperProps>`
   position: absolute;
   top: 0;
   left: ${(props) => (props.$isSidebarHidden ? '-100%' : 0)};
-  transition: left 1s ease-in-out;
+  transition: left 0.2s ease-in-out;
 `;

--- a/frontend/src/components/layouts/Sidebar/index.tsx
+++ b/frontend/src/components/layouts/Sidebar/index.tsx
@@ -43,7 +43,7 @@ const Sidebar = ({ closeSidebar }: SidebarProps) => {
       <S.MenuList>
         {menuItems.map((item) => (
           <S.MenuItem key={item.path} selected={location.pathname === item.path}>
-            <Link to={item.path}>{item.label}</Link>
+            <Link to={item.path} onClick={closeSidebar}>{item.label}</Link>
           </S.MenuItem>
         ))}
       </S.MenuList>

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export { default as useSidebar } from './useSidebar';
+export { default as useModalClose } from './useModalClose';

--- a/frontend/src/hooks/useModalClose.ts
+++ b/frontend/src/hooks/useModalClose.ts
@@ -1,0 +1,35 @@
+import { useEffect, RefObject } from 'react';
+
+const useModalClose = (closeModal: () => void, modalRef: RefObject<HTMLElement>) => {
+  const isNodeElement = (element: EventTarget | null): element is Node => {
+    return element instanceof Node;
+  };
+
+  const isModalChildren = (targetElement: Node | null) => {
+    return modalRef.current ? modalRef.current.contains(targetElement) : false;
+  };
+
+  useEffect(() => {
+    const handleBackgroundClick = (event: MouseEvent) => {
+      if (isNodeElement(event.target) && !isModalChildren(event.target)) {
+        closeModal();
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') closeModal();
+    };
+
+    // NOTE: 모달을 여는 클릭 이벤트가 모달을 닫는 핸들러의 이벤트로 들어가는 것을 막기 위해
+    // 모달을 닫는 클릭 이벤트에 대한 핸들러를 capture 단계에서 추가
+    document.addEventListener('click', handleBackgroundClick, true);
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('click', handleBackgroundClick, true);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [closeModal, modalRef]);
+};
+
+export default useModalClose;

--- a/frontend/src/hooks/useModalClose.ts
+++ b/frontend/src/hooks/useModalClose.ts
@@ -13,6 +13,7 @@ const useModalClose = (closeModal: () => void, modalBackgroundRef: RefObject<HTM
     return element instanceof HTMLElement;
   };
 
+  // NOTE: esc 키를 눌렀을 때 햄버거 버튼이 포커싱되는 문제 해결을 위한 함수
   const blurFocusing = () => {
     const activeElement = document.activeElement;
 
@@ -20,21 +21,22 @@ const useModalClose = (closeModal: () => void, modalBackgroundRef: RefObject<HTM
     if (typeof activeElement.blur === 'function') activeElement.blur();
   };
 
+  const handleBackgroundClick = (event: MouseEvent) => {
+    if (isNodeElement(event.target) && isModalBackground(event.target)) {
+      closeModal();
+    }
+  };
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+
+      blurFocusing();
+      closeModal();
+    }
+  };
+
   useEffect(() => {
-    const handleBackgroundClick = (event: MouseEvent) => {
-      if (isNodeElement(event.target) && isModalBackground(event.target)) {
-        closeModal();
-      }
-    };
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        event.preventDefault();
-        blurFocusing();
-        closeModal();
-      }
-    };
-
     const modalBackgroundElement = modalBackgroundRef.current;
 
     modalBackgroundElement?.addEventListener('click', handleBackgroundClick);

--- a/frontend/src/hooks/useModalClose.ts
+++ b/frontend/src/hooks/useModalClose.ts
@@ -9,6 +9,17 @@ const useModalClose = (closeModal: () => void, modalBackgroundRef: RefObject<HTM
     return modalBackgroundRef.current ? modalBackgroundRef.current === targetElement : false;
   };
 
+  const isHTMLElement = (element: Element | null): element is HTMLElement => {
+    return element instanceof HTMLElement;
+  };
+
+  const blurFocusing = () => {
+    const activeElement = document.activeElement;
+
+    if (!isHTMLElement(activeElement)) return;
+    if (typeof activeElement.blur === 'function') activeElement.blur();
+  };
+
   useEffect(() => {
     const handleBackgroundClick = (event: MouseEvent) => {
       if (isNodeElement(event.target) && isModalBackground(event.target)) {
@@ -17,16 +28,20 @@ const useModalClose = (closeModal: () => void, modalBackgroundRef: RefObject<HTM
     };
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') closeModal();
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        blurFocusing();
+        closeModal();
+      }
     };
 
-    const modalBackGroundElement = modalBackgroundRef.current;
+    const modalBackgroundElement = modalBackgroundRef.current;
 
-    modalBackGroundElement?.addEventListener('click', handleBackgroundClick);
+    modalBackgroundElement?.addEventListener('click', handleBackgroundClick);
     document.addEventListener('keydown', handleKeyDown);
 
     return () => {
-      modalBackGroundElement?.removeEventListener('click', handleBackgroundClick);
+      modalBackgroundElement?.removeEventListener('click', handleBackgroundClick);
       document.removeEventListener('keydown', handleKeyDown);
     };
   }, [closeModal, modalBackgroundRef]);

--- a/frontend/src/hooks/useModalClose.ts
+++ b/frontend/src/hooks/useModalClose.ts
@@ -1,17 +1,17 @@
 import { useEffect, RefObject } from 'react';
 
-const useModalClose = (closeModal: () => void, modalRef: RefObject<HTMLElement>) => {
+const useModalClose = (closeModal: () => void, modalBackgroundRef: RefObject<HTMLElement>) => {
   const isNodeElement = (element: EventTarget | null): element is Node => {
     return element instanceof Node;
   };
 
-  const isModalChildren = (targetElement: Node | null) => {
-    return modalRef.current ? modalRef.current.contains(targetElement) : false;
+  const isModalBackground = (targetElement: Node | null) => {
+    return modalBackgroundRef.current ? modalBackgroundRef.current === targetElement : false;
   };
 
   useEffect(() => {
     const handleBackgroundClick = (event: MouseEvent) => {
-      if (isNodeElement(event.target) && !isModalChildren(event.target)) {
+      if (isNodeElement(event.target) && isModalBackground(event.target)) {
         closeModal();
       }
     };
@@ -20,16 +20,16 @@ const useModalClose = (closeModal: () => void, modalRef: RefObject<HTMLElement>)
       if (event.key === 'Escape') closeModal();
     };
 
-    // NOTE: 모달을 여는 클릭 이벤트가 모달을 닫는 핸들러의 이벤트로 들어가는 것을 막기 위해
-    // 모달을 닫는 클릭 이벤트에 대한 핸들러를 capture 단계에서 추가
-    document.addEventListener('click', handleBackgroundClick, true);
+    const modalBackGroundElement = modalBackgroundRef.current;
+
+    modalBackGroundElement?.addEventListener('click', handleBackgroundClick);
     document.addEventListener('keydown', handleKeyDown);
 
     return () => {
-      document.removeEventListener('click', handleBackgroundClick, true);
+      modalBackGroundElement?.removeEventListener('click', handleBackgroundClick);
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [closeModal, modalRef]);
+  }, [closeModal, modalBackgroundRef]);
 };
 
 export default useModalClose;

--- a/frontend/src/hooks/useSidebar.ts
+++ b/frontend/src/hooks/useSidebar.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 const useSidebar = () => {
-  const OPEN_TIME = 0.5;
+  const OPEN_TIME = 0.2;
 
   const [isSidebarModalOpen, setIsSidebarModalOpen] = useState(false);
   const [isSidebarHidden, setIsSidebarHidden] = useState(true);

--- a/frontend/src/hooks/useSidebar.ts
+++ b/frontend/src/hooks/useSidebar.ts
@@ -1,21 +1,19 @@
 import { useState } from 'react';
 
 const useSidebar = () => {
-  const CLOSE_TIME = 1000;
   const OPEN_TIME = 0.5;
 
   const [isSidebarModalOpen, setIsSidebarModalOpen] = useState(false);
   const [isSidebarHidden, setIsSidebarHidden] = useState(true);
 
   const closeSidebar = () => {
+    setIsSidebarModalOpen(false);
     setIsSidebarHidden(true);
-    setTimeout(() => {
-      setIsSidebarModalOpen(false);
-    }, CLOSE_TIME);
   };
 
   const openSidebar = () => {
     setIsSidebarModalOpen(true);
+
     setTimeout(() => {
       setIsSidebarHidden(false);
     }, OPEN_TIME);


### PR DESCRIPTION

- resolves #137 

---

### 🚀 어떤 기능을 구현했나요 ?
- 사이드바 리팩토링
  - 사이드바가 열릴 때는 등장 애니메이션이 여전히 존재함, 단 더 빠르게 등장 (0.2초)
  - 닫힐 때의 애니메이션 제거
- 모달 닫는 기능 추가
  - 모달 배경 클릭, esc 키를 누른 경우 모달 닫힘
- 사이드바 메뉴의 아이템을 선택해 특정 페이지로 이동한 경우에도 사이드바 닫힘

### 🔥 어떻게 해결했나요 ?
- `useModalClose` 훅 생성: 모달이 공통 컴포넌트인 만큼 모달을 esc 또는 배경 클릭으로 닫는 기능을 반복적으로 사용할 것 같아 별도의 훅으로 분리했습니다.
  - 이렇게 훅을 사용하는 쪽에서 모달 컴포넌트를 전달해주면 됩니다.
  ```ts
    const modalRef = useRef<HTMLDivElement>(null);
    useModalClose(closeModal, modalRef);

    ...

    <S.SidebarWrapper ref={modalRef} $isSidebarHidden={isSidebarHidden}>
   ``` 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- handler 네이밍 규칙이 잘 지켜졌는지 궁금합니다. 
- `useModalClose` 훅을 hooks 폴더 내부에 만들었는데, 모달 폴더 안에 있어야 할까요?
- `useModalClose` 훅에서 어떤 if문은 (가독성을 위해 사용하는 게 좋다고 생각해서)중괄호를 사용했고, 어떤 것은 사용하지 않았는데 판단이 적절했는지에 대한 의견을 듣고 싶습니다.

### 📚 참고 자료, 할 말
- 리팩토링할 때 코드를 혼자 요상하게 읽고 삽질하지 말고 코드를 작성했던 사람에게 질문을 해봅시다... 내 2시간...