### PR TITLE
[All] fix (actions): PR 내용을 저장하지 않도록 수정

### DIFF
--- a/.github/workflows/discord-pull-request.yml
+++ b/.github/workflows/discord-pull-request.yml
@@ -46,7 +46,6 @@ jobs:
           PR_TITLE='${{ github.event.pull_request.title }}'
           PR_AUTHOR='${{ github.event.sender.login }}'
           DISCORD_ID='${{ env[github.event.sender.id] }}'
-          PR_BODY='${{ github.event.pull_request.body }}'
           if [ "${{ env.PR_PREFIX }}" = 'BE' ]; then
             NOTIFY_CONTENT="<@&${{ env.backend }}>"
             WEBHOOK_URL=${{ secrets.DISCORD_BE_PR_WEBHOOK_URL }}


### PR DESCRIPTION
디코 멘션에서 본문을 담지 않고 있는데, 액션 스크립트에서 본문 전체를 변수에 담다가 전체 스크립트에 에러가 발생합니다.
본문에 `'`가 포함되는 경우 escape되어버리네요 ㅎㅎ

### 🔥 어떻게 해결했나요 ?
- 본문 저장하지 않도록 수정
