### PR TITLE
[FE] feat: 내용 확인 체크박스에 체크해야 모달을 닫을 수 있는 기능 추가 및 모달 스타일 조정

### DIFF
--- a/frontend/src/pages/LandingPage/components/ReviewGroupDataModal/index.tsx
+++ b/frontend/src/pages/LandingPage/components/ReviewGroupDataModal/index.tsx
@@ -1,7 +1,10 @@
+import { useState } from 'react';
+
 import { AlertModal } from '@/components';
+import Checkbox from '@/components/common/Checkbox';
 import { useGroupAccessCode } from '@/hooks';
 
-import CopyTextButton from '../CopyTextButton';
+import { CopyTextButton } from '../index';
 
 import * as S from './styles';
 interface URLModalProps {
@@ -10,11 +13,21 @@ interface URLModalProps {
 }
 
 const ReviewGroupDataModal = ({ reviewRequestCode, closeModal }: URLModalProps) => {
+  const [isChecked, setIsChecked] = useState(false);
   const { groupAccessCode } = useGroupAccessCode();
+
+  const handleCheckboxClick = () => {
+    setIsChecked(!isChecked);
+  };
+
+  const handleCloseButtonClick = () => {
+    if (isChecked) closeModal();
+    return;
+  };
 
   return (
     <AlertModal
-      closeButton={{ content: '닫기', type: 'secondary', handleClick: closeModal }}
+      closeButton={{ content: '닫기', type: 'secondary', handleClick: handleCloseButtonClick }}
       handleClose={null}
       isClosableOnBackground={false}
     >
@@ -29,17 +42,21 @@ const ReviewGroupDataModal = ({ reviewRequestCode, closeModal }: URLModalProps) 
           <S.ReviewGroupDataItem>
             <S.DataName>리뷰 확인 코드</S.DataName>
             <S.Data>{groupAccessCode}</S.Data>
-            <CopyTextButton
-              targetText={groupAccessCode ? groupAccessCode : ''}
-              alt="리뷰 확인 코드 복사하기"
-            ></CopyTextButton>
+            <CopyTextButton targetText={groupAccessCode ?? ''} alt="리뷰 확인 코드 복사하기"></CopyTextButton>
           </S.ReviewGroupDataItem>
+        </S.ReviewGroupDataContainer>
+        <S.WarningContainer>
           <S.CheckContainer>
-            <S.Checkbox />
+            <Checkbox
+              id="is-confirmed-checkbox"
+              isChecked={isChecked}
+              onChange={handleCheckboxClick}
+              $style={{ width: '2.3rem', height: '2.3rem' }}
+            />
             <S.CheckMessage>URL과 코드를 다른 곳에 저장해두었어요!</S.CheckMessage>
           </S.CheckContainer>
           <S.Warning>* 창이 닫히면 코드를 다시 확인할 수 없어요!</S.Warning>
-        </S.ReviewGroupDataContainer>
+        </S.WarningContainer>
       </S.ReviewGroupDataModal>
     </AlertModal>
   );

--- a/frontend/src/pages/LandingPage/components/ReviewGroupDataModal/styles.ts
+++ b/frontend/src/pages/LandingPage/components/ReviewGroupDataModal/styles.ts
@@ -6,27 +6,25 @@ export const ReviewGroupDataModal = styled.div`
 
   width: 52rem;
   height: 23rem;
-
-  gap: 4rem;
 `;
 
 export const ReviewGroupDataTitle = styled.h3`
   font-weight: ${({ theme }) => theme.fontWeight.bold};
   font-size: 2rem;
+  margin-bottom: 4rem;
 `;
 
 export const ReviewGroupDataContainer = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 1.7rem;
-  min-width: 0;
+  gap: 2.4rem;
 `;
 
 export const ReviewGroupDataItem = styled.div`
   display: flex;
   justify-content: space-between;
   gap: 1.8rem;
-
+  align-items: center;
   font-size: 1.5rem;
 `;
 
@@ -40,20 +38,33 @@ export const Data = styled.span`
   color: ${({ theme }) => theme.colors.gray};
 `;
 
-export const CheckContainer = styled.div`
+export const WarningContainer = styled.div`
   display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+
+  margin-top: 3.7rem;
+`;
+
+export const CheckContainer = styled.div`
   font-size: 1.5rem;
+
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
 `;
 
 export const Checkbox = styled.input`
   height: 1rem;
   width: 1rem;
-  margin-right: 0.5rem;
+  margin-right: 0.3rem;
 
   cursor: pointer;
 `;
 
-export const CheckMessage = styled.p``;
+export const CheckMessage = styled.p`
+  font-size: 1.3rem;
+`;
 
 export const Warning = styled.p`
   color: ${({ theme }) => theme.colors.red};


### PR DESCRIPTION


- resolves #266 

---

### 🚀 어떤 기능을 구현했나요 ?
- URL 확인 모달에서 주의사항을 확인했다는 체크박스를 체크해야 모달을 닫을 수 있는 기능을 구현했습니다.
- URL 확인 모달에 텍스트 복사 컴포넌트를 붙였습니다.
- 그 외 러프했던 스타일을 다듬었습니다.

### 🔥 어떻게 해결했나요 ?
- 공통 컴포넌트인 `AlertModal` 의 `handleClick` 속성에 단순 `closeModal` 함수가 아니라 체크박스 체크 여부를 확인하고 모달을 닫는 `handleCloseButtonClick`함수를 전달했습니다.
- 스타일: flex 구조 및 gap 등을 변경했습니다.
![image](https://github.com/user-attachments/assets/d051ac3d-4fc6-4fbd-aa0e-c19779e448a4)


### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 스타일 괜찮은지 봐주세요~~

### 📚 참고 자료, 할 말
- 이런 방식으로 주말 업무가 쌓일 줄은 몰랐다. 리팩토링 할 수 있을 줄 알았습니다.