### PR TITLE
[FE] feature: 제출할 리뷰를 한 번에 볼 수 있는 preview 모달 제작

### DIFF
--- a/frontend/src/assets/x.svg
+++ b/frontend/src/assets/x.svg
@@ -1,0 +1,3 @@
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M36 12L12 36M12 12L36 36" stroke="#7F7F7F" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/components/AnswerListPreviewModal/answerList.ts
+++ b/frontend/src/components/AnswerListPreviewModal/answerList.ts
@@ -1,0 +1,115 @@
+interface Option {
+  optionId: number;
+  content: string;
+  isChecked: boolean;
+}
+
+interface OptionGroup {
+  optionGroupId: number;
+  minCount: number;
+  maxCount: number;
+  options: Option[];
+}
+
+interface BaseQuestion {
+  questionId: number;
+  required: boolean;
+  questionType: 'CHECKBOX' | 'TEXT';
+  content: string;
+}
+
+interface CheckboxQuestion extends BaseQuestion {
+  questionType: 'CHECKBOX';
+  optionGroup: OptionGroup;
+}
+
+interface TextQuestion extends BaseQuestion {
+  questionType: 'TEXT';
+  optionGroup: null;
+  hasGuideline: boolean;
+  guideline: string | null;
+  answer: string | null;
+}
+
+type Question = CheckboxQuestion | TextQuestion;
+
+export interface Section {
+  sectionId: number;
+  header: string;
+  questions: Question[];
+}
+
+// NOTE: 리뷰 상세 조회의 Section 속성 이하를 가져옴
+export const ANSWER_LIST: Section[] = [
+  {
+    sectionId: 1,
+    header: '기억을 떠올려볼게요.',
+    questions: [
+      {
+        questionId: 1,
+        required: true,
+        questionType: 'CHECKBOX',
+        content: '프로젝트 기간동안 강점이 드러난 ~ 골라주세요',
+        optionGroup: {
+          optionGroupId: 1,
+          minCount: 1,
+          maxCount: 2,
+          options: [
+            { optionId: 1, content: '코드리뷰', isChecked: true },
+            { optionId: 2, content: '프로젝트 관리', isChecked: false },
+            { optionId: 3, content: '커뮤니케이션 능력', isChecked: true },
+          ],
+        },
+      },
+    ],
+  },
+
+  {
+    sectionId: 2,
+    header: '이제 선택한 순간을 바탕으로 리뷰를 작성해볼게요',
+    questions: [
+      {
+        questionId: 2,
+        required: true,
+        questionType: 'CHECKBOX',
+        content: '어떤 부분이 인상깊었나요 ?',
+        optionGroup: {
+          optionGroupId: 1,
+          minCount: 1,
+          maxCount: 3,
+          options: [
+            { optionId: 4, content: '코드리뷰', isChecked: true },
+            { optionId: 5, content: '프로젝트 관리', isChecked: true },
+            { optionId: 6, content: '커뮤니케이션 능력', isChecked: false },
+          ],
+        },
+      },
+      {
+        questionId: 3,
+        required: true,
+        questionType: 'TEXT',
+        content: '인상깊은 상황을 이야기해주세요',
+        optionGroup: null,
+        hasGuideline: true,
+        guideline: '가이드라인',
+        answer: '쑤쑤 쑤퍼노바 인상깊어요',
+      },
+    ],
+  },
+  {
+    sectionId: 3,
+    header: '응원의 한마디를 남겨주세요',
+    questions: [
+      {
+        questionId: 4,
+        required: false,
+        questionType: 'TEXT',
+        content: '응원의 한마디',
+        optionGroup: null,
+        hasGuideline: false,
+        guideline: null,
+        answer: '응원합니다 화이팅!!',
+      },
+    ],
+  },
+];

--- a/frontend/src/components/AnswerListPreviewModal/components/QuestionCard/index.tsx
+++ b/frontend/src/components/AnswerListPreviewModal/components/QuestionCard/index.tsx
@@ -1,0 +1,14 @@
+import { QuestionCardStyleType } from '@/types';
+
+import * as S from './styles';
+
+interface QuestionCardProps {
+  questionType: QuestionCardStyleType;
+  question: string;
+}
+
+const QuestionCard = ({ questionType, question }: QuestionCardProps) => {
+  return <S.QuestionCard questionType={questionType}>{question}</S.QuestionCard>;
+};
+
+export default QuestionCard;

