### PR TITLE
[FE] Children 속성이 필수인 타입 제작

### DIFF
--- a/frontend/src/components/common/Button/index.tsx
+++ b/frontend/src/components/common/Button/index.tsx
@@ -1,4 +1,4 @@
-import { ButtonType } from '@/types/styles';
+import { ButtonType } from '@/types';
 
 import * as S from './styles';
 

--- a/frontend/src/components/common/Button/styles.ts
+++ b/frontend/src/components/common/Button/styles.ts
@@ -1,7 +1,7 @@
 import { css, Theme } from '@emotion/react';
 import styled from '@emotion/styled';
 
-import { ButtonType } from '@/types/styles';
+import { ButtonType } from '@/types';
 
 const primaryStyle = (theme: Theme) => css`
   color: ${theme.colors.white};

--- a/frontend/src/components/common/modals/ConfirmModal/index.tsx
+++ b/frontend/src/components/common/modals/ConfirmModal/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { ButtonType } from '@/types/styles';
+import { ButtonType } from '@/types';
 
 import Button from '../../Button';
 import ModalBackground from '../ModalBackground';

--- a/frontend/src/types/essentialPropsWithChildren.ts
+++ b/frontend/src/types/essentialPropsWithChildren.ts
@@ -1,0 +1,5 @@
+import { ReactNode } from 'react';
+
+export type EssentialPropsWithChildren<P = object> = P & {
+  children: ReactNode;
+};

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,2 +1,5 @@
 export * from './review';
 export * from './theme';
+export * from './emotion';
+export * from './styles';
+export * from './essentialPropsWithChildren';


### PR DESCRIPTION
- resolves #143 

---

### 🚀 어떤 기능을 구현했나요 ?
- `children`타입을 필수로 받는 타입인 `EssentialPropsWithChildren` 타입을 만들었습니다.
- 그 외 기존 tyeps 폴더의 `index.ts`에서 일부 파일들의 export가 누락된 것을 발견해 추가 및 import 구문을 수정했습니다.

### 🔥 어떻게 해결했나요 ?
- 아래와 같은 `children` 필수 타입을 만들었습니다.
```ts
export type EssentialPropsWithChildren<P = object> = P & {
  children: ReactNode;
};
```

- 이 타입은 P를 통해 객체 타입을 병합할 수 있기 때문에 다른 타입과 함께 사용할 수 있습니다. 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 아래 참고 자료를 참고해주세용

### 📚 참고 자료, 할 말
이 타입은 다음과 같이 사용할 수 있습니다.
```tsx
// Component.tsx
...
import { EssentialPropsWithChildren } from '@/types';

interface ComponentProps {
   title: string;
}

const Component: React.FC<EssentialPropsWithChildren<ComponentProps>> = ({ title, children }) => {
  return (
    <div>
      <p>{title}</p>
      {children}
    </div>
  );
};


// App.tsx
const App = () => {
  return (
    <div>
      {/* 1. children이 없을 때 에러 발생 */}
      {/* 아래 줄의 주석을 해제하면 children이 없기 때문에 에러가 발생합니다 */}
      {/* <Component title="Hello" /> */}

      {/* 2. children은 있지만 title을 사용하지 않아 에러 발생 */}
      {/* 아래 줄의 주석을 해제하면 title이 없기 때문에 에러가 발생합니다 */}
      {/* <Component>
        <p>This is a child</p>
      </Component> */}

      {/* 올바른 사용 예 */}
      <Component title="Hello">
        <p>This is a child</p>
      </Component>
    </div>
  );
};

```