### PR TITLE
[BE] feat: 리뷰 목록 재구현

### DIFF
--- a/backend/src/main/java/reviewme/question/domain/OptionGroup.java
+++ b/backend/src/main/java/reviewme/question/domain/OptionGroup.java
@@ -28,4 +28,10 @@ public class OptionGroup {
 
     @Column(name = "max_selection_count", nullable = false)
     private int maxSelectionCount;
+
+    public OptionGroup(long questionId, int minSelectionCount, int maxSelectionCount) {
+        this.questionId = questionId;
+        this.minSelectionCount = minSelectionCount;
+        this.maxSelectionCount = maxSelectionCount;
+    }
 }

--- a/backend/src/main/java/reviewme/question/domain/OptionItem.java
+++ b/backend/src/main/java/reviewme/question/domain/OptionItem.java
@@ -2,6 +2,8 @@ package reviewme.question.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -28,4 +30,15 @@ public class OptionItem {
 
     @Column(name = "position", nullable = false)
     private int position;
+
+    @Column(name = "option_type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private OptionType optionType;
+
+    public OptionItem(String content, long optionGroupId, int position, OptionType optionType) {
+        this.content = content;
+        this.optionGroupId = optionGroupId;
+        this.position = position;
+        this.optionType = optionType;
+    }
 }

--- a/backend/src/main/java/reviewme/question/domain/OptionType.java
+++ b/backend/src/main/java/reviewme/question/domain/OptionType.java
@@ -1,0 +1,6 @@
+package reviewme.question.domain;
+
+public enum OptionType {
+    CATEGORY,
+    KEYWORD,
+}

--- a/backend/src/main/java/reviewme/question/repository/OptionGroupRepository.java
+++ b/backend/src/main/java/reviewme/question/repository/OptionGroupRepository.java
@@ -1,0 +1,9 @@
+package reviewme.question.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import reviewme.question.domain.OptionGroup;
+
+@Repository
+public interface OptionGroupRepository extends JpaRepository<OptionGroup, Long> {
+}

--- a/backend/src/main/java/reviewme/question/repository/OptionItemRepository.java
+++ b/backend/src/main/java/reviewme/question/repository/OptionItemRepository.java
@@ -7,7 +7,7 @@ import reviewme.question.domain.OptionItem;
 import reviewme.question.domain.OptionType;
 
 @Repository
-public interface OptionRepository extends JpaRepository<OptionItem, Long> {
+public interface OptionItemRepository extends JpaRepository<OptionItem, Long> {
 
     List<OptionItem> findAllByOptionType(OptionType optionType);
 

--- a/backend/src/main/java/reviewme/question/repository/OptionRepository.java
+++ b/backend/src/main/java/reviewme/question/repository/OptionRepository.java
@@ -1,0 +1,15 @@
+package reviewme.question.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import reviewme.question.domain.OptionItem;
+import reviewme.question.domain.OptionType;
+
+@Repository
+public interface OptionRepository extends JpaRepository<OptionItem, Long> {
+
+    List<OptionItem> findAllByOptionType(OptionType optionType);
+
+    boolean existsByOptionTypeAndId(OptionType optionType, long id);
+}

--- a/backend/src/main/java/reviewme/review/controller/ReviewController.java
+++ b/backend/src/main/java/reviewme/review/controller/ReviewController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import reviewme.global.HeaderProperty;
 import reviewme.review.dto.request.CreateReviewRequest;
 import reviewme.review.dto.response.ReceivedReviewsResponse;
+import reviewme.review.dto.response.ReceivedReviewsResponse2;
 import reviewme.review.dto.response.ReviewDetailResponse;
 import reviewme.review.dto.response.ReviewSetupResponse;
 import reviewme.review.service.ReviewService;
@@ -42,6 +43,14 @@ public class ReviewController implements ReviewApi {
             @HeaderProperty(GROUP_ACCESS_CODE_HEADER) String groupAccessCode
     ) {
         ReceivedReviewsResponse response = reviewService.findReceivedReviews(groupAccessCode);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/v2/reviews")
+    public ResponseEntity<ReceivedReviewsResponse2> findReceivedReviews2(
+            @HeaderProperty(GROUP_ACCESS_CODE_HEADER) String groupAccessCode
+    ) {
+        ReceivedReviewsResponse2 response = reviewService.findReceivedReviews2(groupAccessCode);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/reviewme/review/domain/CheckboxAnswer.java
+++ b/backend/src/main/java/reviewme/review/domain/CheckboxAnswer.java
@@ -29,4 +29,12 @@ public class CheckboxAnswer {
     @ElementCollection
     @CollectionTable(name = "selected_option_ids")
     private List<Long> selectedOptionIds;
+
+    @Column(name = "review_id", insertable = false, updatable = false)
+    private long reviewId;
+
+    public CheckboxAnswer(long questionId, List<Long> selectedOptionIds) {
+        this.questionId = questionId;
+        this.selectedOptionIds = selectedOptionIds;
+    }
 }

--- a/backend/src/main/java/reviewme/review/domain/CheckboxAnswer.java
+++ b/backend/src/main/java/reviewme/review/domain/CheckboxAnswer.java
@@ -30,9 +30,6 @@ public class CheckboxAnswer {
     @CollectionTable(name = "selected_option_ids")
     private List<Long> selectedOptionIds;
 
-    @Column(name = "review_id", insertable = false, updatable = false)
-    private long reviewId;
-
     public CheckboxAnswer(long questionId, List<Long> selectedOptionIds) {
         this.questionId = questionId;
         this.selectedOptionIds = selectedOptionIds;

--- a/backend/src/main/java/reviewme/review/domain/Review2.java
+++ b/backend/src/main/java/reviewme/review/domain/Review2.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -37,6 +38,9 @@ public class Review2 {
     @OneToMany(cascade = CascadeType.PERSIST)
     @JoinColumn(name = "review_id", nullable = false, updatable = false)
     private List<CheckboxAnswer> checkboxAnswers;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
 
     public Review2(long templateId, long reviewGroupId, List<TextAnswer> textAnswers,
                    List<CheckboxAnswer> checkboxAnswers,

--- a/backend/src/main/java/reviewme/review/domain/Review2.java
+++ b/backend/src/main/java/reviewme/review/domain/Review2.java
@@ -42,8 +42,8 @@ public class Review2 {
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
-    public Review2(long templateId, long reviewGroupId, List<TextAnswer> textAnswers,
-                   List<CheckboxAnswer> checkboxAnswers,
+    public Review2(long templateId, long reviewGroupId,
+                   List<TextAnswer> textAnswers, List<CheckboxAnswer> checkboxAnswers,
                    LocalDateTime createdAt) {
         this.templateId = templateId;
         this.reviewGroupId = reviewGroupId;

--- a/backend/src/main/java/reviewme/review/domain/Review2.java
+++ b/backend/src/main/java/reviewme/review/domain/Review2.java
@@ -37,4 +37,14 @@ public class Review2 {
     @OneToMany(cascade = CascadeType.PERSIST)
     @JoinColumn(name = "review_id", nullable = false, updatable = false)
     private List<CheckboxAnswer> checkboxAnswers;
+
+    public Review2(long templateId, long reviewGroupId, List<TextAnswer> textAnswers,
+                   List<CheckboxAnswer> checkboxAnswers,
+                   LocalDateTime createdAt) {
+        this.templateId = templateId;
+        this.reviewGroupId = reviewGroupId;
+        this.textAnswers = textAnswers;
+        this.checkboxAnswers = checkboxAnswers;
+        this.createdAt = createdAt;
+    }
 }

--- a/backend/src/main/java/reviewme/review/domain/TextAnswer.java
+++ b/backend/src/main/java/reviewme/review/domain/TextAnswer.java
@@ -25,4 +25,9 @@ public class TextAnswer {
 
     @Column(name = "text", nullable = false, length = 1_000)
     private String text;
+
+    public TextAnswer(long questionId, String text) {
+        this.questionId = questionId;
+        this.text = text;
+    }
 }

--- a/backend/src/main/java/reviewme/review/domain/exception/CategoryOptionByReviewNotFoundException.java
+++ b/backend/src/main/java/reviewme/review/domain/exception/CategoryOptionByReviewNotFoundException.java
@@ -1,0 +1,13 @@
+package reviewme.review.domain.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import reviewme.global.exception.NotFoundException;
+
+@Slf4j
+public class CategoryOptionByReviewNotFoundException extends NotFoundException {
+
+    public CategoryOptionByReviewNotFoundException(long reviewId) {
+        super("리뷰에 선택한 카테고리가 없어요.");
+        log.warn("CategoryOptionNotFoundException is occured - reviewId: {}", reviewId);
+    }
+}

--- a/backend/src/main/java/reviewme/review/dto/response/ReceivedReviewCategoryResponse.java
+++ b/backend/src/main/java/reviewme/review/dto/response/ReceivedReviewCategoryResponse.java
@@ -1,0 +1,14 @@
+package reviewme.review.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "선택된 카테고리 응답")
+public record ReceivedReviewCategoryResponse(
+
+        @Schema(description = "카테고리 ID")
+        long optionId,
+
+        @Schema(description = "카테고리 내용")
+        String content
+) {
+}

--- a/backend/src/main/java/reviewme/review/dto/response/ReceivedReviewResponse.java
+++ b/backend/src/main/java/reviewme/review/dto/response/ReceivedReviewResponse.java
@@ -16,7 +16,7 @@ public record ReceivedReviewResponse(
         @Schema(description = "응답 내용 미리보기")
         String contentPreview,
 
-        @Schema(description = "선택된 키워드 목록")
-        List<ReceivedReviewKeywordsResponse> keywords
+        @Schema(description = "선택된 카테고리 목록")
+        List<ReceivedReviewCategoryResponse> categories
 ) {
 }

--- a/backend/src/main/java/reviewme/review/dto/response/ReceivedReviewResponse2.java
+++ b/backend/src/main/java/reviewme/review/dto/response/ReceivedReviewResponse2.java
@@ -5,7 +5,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 @Schema(name = "리뷰 내용 응답")
-public record ReceivedReviewResponse(
+public record ReceivedReviewResponse2(
 
         @Schema(description = "리뷰 ID")
         long id,
@@ -16,7 +16,7 @@ public record ReceivedReviewResponse(
         @Schema(description = "응답 내용 미리보기")
         String contentPreview,
 
-        @Schema(description = "선택된 키워드 목록")
-        List<ReceivedReviewKeywordsResponse> keywords
+        @Schema(description = "선택된 카테고리 목록")
+        List<ReceivedReviewCategoryResponse> categories
 ) {
 }

--- a/backend/src/main/java/reviewme/review/dto/response/ReceivedReviewsResponse2.java
+++ b/backend/src/main/java/reviewme/review/dto/response/ReceivedReviewsResponse2.java
@@ -1,0 +1,18 @@
+package reviewme.review.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(name = "내가 받은 리뷰 목록 응답")
+public record ReceivedReviewsResponse2(
+
+        @Schema(description = "리뷰이 이름")
+        String revieweeName,
+
+        @Schema(description = "프로젝트 이름")
+        String projectName,
+
+        @Schema(description = "받은 리뷰 미리보기 목록")
+        List<ReceivedReviewResponse2> reviews
+) {
+}

--- a/backend/src/main/java/reviewme/review/repository/CheckboxAnswerRepository.java
+++ b/backend/src/main/java/reviewme/review/repository/CheckboxAnswerRepository.java
@@ -1,0 +1,9 @@
+package reviewme.review.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import reviewme.review.domain.CheckboxAnswer;
+
+@Repository
+public interface CheckboxAnswerRepository extends JpaRepository<CheckboxAnswer, Long> {
+}

--- a/backend/src/main/java/reviewme/review/repository/Review2Repository.java
+++ b/backend/src/main/java/reviewme/review/repository/Review2Repository.java
@@ -1,0 +1,14 @@
+package reviewme.review.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+import reviewme.review.domain.Review2;
+
+@Repository
+public interface Review2Repository extends JpaRepository<Review2, Long> {
+
+    @Query("SELECT r FROM Review2 r WHERE r.reviewGroupId=:reviewGroupId ORDER BY r.createdAt DESC")
+    List<Review2> findReceivedReviewsByGroupId(long reviewGroupId);
+}

--- a/backend/src/main/java/reviewme/review/service/ReviewPreviewGenerator.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewPreviewGenerator.java
@@ -1,23 +1,11 @@
 package reviewme.review.service;
 
 import java.util.List;
-import reviewme.review.domain.ReviewContent;
 import reviewme.review.domain.TextAnswer;
 
 public class ReviewPreviewGenerator {
 
     private static final int PREVIEW_LENGTH = 150;
-
-    public String generatePreview(List<ReviewContent> reviewContents) {
-        if (reviewContents.isEmpty()) {
-            return "";
-        }
-        String answer = reviewContents.get(0).getAnswer();
-        if (answer.length() > PREVIEW_LENGTH) {
-            return answer.substring(0, PREVIEW_LENGTH);
-        }
-        return answer;
-    }
 
     public String generatePreview2(List<TextAnswer> reviewTextAnswers) {
         if (reviewTextAnswers.isEmpty()) {

--- a/backend/src/main/java/reviewme/review/service/ReviewPreviewGenerator.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewPreviewGenerator.java
@@ -1,11 +1,23 @@
 package reviewme.review.service;
 
 import java.util.List;
+import reviewme.review.domain.ReviewContent;
 import reviewme.review.domain.TextAnswer;
 
 public class ReviewPreviewGenerator {
 
     private static final int PREVIEW_LENGTH = 150;
+
+    public String generatePreview(List<ReviewContent> reviewContents) {
+        if (reviewContents.isEmpty()) {
+            return "";
+        }
+        String answer = reviewContents.get(0).getAnswer();
+        if (answer.length() > PREVIEW_LENGTH) {
+            return answer.substring(0, PREVIEW_LENGTH);
+        }
+        return answer;
+    }
 
     public String generatePreview2(List<TextAnswer> reviewTextAnswers) {
         if (reviewTextAnswers.isEmpty()) {

--- a/backend/src/main/java/reviewme/review/service/ReviewPreviewGenerator.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewPreviewGenerator.java
@@ -2,6 +2,7 @@ package reviewme.review.service;
 
 import java.util.List;
 import reviewme.review.domain.ReviewContent;
+import reviewme.review.domain.TextAnswer;
 
 public class ReviewPreviewGenerator {
 
@@ -12,6 +13,17 @@ public class ReviewPreviewGenerator {
             return "";
         }
         String answer = reviewContents.get(0).getAnswer();
+        if (answer.length() > PREVIEW_LENGTH) {
+            return answer.substring(0, PREVIEW_LENGTH);
+        }
+        return answer;
+    }
+
+    public String generatePreview2(List<TextAnswer> reviewTextAnswers) {
+        if (reviewTextAnswers.isEmpty()) {
+            return "";
+        }
+        String answer = reviewTextAnswers.get(0).getText();
         if (answer.length() > PREVIEW_LENGTH) {
             return answer.substring(0, PREVIEW_LENGTH);
         }

--- a/backend/src/main/java/reviewme/review/service/ReviewService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewService.java
@@ -14,6 +14,7 @@ import reviewme.review.domain.Review;
 import reviewme.review.domain.Review2;
 import reviewme.review.domain.ReviewContent;
 import reviewme.review.domain.ReviewKeyword;
+import reviewme.review.domain.exception.CategoryOptionByReviewNotFoundException;
 import reviewme.review.domain.exception.ReviewGroupNotFoundByGroupAccessCodeException;
 import reviewme.review.domain.exception.ReviewGroupNotFoundByRequestReviewCodeException;
 import reviewme.review.domain.exception.ReviewIsNotInReviewGroupException;
@@ -170,7 +171,7 @@ public class ReviewService {
                 .filter(answer -> optionRepository.existsByOptionTypeAndId(OptionType.CATEGORY,
                         answer.getSelectedOptionIds().get(0)))
                 .findFirst()
-                .orElseThrow();
+                .orElseThrow(() -> new CategoryOptionByReviewNotFoundException(review.getId()));
 
         List<ReceivedReviewCategoryResponse> categoryResponses = optionRepository.findAllById(
                         checkboxAnswer.getSelectedOptionIds())

--- a/backend/src/main/java/reviewme/review/service/ReviewService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewService.java
@@ -8,7 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import reviewme.keyword.repository.KeywordRepository;
 import reviewme.question.domain.OptionType;
 import reviewme.question.domain.Question;
-import reviewme.question.repository.OptionRepository;
+import reviewme.question.repository.OptionItemRepository;
 import reviewme.review.domain.CheckboxAnswer;
 import reviewme.review.domain.Review;
 import reviewme.review.domain.Review2;
@@ -44,7 +44,7 @@ public class ReviewService {
     private final ReviewGroupRepository reviewGroupRepository;
     private final QuestionRepository questionRepository;
     private final KeywordRepository keywordRepository;
-    private final OptionRepository optionRepository;
+    private final OptionItemRepository optionItemRepository;
     private final Review2Repository review2Repository;
 
     private final ReviewCreationQuestionValidator reviewCreationQuestionValidator;
@@ -168,12 +168,12 @@ public class ReviewService {
     private ReceivedReviewResponse createReceivedReviewResponse(Review2 review) {
         CheckboxAnswer checkboxAnswer = review.getCheckboxAnswers()
                 .stream()
-                .filter(answer -> optionRepository.existsByOptionTypeAndId(OptionType.CATEGORY,
+                .filter(answer -> optionItemRepository.existsByOptionTypeAndId(OptionType.CATEGORY,
                         answer.getSelectedOptionIds().get(0)))
                 .findFirst()
                 .orElseThrow(() -> new CategoryOptionByReviewNotFoundException(review.getId()));
 
-        List<ReceivedReviewCategoryResponse> categoryResponses = optionRepository.findAllById(
+        List<ReceivedReviewCategoryResponse> categoryResponses = optionItemRepository.findAllById(
                         checkboxAnswer.getSelectedOptionIds())
                 .stream()
                 .map(optionItem -> new ReceivedReviewCategoryResponse(optionItem.getId(), optionItem.getContent()))

--- a/backend/src/main/java/reviewme/review/service/ReviewService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewService.java
@@ -159,11 +159,11 @@ public class ReviewService {
         ReviewGroup reviewGroup = reviewGroupRepository.findByGroupAccessCode(groupAccessCode)
                 .orElseThrow(() -> new ReviewGroupNotFoundByGroupAccessCodeException(groupAccessCode));
 
-        List<ReceivedReviewResponse2> reviewResponses = review2Repository.findReceivedReviewsByGroupId(
-                        reviewGroup.getId())
-                .stream()
-                .map(this::createReceivedReviewResponse2)
-                .toList();
+        List<ReceivedReviewResponse2> reviewResponses =
+                review2Repository.findReceivedReviewsByGroupId(reviewGroup.getId())
+                        .stream()
+                        .map(this::createReceivedReviewResponse2)
+                        .toList();
 
         return new ReceivedReviewsResponse2(reviewGroup.getReviewee(), reviewGroup.getProjectName(), reviewResponses);
     }
@@ -171,16 +171,19 @@ public class ReviewService {
     private ReceivedReviewResponse2 createReceivedReviewResponse2(Review2 review) {
         CheckboxAnswer checkboxAnswer = review.getCheckboxAnswers()
                 .stream()
-                .filter(answer -> optionItemRepository.existsByOptionTypeAndId(OptionType.CATEGORY,
-                        answer.getSelectedOptionIds().get(0)))
+                .filter(answer -> optionItemRepository.existsByOptionTypeAndId(
+                        OptionType.CATEGORY, answer.getSelectedOptionIds().get(0)
+                ))
                 .findFirst()
                 .orElseThrow(() -> new CategoryOptionByReviewNotFoundException(review.getId()));
 
-        List<ReceivedReviewCategoryResponse> categoryResponses = optionItemRepository.findAllById(
-                        checkboxAnswer.getSelectedOptionIds())
-                .stream()
-                .map(optionItem -> new ReceivedReviewCategoryResponse(optionItem.getId(), optionItem.getContent()))
-                .toList();
+        List<ReceivedReviewCategoryResponse> categoryResponses =
+                optionItemRepository.findAllById(checkboxAnswer.getSelectedOptionIds())
+                        .stream()
+                        .map(optionItem -> new ReceivedReviewCategoryResponse(
+                                optionItem.getId(), optionItem.getContent()
+                        ))
+                        .toList();
 
         return new ReceivedReviewResponse2(
                 review.getId(),
@@ -189,7 +192,6 @@ public class ReviewService {
                 categoryResponses
         );
     }
-
 
     @Transactional(readOnly = true)
     public ReceivedReviewsResponse findReceivedReviews(String groupAccessCode) {

--- a/backend/src/main/java/reviewme/review/service/ReviewService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewService.java
@@ -154,23 +154,26 @@ public class ReviewService {
     public ReceivedReviewsResponse findReceivedReviews(String groupAccessCode) {
         ReviewGroup reviewGroup = reviewGroupRepository.findByGroupAccessCode(groupAccessCode)
                 .orElseThrow(() -> new ReviewGroupNotFoundByGroupAccessCodeException(groupAccessCode));
-        List<ReceivedReviewResponse> reviewResponses =
-                review2Repository.findReceivedReviewsByGroupId(reviewGroup.getId())
-                        .stream()
-                        .map(this::createReceivedReviewResponse)
-                        .toList();
+
+        List<ReceivedReviewResponse> reviewResponses = review2Repository.findReceivedReviewsByGroupId(
+                        reviewGroup.getId())
+                .stream()
+                .map(this::createReceivedReviewResponse)
+                .toList();
+
         return new ReceivedReviewsResponse(reviewGroup.getReviewee(), reviewGroup.getProjectName(), reviewResponses);
     }
 
     private ReceivedReviewResponse createReceivedReviewResponse(Review2 review) {
         CheckboxAnswer checkboxAnswer = review.getCheckboxAnswers()
                 .stream()
-                .filter(answer -> optionRepository.existsByOptionTypeAndId(OptionType.CATEGORY, answer.getSelectedOptionIds().get(0)))
+                .filter(answer -> optionRepository.existsByOptionTypeAndId(OptionType.CATEGORY,
+                        answer.getSelectedOptionIds().get(0)))
                 .findFirst()
                 .orElseThrow();
 
-        List<ReceivedReviewCategoryResponse> categoryResponses =
-                optionRepository.findAllById(checkboxAnswer.getSelectedOptionIds())
+        List<ReceivedReviewCategoryResponse> categoryResponses = optionRepository.findAllById(
+                        checkboxAnswer.getSelectedOptionIds())
                 .stream()
                 .map(optionItem -> new ReceivedReviewCategoryResponse(optionItem.getId(), optionItem.getContent()))
                 .toList();

--- a/backend/src/main/java/reviewme/template/domain/Section.java
+++ b/backend/src/main/java/reviewme/template/domain/Section.java
@@ -43,8 +43,8 @@ public class Section {
     @Column(name = "position", nullable = false)
     private int position;
 
-    public Section(VisibleType visibleType, List<Long> questionIds, Long onSelectedOptionId, String header,
-                   int position) {
+    public Section(VisibleType visibleType, List<Long> questionIds,
+                   Long onSelectedOptionId, String header, int position) {
         this.visibleType = visibleType;
         this.questionIds = questionIds;
         this.onSelectedOptionId = onSelectedOptionId;

--- a/backend/src/main/java/reviewme/template/domain/Section.java
+++ b/backend/src/main/java/reviewme/template/domain/Section.java
@@ -42,4 +42,13 @@ public class Section {
 
     @Column(name = "position", nullable = false)
     private int position;
+
+    public Section(VisibleType visibleType, List<Long> questionIds, Long onSelectedOptionId, String header,
+                   int position) {
+        this.visibleType = visibleType;
+        this.questionIds = questionIds;
+        this.onSelectedOptionId = onSelectedOptionId;
+        this.header = header;
+        this.position = position;
+    }
 }

--- a/backend/src/main/java/reviewme/template/domain/Template.java
+++ b/backend/src/main/java/reviewme/template/domain/Template.java
@@ -26,4 +26,8 @@ public class Template {
     @ElementCollection
     @CollectionTable(name = "section_ids", joinColumns = @JoinColumn(name = "template_id"))
     List<Long> sectionIds;
+
+    public Template(List<Long> sectionIds) {
+        this.sectionIds = sectionIds;
+    }
 }

--- a/backend/src/main/java/reviewme/template/repository/SectionRepository.java
+++ b/backend/src/main/java/reviewme/template/repository/SectionRepository.java
@@ -1,0 +1,9 @@
+package reviewme.template.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import reviewme.template.domain.Section;
+
+@Repository
+public interface SectionRepository extends JpaRepository<Section, Long> {
+}

--- a/backend/src/main/java/reviewme/template/repository/TemplateRepository.java
+++ b/backend/src/main/java/reviewme/template/repository/TemplateRepository.java
@@ -1,0 +1,9 @@
+package reviewme.template.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import reviewme.template.domain.Template;
+
+@Repository
+public interface TemplateRepository extends JpaRepository<Template, Long> {
+}

--- a/backend/src/test/java/reviewme/review/service/ReviewPreviewGeneratorTest.java
+++ b/backend/src/test/java/reviewme/review/service/ReviewPreviewGeneratorTest.java
@@ -6,7 +6,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import reviewme.review.domain.ReviewContent;
+import reviewme.review.domain.TextAnswer;
 
 class ReviewPreviewGeneratorTest {
 
@@ -15,10 +15,10 @@ class ReviewPreviewGeneratorTest {
         // given
         ReviewPreviewGenerator reviewPreviewGenerator = new ReviewPreviewGenerator();
         String answer = "*".repeat(151);
-        ReviewContent reviewContent = new ReviewContent(1L, answer);
+        TextAnswer textAnswer = new TextAnswer(1, answer);
 
         // when
-        String actual = reviewPreviewGenerator.generatePreview(List.of(reviewContent));
+        String actual = reviewPreviewGenerator.generatePreview2(List.of(textAnswer));
 
         // then
         assertThat(actual).hasSize(150);
@@ -30,10 +30,10 @@ class ReviewPreviewGeneratorTest {
         // given
         ReviewPreviewGenerator reviewPreviewGenerator = new ReviewPreviewGenerator();
         String answer = "*".repeat(length);
-        ReviewContent reviewContent = new ReviewContent(1L, answer);
+        TextAnswer textAnswer = new TextAnswer(1, answer);
 
         // when
-        String actual = reviewPreviewGenerator.generatePreview(List.of(reviewContent));
+        String actual = reviewPreviewGenerator.generatePreview2(List.of(textAnswer));
 
         // then
         assertThat(actual).hasSize(length);

--- a/backend/src/test/java/reviewme/review/service/ReviewServiceTest.java
+++ b/backend/src/test/java/reviewme/review/service/ReviewServiceTest.java
@@ -277,12 +277,13 @@ class ReviewServiceTest {
 
         // when
         ReceivedReviewsResponse response = reviewService.findReceivedReviews(groupAccessCode);
+
+        // then
         List<String> categoryContents = optionItemRepository.findAllByOptionType(OptionType.CATEGORY)
                 .stream()
                 .map(OptionItem::getContent)
                 .toList();
 
-        // then
         assertThat(response.reviews())
                 .map(review -> review.categories()
                         .stream()

--- a/backend/src/test/java/reviewme/review/service/ReviewServiceTest.java
+++ b/backend/src/test/java/reviewme/review/service/ReviewServiceTest.java
@@ -20,7 +20,7 @@ import reviewme.question.domain.OptionItem;
 import reviewme.question.domain.OptionType;
 import reviewme.question.domain.Question;
 import reviewme.question.repository.OptionGroupRepository;
-import reviewme.question.repository.OptionRepository;
+import reviewme.question.repository.OptionItemRepository;
 import reviewme.review.domain.CheckboxAnswer;
 import reviewme.review.domain.Review;
 import reviewme.review.domain.Review2;
@@ -73,7 +73,7 @@ class ReviewServiceTest {
     ReviewKeywordRepository reviewKeywordRepository;
 
     @Autowired
-    OptionRepository optionRepository;
+    OptionItemRepository optionItemRepository;
 
     @Autowired
     OptionGroupRepository optionGroupRepository;
@@ -160,7 +160,7 @@ class ReviewServiceTest {
         OptionGroup categoryOptionGroup = optionGroupRepository.save(new OptionGroup(question1.getId(), 1, 2));
         OptionItem categoryOption1 = new OptionItem("커뮤니케이션 능력 ", categoryOptionGroup.getId(), 1, OptionType.CATEGORY);
         OptionItem categoryOption2 = new OptionItem("시간 관리 능력", categoryOptionGroup.getId(), 2, OptionType.CATEGORY);
-        optionRepository.saveAll(List.of(categoryOption1, categoryOption2));
+        optionItemRepository.saveAll(List.of(categoryOption1, categoryOption2));
 
         Template template = templateRepository.save(new Template(List.of()));
 
@@ -255,7 +255,7 @@ class ReviewServiceTest {
         OptionItem categoryOption1 = new OptionItem("커뮤니케이션 능력 ", categoryOptionGroup.getId(), 1, OptionType.CATEGORY);
         OptionItem categoryOption2 = new OptionItem("시간 관리 능력", categoryOptionGroup.getId(), 2, OptionType.CATEGORY);
         OptionItem keywordOption = new OptionItem("얘기를 잘 들어줘요", keywordOptionGroup.getId(), 2, OptionType.KEYWORD);
-        optionRepository.saveAll(List.of(categoryOption1, categoryOption2, keywordOption));
+        optionItemRepository.saveAll(List.of(categoryOption1, categoryOption2, keywordOption));
 
         Section section1 = secionRepository.save(
                 new Section(VisibleType.ALWAYS, List.of(question1.getId()), null, "팀원과 함께 한 기억을 떠올려볼게요.", 1)
@@ -277,7 +277,7 @@ class ReviewServiceTest {
 
         // when
         ReceivedReviewsResponse response = reviewService.findReceivedReviews(groupAccessCode);
-        List<String> categoryContents = optionRepository.findAllByOptionType(OptionType.CATEGORY)
+        List<String> categoryContents = optionItemRepository.findAllByOptionType(OptionType.CATEGORY)
                 .stream()
                 .map(OptionItem::getContent)
                 .toList();

--- a/backend/src/test/java/reviewme/review/service/ReviewServiceTest.java
+++ b/backend/src/test/java/reviewme/review/service/ReviewServiceTest.java
@@ -3,7 +3,6 @@ package reviewme.review.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static reviewme.fixture.KeywordFixture.꼼꼼하게_기록해요;
 import static reviewme.fixture.KeywordFixture.추진력이_좋아요;
 import static reviewme.fixture.KeywordFixture.회의를_이끌어요;
 import static reviewme.fixture.QuestionFixure.기술역량이_어떤가요;
@@ -16,25 +15,38 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import reviewme.keyword.domain.Keyword;
 import reviewme.keyword.repository.KeywordRepository;
+import reviewme.question.domain.OptionGroup;
+import reviewme.question.domain.OptionItem;
+import reviewme.question.domain.OptionType;
 import reviewme.question.domain.Question;
+import reviewme.question.repository.OptionGroupRepository;
+import reviewme.question.repository.OptionRepository;
+import reviewme.review.domain.CheckboxAnswer;
 import reviewme.review.domain.Review;
-import reviewme.review.domain.ReviewContent;
-import reviewme.review.domain.ReviewKeyword;
+import reviewme.review.domain.Review2;
 import reviewme.review.domain.exception.ReviewGroupNotFoundByGroupAccessCodeException;
 import reviewme.review.domain.exception.ReviewIsNotInReviewGroupException;
 import reviewme.review.dto.request.CreateReviewContentRequest;
 import reviewme.review.dto.request.CreateReviewRequest;
 import reviewme.review.dto.response.QuestionSetupResponse;
+import reviewme.review.dto.response.ReceivedReviewCategoryResponse;
 import reviewme.review.dto.response.ReceivedReviewsResponse;
 import reviewme.review.dto.response.ReviewDetailResponse;
 import reviewme.review.dto.response.ReviewSetupResponse;
+import reviewme.review.repository.CheckboxAnswerRepository;
 import reviewme.review.repository.QuestionRepository;
+import reviewme.review.repository.Review2Repository;
 import reviewme.review.repository.ReviewContentRepository;
 import reviewme.review.repository.ReviewKeywordRepository;
 import reviewme.review.repository.ReviewRepository;
 import reviewme.reviewgroup.domain.ReviewGroup;
 import reviewme.reviewgroup.repository.ReviewGroupRepository;
 import reviewme.support.ServiceTest;
+import reviewme.template.domain.Section;
+import reviewme.template.domain.Template;
+import reviewme.template.domain.VisibleType;
+import reviewme.template.repository.SectionRepository;
+import reviewme.template.repository.TemplateRepository;
 
 @ServiceTest
 class ReviewServiceTest {
@@ -59,6 +71,24 @@ class ReviewServiceTest {
 
     @Autowired
     ReviewKeywordRepository reviewKeywordRepository;
+
+    @Autowired
+    OptionRepository optionRepository;
+
+    @Autowired
+    OptionGroupRepository optionGroupRepository;
+
+    @Autowired
+    SectionRepository secionRepository;
+
+    @Autowired
+    TemplateRepository templateRepository;
+
+    @Autowired
+    CheckboxAnswerRepository checkboxAnswerRepository;
+
+    @Autowired
+    Review2Repository review2Repository;
 
     @Test
     void 리뷰를_생성한다() {
@@ -125,24 +155,23 @@ class ReviewServiceTest {
     @Test
     void 확인_코드에_해당하는_그룹이_존재하면_리뷰_리스트를_반환한다() {
         // given
-        String groupAccessCode = "5678";
-        ReviewGroup reviewGroup = reviewGroupRepository.save(new ReviewGroup("산초", "리뷰미", "1234", groupAccessCode));
-        Question question = questionRepository.save(기술역량이_어떤가요.create());
-        Keyword keyword = keywordRepository.save(꼼꼼하게_기록해요.create());
-        ReviewContent reviewContent1 = new ReviewContent(question.getId(), "기술역량 최고입니다 최고예요 !!!!!");
-        ReviewContent reviewContent2 = new ReviewContent(question.getId(), "기술역량은 별로라고 생각해요 !!!!!");
+        String groupAccessCode = "groupAccessCode";
+        Question question1 = questionRepository.save(new Question("프로젝트 기간 동안, 팀원의 강점이 드러났던 순간을 선택해주세요. (1~2개)"));
+        OptionGroup categoryOptionGroup = optionGroupRepository.save(new OptionGroup(question1.getId(), 1, 2));
+        OptionItem categoryOption1 = new OptionItem("커뮤니케이션 능력 ", categoryOptionGroup.getId(), 1, OptionType.CATEGORY);
+        OptionItem categoryOption2 = new OptionItem("시간 관리 능력", categoryOptionGroup.getId(), 2, OptionType.CATEGORY);
+        optionRepository.saveAll(List.of(categoryOption1, categoryOption2));
 
-        Review review1 = reviewRepository.save(
-                new Review(reviewGroup.getId(), List.of(reviewContent1), LocalDateTime.now())
-        );
-        Review review2 = reviewRepository.save(
-                new Review(reviewGroup.getId(), List.of(reviewContent2), LocalDateTime.now())
-        );
+        Template template = templateRepository.save(new Template(List.of()));
 
-        reviewKeywordRepository.saveAll(List.of(
-                new ReviewKeyword(review1.getId(), keyword.getId()),
-                new ReviewKeyword(review2.getId(), keyword.getId())
-        ));
+        ReviewGroup reviewGroup = reviewGroupRepository.save(
+                new ReviewGroup("커비", "리뷰미", "reviewRequestCode", groupAccessCode)
+        );
+        CheckboxAnswer categoryAnswer1 = new CheckboxAnswer(question1.getId(), List.of(categoryOption1.getId()));
+        CheckboxAnswer categoryAnswer2 = new CheckboxAnswer(question1.getId(), List.of(categoryOption2.getId()));
+        Review2 review1 = new Review2(template.getId(), reviewGroup.getId(), List.of(), List.of(categoryAnswer1), LocalDateTime.now());
+        Review2 review2 = new Review2(template.getId(), reviewGroup.getId(), List.of(), List.of(categoryAnswer2), LocalDateTime.now());
+        review2Repository.saveAll(List.of(review1, review2));
 
         // when
         ReceivedReviewsResponse response = reviewService.findReceivedReviews(groupAccessCode);
@@ -211,5 +240,54 @@ class ReviewServiceTest {
 
         // then
         assertThat(questionResponse.content()).contains("에프이");
+    }
+
+    @Test
+    void 리뷰_목록을_반환할때_선택한_카테고리만_함께_반환한다() {
+        // given
+        String groupAccessCode = "groupAccessCode";
+        Question question1 = questionRepository.save(new Question("프로젝트 기간 동안, 팀원의 강점이 드러났던 순간을 선택해주세요. (1~2개)"));
+        Question question2 = questionRepository.save(new Question("커뮤니케이션, 협업 능력에서 어떤 부분이 인상 깊었는지 선택해주세요. (1개 이상)"));
+
+        OptionGroup categoryOptionGroup = optionGroupRepository.save(new OptionGroup(question1.getId(), 1, 2));
+        OptionGroup keywordOptionGroup = optionGroupRepository.save(new OptionGroup(question2.getId(), 1, 10));
+
+        OptionItem categoryOption1 = new OptionItem("커뮤니케이션 능력 ", categoryOptionGroup.getId(), 1, OptionType.CATEGORY);
+        OptionItem categoryOption2 = new OptionItem("시간 관리 능력", categoryOptionGroup.getId(), 2, OptionType.CATEGORY);
+        OptionItem keywordOption = new OptionItem("얘기를 잘 들어줘요", keywordOptionGroup.getId(), 2, OptionType.KEYWORD);
+        optionRepository.saveAll(List.of(categoryOption1, categoryOption2, keywordOption));
+
+        Section section1 = secionRepository.save(
+                new Section(VisibleType.ALWAYS, List.of(question1.getId()), null, "팀원과 함께 한 기억을 떠올려볼게요.", 1)
+        );
+        Section section2 = secionRepository.save(
+                new Section(VisibleType.CONDITIONAL, List.of(question2.getId()), null, "선택한 순간들을 바탕으로 리뷰를 작성해볼게요.", 1)
+        );
+        Template template = templateRepository.save(new Template(List.of(section1.getId(), section2.getId())));
+
+        ReviewGroup reviewGroup = reviewGroupRepository.save(
+                new ReviewGroup("커비", "리뷰미", "reviewRequestCode", groupAccessCode)
+        );
+        CheckboxAnswer categoryAnswer = new CheckboxAnswer(question1.getId(), List.of(categoryOption1.getId()));
+        CheckboxAnswer keywordAnswer = new CheckboxAnswer(question2.getId(), List.of(keywordOption.getId()));
+        review2Repository.save(
+                new Review2(template.getId(), reviewGroup.getId(), List.of(), List.of(categoryAnswer, keywordAnswer),
+                        LocalDateTime.now())
+        );
+
+        // when
+        ReceivedReviewsResponse response = reviewService.findReceivedReviews(groupAccessCode);
+        List<String> categoryContents = optionRepository.findAllByOptionType(OptionType.CATEGORY)
+                .stream()
+                .map(OptionItem::getContent)
+                .toList();
+
+        // then
+        assertThat(response.reviews())
+                .map(review -> review.categories()
+                        .stream()
+                        .map(ReceivedReviewCategoryResponse::content)
+                        .toList())
+                .allSatisfy(content -> assertThat(categoryContents).containsAll(content));
     }
 }

--- a/backend/src/test/java/reviewme/review/service/ReviewServiceTest.java
+++ b/backend/src/test/java/reviewme/review/service/ReviewServiceTest.java
@@ -30,7 +30,7 @@ import reviewme.review.dto.request.CreateReviewContentRequest;
 import reviewme.review.dto.request.CreateReviewRequest;
 import reviewme.review.dto.response.QuestionSetupResponse;
 import reviewme.review.dto.response.ReceivedReviewCategoryResponse;
-import reviewme.review.dto.response.ReceivedReviewsResponse;
+import reviewme.review.dto.response.ReceivedReviewsResponse2;
 import reviewme.review.dto.response.ReviewDetailResponse;
 import reviewme.review.dto.response.ReviewSetupResponse;
 import reviewme.review.repository.CheckboxAnswerRepository;
@@ -148,7 +148,7 @@ class ReviewServiceTest {
 
     @Test
     void 확인_코드에_해당하는_그룹이_없는_경우_예외가_발생한다() {
-        assertThatThrownBy(() -> reviewService.findReceivedReviews("abc"))
+        assertThatThrownBy(() -> reviewService.findReceivedReviews2("abc"))
                 .isInstanceOf(ReviewGroupNotFoundByGroupAccessCodeException.class);
     }
 
@@ -174,7 +174,7 @@ class ReviewServiceTest {
         review2Repository.saveAll(List.of(review1, review2));
 
         // when
-        ReceivedReviewsResponse response = reviewService.findReceivedReviews(groupAccessCode);
+        ReceivedReviewsResponse2 response = reviewService.findReceivedReviews2(groupAccessCode);
 
         // then
         assertThat(response.reviews()).hasSize(2);
@@ -276,7 +276,7 @@ class ReviewServiceTest {
         );
 
         // when
-        ReceivedReviewsResponse response = reviewService.findReceivedReviews(groupAccessCode);
+        ReceivedReviewsResponse2 response = reviewService.findReceivedReviews2(groupAccessCode);
 
         // then
         List<String> categoryContents = optionItemRepository.findAllByOptionType(OptionType.CATEGORY)


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #285 

---

### 🚀 어떤 기능을 구현했나요 ?
- 바뀐 도메인과 API에 따라 리뷰 목록을 재구현했습니다!

### 🔥 어떻게 해결했나요 ?
- 카테고리만 가져오는 등의 필터링 작업을 위해 OptionItem에 OptionType 컬럼을 추가하였습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 현재는 List<CheckBoxAnswer> 속에 첫질문(카테고리 선택), 꼬리질문(키워드 선택) selectedOptionId가 섞여있습니다. 따라서 리뷰 목록에서 카테고리 선택지만 가져오기 위해서는  selectedOptionId를 갖고 DB에 접근해서 OptionType이 CATEGORY인지를 확인하고 있습니다. 따라서, 리뷰 목록을 응답하기 위해서 리뷰 갯수만큼 exist 확인 쿼리가 나갑니다. 
- 약속한 API 문서 응답 내에서 작업하기 위해 우선 이렇게 구현하였는데, 리뷰 작성 요청에서 선택된 optionId와 함께 optionType을 함께 받아서 CheckBoxAnswer에 OptionType 컬럼을 추가한다면 DB에 접근하지 않고 리뷰 목록을 위한 카테고리 선택지만 가져오는 것이 쉬울 것 같아 논의해보고 싶습니다!

### 📚 참고 자료, 할 말
- 용어 통일이 필요할 것 같습니다. 첫번째 화면 선택지는 카테고리, 꼬리 질문 선택지는 키워드라고 일단 통일하면 될까요?