--- a/frontend/src/components/AnswerListPreviewModal/components/QuestionCard/styles.ts
+++ b/frontend/src/components/AnswerListPreviewModal/components/QuestionCard/styles.ts
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+
+import { QuestionCardStyleType } from '@/types';
+
+export const QuestionCard = styled.div<{ questionType: QuestionCardStyleType }>`
+  margin-bottom: 2rem;
+  font-size: ${({ questionType, theme }) => (questionType === 'guideline' ? theme.fontSize.basic : '1.8rem')};
+  font-weight: ${({ questionType, theme }) =>
+    questionType === 'guideline' ? theme.fontWeight.normal : theme.fontWeight.semibold};
+  color: ${({ questionType, theme }) => (questionType === 'guideline' ? theme.colors.placeholder : theme.colors.black)};
+`;

--- a/frontend/src/components/AnswerListPreviewModal/components/ReviewWritingCard/index.tsx
+++ b/frontend/src/components/AnswerListPreviewModal/components/ReviewWritingCard/index.tsx
@@ -1,0 +1,20 @@
+import { EssentialPropsWithChildren } from '@/types';
+
+import * as S from './styles';
+
+interface ReviewWritingCardProps {
+  title: string;
+}
+
+const ReviewWritingCard = ({ title, children }: EssentialPropsWithChildren<ReviewWritingCardProps>) => {
+  return (
+    <S.Container>
+      <S.Header>
+        <S.Title>{title}</S.Title>
+      </S.Header>
+      <S.Main>{children}</S.Main>
+    </S.Container>
+  );
+};
+
+export default ReviewWritingCard;

--- a/frontend/src/components/AnswerListPreviewModal/components/ReviewWritingCard/styles.ts
+++ b/frontend/src/components/AnswerListPreviewModal/components/ReviewWritingCard/styles.ts
@@ -1,0 +1,23 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const Header = styled.div`
+  width: 100%;
+  height: 5rem;
+  padding: 1rem 2rem;
+  background-color: ${({ theme }) => theme.colors.lightPurple};
+`;
+
+export const Main = styled.div`
+  padding: 2rem;
+`;
+
+export const Title = styled.span`
+  margin-bottom: 2rem;
+  font-size: ${({ theme }) => theme.fontSize.mediumSmall};
+  font-weight: ${({ theme }) => theme.fontWeight.semibold};
+`;

--- a/frontend/src/components/AnswerListPreviewModal/index.tsx
+++ b/frontend/src/components/AnswerListPreviewModal/index.tsx
@@ -1,0 +1,54 @@
+import { Fragment } from 'react';
+
+import CheckboxItem from '../common/CheckboxItem';
+import ContentModal from '../common/modals/ContentModal';
+
+import { Section } from './answerList';
+import QuestionCard from './components/QuestionCard';
+import ReviewWritingCard from './components/ReviewWritingCard';
+import * as S from './styles';
+
+interface AnswerListPreviewModalProps {
+  answerList: Section[];
+  closeModal: () => void;
+}
+
+const AnswerListPreviewModal = ({ answerList, closeModal }: AnswerListPreviewModalProps) => {
+  return (
+    <ContentModal handleClose={closeModal}>
+      <S.AnswerListContainer>
+        <S.CardLayout>
+          {answerList.map((section) => (
+            <ReviewWritingCard key={section.sectionId} title={section.header}>
+              {section.questions.map((question) => (
+                <Fragment key={question.questionId}>
+                  <QuestionCard questionType="normal" question={question.content} />
+                  <S.ContentContainer>
+                    {question.questionType === 'CHECKBOX' && (
+                      <div>
+                        {question.optionGroup?.options.map((option, index) => (
+                          <CheckboxItem
+                            key={`${question.questionId}_${index}`}
+                            id={`${question.questionId}_${index}`}
+                            name={`${question.questionId}_${index}`}
+                            isChecked={option.isChecked}
+                            isDisabled={true}
+                            label={option.content}
+                            $isReadonly={true}
+                          />
+                        ))}
+                      </div>
+                    )}
+                    <div>{question.questionType === 'TEXT' && <div>{question.answer ?? ''}</div>}</div>
+                  </S.ContentContainer>
+                </Fragment>
+              ))}
+            </ReviewWritingCard>
+          ))}
+        </S.CardLayout>
+      </S.AnswerListContainer>
+    </ContentModal>
+  );
+};
+
+export default AnswerListPreviewModal;

