### PR TITLE
[FE] chore: topbar에서 사용되지 않는 검색창 및 프로필 사진 숨김 처리

### DIFF
--- a/frontend/src/components/layouts/Topbar/components/Logo/index.tsx
+++ b/frontend/src/components/layouts/Topbar/components/Logo/index.tsx
@@ -1,11 +1,11 @@
-import LogoIcon from '../../../../../assets/logo.svg';
+// import LogoIcon from '../../../../../assets/logo.svg';
 
 import * as S from './styles';
 
 const Logo = () => {
   return (
     <S.Logo>
-      <img src={LogoIcon} alt="로고 아이콘" />
+      {/* <img src={LogoIcon} alt="로고 아이콘" /> */}
       <S.LogoText>
         <span>REVIEW</span>
         <span>ME</span>

--- a/frontend/src/components/layouts/Topbar/index.tsx
+++ b/frontend/src/components/layouts/Topbar/index.tsx
@@ -1,11 +1,11 @@
-import UserProfileIcon from '../../../assets/userProfile.svg';
-import { SearchInput } from '../../common';
+// import UserProfileIcon from '../../../assets/userProfile.svg';
+// import { SearchInput } from '../../common';
 
 import Logo from './components/Logo';
 import SidebarOpenButton from './components/SidebarOpenButton';
 import * as S from './styles';
 
-const USER_SEARCH_PLACE_HOLDER = '사용자를 입력해주세요.';
+// const USER_SEARCH_PLACE_HOLDER = '사용자를 입력해주세요.';
 
 interface TopbarProps {
   openSidebar: () => void;
@@ -18,8 +18,8 @@ const Topbar = ({ openSidebar }: TopbarProps) => {
         <Logo />
       </S.Container>
       <S.Container>
-        <SearchInput $width="30rem" $height="3.6rem" placeholder={USER_SEARCH_PLACE_HOLDER} />
-        <S.UserProfile src={UserProfileIcon} alt="로그인한 사용자 깃허브 프로필" />
+        {/* <SearchInput $width="30rem" $height="3.6rem" placeholder={USER_SEARCH_PLACE_HOLDER} /> */}
+        {/* <S.UserProfile src={UserProfileIcon} alt="로그인한 사용자 깃허브 프로필" /> */}
       </S.Container>
     </S.Layout>
   );


### PR DESCRIPTION
- resolves #278 

---

### 🚀 어떤 기능을 구현했나요 ?
- topbar에서 사용되지 않는 검색창 및 프로필 사진 숨김 처리

### 🔥 어떻게 해결했나요 ?
- 추후 사용될 수 있는 가능성이 있기 때문에 우선 주석 처리만 해두었습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
