### PR TITLE
[FE] refactor: 공용 모달 훅 추가 및 LongReviewItem 리팩토링

### DIFF
--- a/frontend/src/components/common/LongReviewItem/index.tsx
+++ b/frontend/src/components/common/LongReviewItem/index.tsx
@@ -8,14 +8,27 @@ interface LongReviewItemProps extends TextareaHTMLAttributes<HTMLTextAreaElement
   minLength: number;
   maxLength: number;
   initialValue?: string;
+  handleTextareaChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
 }
 
-const LongReviewItem = ({ minLength, maxLength, initialValue = '', style, ...rest }: LongReviewItemProps) => {
+const LongReviewItem = ({
+  minLength,
+  maxLength,
+  initialValue = '',
+  handleTextareaChange,
+  style,
+  ...rest
+}: LongReviewItemProps) => {
   const { value, textLength, isError, errorMessage, handleChange, handleBlur } = useLongReviewItem({
     minLength,
     maxLength,
     initialValue,
   });
+
+  const handleWriteTextarea = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    handleChange(e);
+    handleTextareaChange(e);
+  };
 
   return (
     <S.TextareaContainer>
@@ -23,7 +36,7 @@ const LongReviewItem = ({ minLength, maxLength, initialValue = '', style, ...res
         value={value}
         $isError={isError}
         $style={style}
-        onChange={handleChange}
+        onChange={handleWriteTextarea}
         onBlur={handleBlur}
         {...rest}
       />

--- a/frontend/src/hooks/useModals.ts
+++ b/frontend/src/hooks/useModals.ts
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+
+interface Modals {
+  [key: string]: boolean;
+}
+
+const useModals = () => {
+  const [modals, setModals] = useState<Modals>({});
+
+  const openModal = (key: string) => {
+    setModals((prev) => ({
+      ...prev,
+      [key]: true,
+    }));
+  };
+
+  const closeModal = (key: string) => {
+    setModals((prev) => ({
+      ...prev,
+      [key]: false,
+    }));
+  };
+
+  const isOpen = (key: string) => modals[key];
+
+  return { isOpen, openModal, closeModal };
+};
+
+export default useModals;


### PR DESCRIPTION
- resolves #257 

---

### 🚀 어떤 기능을 구현했나요 ?
- 공용 모달 훅 추가 및 LongReviewItem 리팩토링

### 🔥 어떻게 해결했나요 ?
- 공용 모달 상태를 관리하는 훅 `useModals`를 추가했습니다.
- LongReviewItem이 외부의 Change Event를 props로 받아서 textarea의 값을 사용할 수 있도록 변경했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