--- a/frontend/src/components/AnswerListPreviewModal/index.tsx
+++ b/frontend/src/components/AnswerListPreviewModal/index.tsx
@@ -19,31 +19,33 @@ const AnswerListPreviewModal = ({ answerList, closeModal }: AnswerListPreviewMod
       <S.AnswerListContainer>
         <S.CardLayout>
           {answerList.map((section) => (
-            <ReviewWritingCard key={section.sectionId} title={section.header}>
-              {section.questions.map((question) => (
-                <Fragment key={question.questionId}>
-                  <QuestionCard questionType="normal" question={question.content} />
-                  <S.ContentContainer>
-                    {question.questionType === 'CHECKBOX' && (
-                      <div>
-                        {question.optionGroup?.options.map((option, index) => (
-                          <CheckboxItem
-                            key={`${question.questionId}_${index}`}
-                            id={`${question.questionId}_${index}`}
-                            name={`${question.questionId}_${index}`}
-                            isChecked={option.isChecked}
-                            isDisabled={true}
-                            label={option.content}
-                            $isReadonly={true}
-                          />
-                        ))}
-                      </div>
-                    )}
-                    <div>{question.questionType === 'TEXT' && <div>{question.answer ?? ''}</div>}</div>
-                  </S.ContentContainer>
-                </Fragment>
-              ))}
-            </ReviewWritingCard>
+            <S.ReviewWritingCardWrapper key={section.sectionId}>
+              <ReviewWritingCard title={section.header}>
+                {section.questions.map((question) => (
+                  <Fragment key={question.questionId}>
+                    <QuestionCard questionType="normal" question={question.content} />
+                    <S.ContentContainer>
+                      {question.questionType === 'CHECKBOX' && (
+                        <div>
+                          {question.optionGroup?.options.map((option, index) => (
+                            <CheckboxItem
+                              key={`${question.questionId}_${index}`}
+                              id={`${question.questionId}_${index}`}
+                              name={`${question.questionId}_${index}`}
+                              isChecked={option.isChecked}
+                              isDisabled={true}
+                              label={option.content}
+                              $isReadonly={true}
+                            />
+                          ))}
+                        </div>
+                      )}
+                      <div>{question.questionType === 'TEXT' && <div>{question.answer ?? ''}</div>}</div>
+                    </S.ContentContainer>
+                  </Fragment>
+                ))}
+              </ReviewWritingCard>
+            </S.ReviewWritingCardWrapper>
           ))}
         </S.CardLayout>
       </S.AnswerListContainer>

--- a/frontend/src/components/AnswerListPreviewModal/styles.ts
+++ b/frontend/src/components/AnswerListPreviewModal/styles.ts
@@ -1,0 +1,24 @@
+import styled from '@emotion/styled';
+
+export const AnswerListContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10rem;
+`;
+
+export const CardLayout = styled.div`
+  position: relative;
+
+  overflow: hidden;
+
+  width: ${({ theme }) => theme.formWidth};
+
+  border: 0.1rem solid ${({ theme }) => theme.colors.lightPurple};
+  border-radius: ${({ theme }) => theme.borderRadius.basic};
+`;
+
+export const ContentContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+`;

--- a/frontend/src/components/AnswerListPreviewModal/styles.ts
+++ b/frontend/src/components/AnswerListPreviewModal/styles.ts
@@ -1,24 +1,27 @@
 import styled from '@emotion/styled';
 
-export const AnswerListContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 10rem;
-`;
+export const AnswerListContainer = styled.div``;
 
 export const CardLayout = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  gap: 1.2rem;
   position: relative;
 
   overflow: hidden;
 
   width: ${({ theme }) => theme.formWidth};
-
-  border: 0.1rem solid ${({ theme }) => theme.colors.lightPurple};
-  border-radius: ${({ theme }) => theme.borderRadius.basic};
 `;
 
 export const ContentContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 3rem;
+`;
+
+export const ReviewWritingCardWrapper = styled.div`
+  overflow: hidden;
+  border: 0.2rem solid ${({ theme }) => theme.colors.lightPurple};
+  border-radius: ${({ theme }) => theme.borderRadius.basic};
 `;

--- a/frontend/src/components/common/Checkbox/index.tsx
+++ b/frontend/src/components/common/Checkbox/index.tsx
@@ -17,7 +17,6 @@ export interface CheckboxProps extends CheckboxStyleProps {
   onChange?: (event: ChangeEvent<HTMLInputElement>, label?: string) => void;
   name?: string;
   isDisabled?: boolean;
-  $isReadonly?: boolean;
 }
 
 const Checkbox = ({ id, isChecked, $style, $isReadonly = false, ...rest }: CheckboxProps) => {

--- a/frontend/src/components/common/Checkbox/index.tsx
+++ b/frontend/src/components/common/Checkbox/index.tsx
@@ -7,20 +7,30 @@ import * as S from './styles';
 
 // NOTE: 공통 컴포넌트에서 이 스타일 속성을 계속 쓰는 것 같은데 이걸 아예 공통 타입으로 빼버릴지 고민
 export interface CheckboxStyleProps {
+  $isReadonly?: boolean;
   $style?: React.CSSProperties;
 }
 
 export interface CheckboxProps extends CheckboxStyleProps {
   id: string;
   isChecked: boolean;
-  onChange: (event: ChangeEvent<HTMLInputElement>, label?: string) => void;
+  onChange?: (event: ChangeEvent<HTMLInputElement>, label?: string) => void;
   name?: string;
   isDisabled?: boolean;
+  $isReadonly?: boolean;
 }
 
-const Checkbox = ({ id, name, isChecked, isDisabled = false, onChange, $style }: CheckboxProps) => {
+const Checkbox = ({
+  id,
+  name,
+  isChecked,
+  $isReadonly = false,
+  isDisabled = false,
+  onChange,
+  $style,
+}: CheckboxProps) => {
   return (
-    <S.CheckboxContainer $style={$style}>
+    <S.CheckboxContainer $style={$style} $isReadonly={$isReadonly}>
       <S.CheckboxLabel>
         <input
           id={id}

--- a/frontend/src/components/common/Checkbox/index.tsx
+++ b/frontend/src/components/common/Checkbox/index.tsx
@@ -20,27 +20,11 @@ export interface CheckboxProps extends CheckboxStyleProps {
   $isReadonly?: boolean;
 }
 
-const Checkbox = ({
-  id,
-  name,
-  isChecked,
-  $isReadonly = false,
-  isDisabled = false,
-  onChange,
-  $style,
-}: CheckboxProps) => {
+const Checkbox = ({ id, isChecked, $style, $isReadonly = false, ...rest }: CheckboxProps) => {
   return (
     <S.CheckboxContainer $style={$style} $isReadonly={$isReadonly}>
       <S.CheckboxLabel>
-        <input
-          id={id}
-          name={name}
-          checked={isChecked}
-          onChange={onChange}
-          disabled={isDisabled}
-          aria-hidden={false}
-          type="checkbox"
-        />
+        <input id={id} checked={isChecked} type="checkbox" {...rest} />
         <img src={isChecked ? CheckedIcon : UncheckedIcon} alt="체크박스" />
       </S.CheckboxLabel>
     </S.CheckboxContainer>

--- a/frontend/src/components/common/Checkbox/styles.ts
+++ b/frontend/src/components/common/Checkbox/styles.ts
@@ -16,6 +16,8 @@ export const CheckboxContainer = styled.div<CheckboxStyleProps>`
     width: 0;
     height: 0;
   }
