### PR TITLE
[FE] 페이지 상단 이동 버튼 구현

### DIFF
--- a/frontend/src/assets/upperArrow.svg
+++ b/frontend/src/assets/upperArrow.svg
@@ -1,0 +1,3 @@
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M24 38V10M24 10L10 24M24 10L38 24" stroke="#ffffff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/components/common/TopButton/index.tsx
+++ b/frontend/src/components/common/TopButton/index.tsx
@@ -1,4 +1,4 @@
-import UpperArrow from '@/assets/upperArrow.svg';
+import UpperArrowIcon from '@/assets/upperArrow.svg';
 import useTopButton from '@/hooks/useTopButton';
 
 import * as S from './style';
@@ -10,7 +10,7 @@ const TopButton = () => {
 
   return (
     <S.TopButton onClick={scrollToTop} type="button">
-      <S.ArrowImage src={UpperArrow} alt="위 화살표"></S.ArrowImage>
+      <S.ArrowImage src={UpperArrowIcon} alt="위 화살표"></S.ArrowImage>
     </S.TopButton>
   );
 };

--- a/frontend/src/components/common/TopButton/index.tsx
+++ b/frontend/src/components/common/TopButton/index.tsx
@@ -1,0 +1,18 @@
+import UpperArrow from '@/assets/upperArrow.svg';
+import useTopButton from '@/hooks/useTopButton';
+
+import * as S from './style';
+
+const TopButton = () => {
+  const { showTopButton, scrollToTop } = useTopButton();
+
+  if (!showTopButton) return null;
+
+  return (
+    <S.TopButton onClick={scrollToTop} type="button">
+      <S.ArrowImage src={UpperArrow} alt="위 화살표"></S.ArrowImage>
+    </S.TopButton>
+  );
+};
+
+export default TopButton;

--- a/frontend/src/components/common/TopButton/style.ts
+++ b/frontend/src/components/common/TopButton/style.ts
@@ -1,0 +1,26 @@
+import styled from '@emotion/styled';
+
+export const TopButton = styled.button`
+  position: fixed;
+  right: 5rem;
+  bottom: 5rem;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 5rem;
+  height: 5rem;
+
+  color: ${({ theme }) => theme.colors.white};
+
+  background-color: ${({ theme }) => theme.colors.primary};
+  filter: drop-shadow(0 0 0.2rem ${({ theme }) => theme.colors.primary});
+  border: 0.2rem solid ${({ theme }) => theme.colors.primary};
+  border-radius: 100%;
+`;
+
+export const ArrowImage = styled.img`
+  width: 3rem;
+  height: 3rem;
+`;

--- a/frontend/src/components/common/index.tsx
+++ b/frontend/src/components/common/index.tsx
@@ -5,4 +5,5 @@ export { default as ProjectImg } from './ProjectImg';
 export { default as ReviewDate } from './ReviewDate';
 export { default as ReviewComment } from './ReviewComment';
 export { default as MultilineTextViewer } from './MultilineTextViewer';
+export { default as TopButton } from './TopButton';
 export * from './modals';

--- a/frontend/src/components/layouts/PageLayout/index.tsx
+++ b/frontend/src/components/layouts/PageLayout/index.tsx
@@ -1,11 +1,14 @@
 import { PropsWithChildren } from 'react';
 
+import { TopButton } from '@/components/common';
+
 import * as S from './styles';
 
 const PageLayout = ({ children }: PropsWithChildren) => {
   return (
     <S.Layout>
       <S.Wrapper>{children}</S.Wrapper>
+      <TopButton />
     </S.Layout>
   );
 };

--- a/frontend/src/hooks/useTopButton.ts
+++ b/frontend/src/hooks/useTopButton.ts
@@ -1,0 +1,39 @@
+import { useState, useEffect } from 'react';
+
+const TOP_BUTTON_DISPLAY_THRESHOLD = 500;
+
+interface UseTopButtonResult {
+  showTopButton: boolean;
+  scrollToTop: () => void;
+}
+
+const useTopButton = (): UseTopButtonResult => {
+  const [showTopButton, setShowTopButton] = useState(false);
+
+  useEffect(() => {
+    const handleShowTopButton = () => {
+      if (window.scrollY > TOP_BUTTON_DISPLAY_THRESHOLD) {
+        setShowTopButton(true);
+      } else {
+        setShowTopButton(false);
+      }
+    };
+
+    window.addEventListener('scroll', handleShowTopButton);
+
+    return () => {
+      window.removeEventListener('scroll', handleShowTopButton);
+    };
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
+
+  return { showTopButton, scrollToTop };
+};
+
+export default useTopButton;

--- a/frontend/src/hooks/useTopButton.ts
+++ b/frontend/src/hooks/useTopButton.ts
@@ -10,15 +10,15 @@ interface UseTopButtonResult {
 const useTopButton = (): UseTopButtonResult => {
   const [showTopButton, setShowTopButton] = useState(false);
 
-  useEffect(() => {
-    const handleShowTopButton = () => {
-      if (window.scrollY > TOP_BUTTON_DISPLAY_THRESHOLD) {
-        setShowTopButton(true);
-      } else {
-        setShowTopButton(false);
-      }
-    };
+  const handleShowTopButton = () => {
+    if (window.scrollY > TOP_BUTTON_DISPLAY_THRESHOLD) {
+      setShowTopButton(true);
+    } else {
+      setShowTopButton(false);
+    }
+  };
 
+  useEffect(() => {
     window.addEventListener('scroll', handleShowTopButton);
 
     return () => {


### PR DESCRIPTION
- resolves #141 

---

### 🚀 어떤 기능을 구현했나요 ?
- 페이지 상단 이동 버튼을 구현했습니다.

### 🔥 어떻게 해결했나요 ?
- `window.scrollTo` 메서드를 사용해서 스크롤 기능을 구현했습니다.
- 버튼이 항상 보이는 것이 아닌, 500px 이상 내려갔을 때 버튼이 보이도록 구현했습니다.
- 버튼의 핵심 로직을 커스텀 훅으로 분리했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
![image](https://github.com/user-attachments/assets/648ae422-4262-4f0d-a87f-b7e52d19d64e)
구현 모습입니다.