+
+  ${(props) => props.$isReadonly && 'pointer-events: none;'}
   ${({ $style }) => $style && { ...$style }};
 `;
 

--- a/frontend/src/components/common/modals/ContentModal/index.tsx
+++ b/frontend/src/components/common/modals/ContentModal/index.tsx
@@ -1,0 +1,30 @@
+import CloseIcon from '@/assets/x.svg';
+import { EssentialPropsWithChildren } from '@/types';
+
+import ModalBackground from '../ModalBackground';
+import ModalPortal from '../ModalPortal';
+
+import * as S from './styles';
+
+interface ContentModalProps {
+  handleClose: () => void;
+}
+
+const ContentModal = ({ handleClose, children }: EssentialPropsWithChildren<ContentModalProps>) => {
+  return (
+    <ModalPortal>
+      <ModalBackground closeModal={handleClose}>
+        <S.ContentModalContainer>
+          <S.ContentModalHeader>
+            <S.CloseButton onClick={handleClose}>
+              <img src={CloseIcon} alt="모달 닫기" />
+            </S.CloseButton>
+          </S.ContentModalHeader>
+          <S.Contents>{children}</S.Contents>
+        </S.ContentModalContainer>
+      </ModalBackground>
+    </ModalPortal>
+  );
+};
+
+export default ContentModal;

--- a/frontend/src/components/common/modals/ContentModal/styles.ts
+++ b/frontend/src/components/common/modals/ContentModal/styles.ts
@@ -1,0 +1,50 @@
+import styled from '@emotion/styled';
+
+export const ContentModalContainer = styled.div`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  align-items: center;
+
+  min-width: 30rem;
+  max-width: 80vw;
+  max-height: 90vh;
+  padding: 3.2rem;
+
+  background-color: ${({ theme }) => theme.colors.white};
+  border-radius: ${({ theme }) => theme.borderRadius.basic};
+
+  overflow: hidden;
+`;
+
+export const ContentModalHeader = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+  height: 3rem;
+`;
+
+export const Contents = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  white-space: pre-line;
+
+  overflow-y: auto;
+
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+export const CloseButton = styled.button`
+  width: 2.4rem;
+  height: 2.4rem;
+`;

--- a/frontend/src/components/common/modals/ContentModal/styles.ts
+++ b/frontend/src/components/common/modals/ContentModal/styles.ts
@@ -36,12 +36,6 @@ export const Contents = styled.div`
   white-space: pre-line;
 
   overflow-y: auto;
-
-  scrollbar-width: none;
-  -ms-overflow-style: none;
-  &::-webkit-scrollbar {
-    display: none;
-  }
 `;
 
 export const CloseButton = styled.button`

--- a/frontend/src/pages/TempPage/index.tsx
+++ b/frontend/src/pages/TempPage/index.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+
+import AnswerListPreviewModal from '@/components/AnswerListPreviewModal';
+import { ANSWER_LIST } from '@/components/AnswerListPreviewModal/answerList';
+
+const TempPage = () => {
+  const [isOpen, setIsOpen] = useState(true);
+
+  const onClick = () => {
+    setIsOpen(true);
+  };
+
+  return (
+    <div>
+      <button onClick={onClick} type="button">
+        모달버튼
+      </button>
+      {isOpen && (
+        <AnswerListPreviewModal
+          answerList={ANSWER_LIST}
+          closeModal={() => {
+            setIsOpen(false);
+          }}
+        ></AnswerListPreviewModal>
+      )}
+    </div>
+  );
+};
+
+export default TempPage;


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #280 

---

### 🚀 어떤 기능을 구현했나요 ?
### 새로운 모달 형식인 `ContentModal` 제작
- 기존의 다른 모달들에 비해 긴 content를 보여주는 데 특화된 모달입니다. (`maxHeight` 증가 및 스크롤바 적용) 
- 처음엔 모달 컨텐츠에 집중할 수 있도록 아예 명시적인 닫기 버튼 없이 esc나 배경 클릭만으로 모달을 닫을 수 있도록 하려 했는데, 그래도 닫기 버튼이 아예 없는 건 불친절하다고 생각해서 모달 최상단에 닫기 버튼(X)을 배치했습니다.
- 그렇다고 닫기 버튼을 하단 sticky로 두자니 과하게 자리를 차지하는 느낌이고, 그냥 하단에 두면 사용자가 닫기 버튼을 찾기 위해 스크롤을 쭉 내려야 하는 문제가 있습니다.
- 그래서 상단에 작게 X 버튼을 배치해서 사용자가 필요할 때 직관적으로 찾을 수 있도록 했습니다.


### 프리뷰 모달 임시 스타일링
![image](https://github.com/user-attachments/assets/d15c900d-b60d-494e-8de0-5e23d298384a)
- 프리뷰 모달에서까지 누구에게 쓰는 것인지, 어떤 프로젝트인지를 보여줄 필요는 없다고 생각해서 별도로 표시하지 않았고 컴팩트하게 질문-답변 카드만 보여주고 있습니다.
  - X 버튼과 이하 Content를 위한 gap 때문에 모달 상단부가 조금 비어 보이는 느낌은 있습니다.
- 리뷰를 작성할 때는 단일 카드 형식으로 질문과 답변을 받았으나 프리뷰 모달에서는 모든 카드를 세로로 보여줘야 했습니다.
- 기존 카드 스타일을 그대로 가져오고 카드 사이에 gap을 주러고 했는데, 현재 스타일상 질문이 보라색 배경이라 gap이 없어도 개별 카드를 식별할 수 있었습니다.
- ~~어차피 카드가 식별되므로 별도의 gap을 부여하는 것은 불필요하게 스크롤 길이만 늘인다고 생각해서 적용하지 않았습니다.~~
- ~~현재 화이트톤의 깔끔한 디자인이 적용되어 있기 때문에 투박한 스크롤바가 생기는 것은 옳지 않다고 생각해서 일단 스크롤은 가능하나 스크롤바를 없앤 상황입니다.~~
  - ~~또 Content의 길이가 어느 정도 보장되어 있고 사용자도 Content의 길이를 대충 가늠해볼 수 있기 때문에 스크롤바가 없어도 큰 혼란은 없을 거라고 생각했습니다.~~

### `CheckItem` 리팩토링
- 기존에는 해당 컴포넌트가 읽기 전용으로 사용될 수도 있다는 점을 간과해서 `handleClick`이 필수였고 `readOnly` 속성이 없었습니다.
  - 리뷰를 볼 때도 이 컴포넌트를 사용할 수 있도록 핸들러를 선택 옵션으로 변경했습니다.
  - `input`에서 type이 `checkbox`인 요소에는 `readonly` 속성이 적용되지 않는다고 해서 우회적으로 읽기 전용 컴포넌트 처리를 했습니다. (아래에서 자세히 설명)
  - 읽기 전용 처리가 없으면 체크박스에 마우스를 가져다 댔을 때 항상 포인터가 클릭할 수 있는 것처럼 변합니다. 

### 🔥 어떻게 해결했나요 ?
- `Checkbox`에 읽기 전용 타입 추가
  - 어차피 input 동작 여부는 `disabled`로 다룰 수 있는 만큼 단지 스타일(마우스 포인터 스타일링)만을 위한 속성이라고 생각해서 styleType에 $를 달고 있는 속성을 추가했습니다.
  - styles 파일에서 이를 받아 `pointer-events`를 `none`으로 설정합니다.
  - 기본적으로 체크박스는 사용자와 상호작용해야 한다고 생각해서, 즉 읽기 전용인 상황이 특수하다고 생각해서 기본값은 false로 주고 필요할 때 true로 명시적으로 사용하도록 만들었습니다. 
```ts
// 새 스타일 인터페이스
export interface CheckboxStyleProps {
  $isReadonly?: boolean; // 추가
  $style?: React.CSSProperties;
}

// styles
export const CheckboxContainer = styled.div<CheckboxStyleProps>`
  ...

  ${(props) => props.$isReadonly && 'pointer-events: none;'}
`;
```

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 누락된 타입이나 내용이 없을까요?
- `TempPage`를 App에서 불러오면 모달을 바로 테스트해볼 수 있습니다.

### 📚 참고 자료, 할 말
- 아직 develop 브랜치에 카드 형식의 레이아웃 및 스타일이 없어서 임의로 3차데모 로컬 시연 브랜치에서 `QuestionCard`와 `ReviewWritingCard`를 가져왔습니다.
- 위의 복사해온 컴포넌트도 그렇고 import해온 다른 요소들도 조만간 이 모달 컴포넌트의 폴더 위치가 달라질 것 같아 별도의 indexing 없이 임시로(마구잡이로?) 가져온 상태입니다. 모킹 데이터를 위한 타입들도 임시 타입이라 이름을 성심성의껏 짓지 않았습니다^_^...
- 임의로 스타일링한 거라 많은 의견 받습니다~~~
- 이제 곧 모달 수정사항 반영해서 리팩토링해야겠지,,,
