### PR TITLE
[FE] feature: 전역 스타일에 커스텀 스크롤바 스타일 적용

### DIFF
--- a/frontend/src/components/common/modals/ContentModal/styles.ts
+++ b/frontend/src/components/common/modals/ContentModal/styles.ts
@@ -30,10 +30,7 @@ export const ContentModalHeader = styled.div`
 `;
 
 export const Contents = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  white-space: pre-line;
+  padding-right: 1.2rem;
 
   overflow-y: auto;
 `;

--- a/frontend/src/styles/globalStyles.ts
+++ b/frontend/src/styles/globalStyles.ts
@@ -16,6 +16,26 @@ const globalStyles = css`
     box-sizing: border-box;
 
     font-size: 1.6rem;
+
+    padding-right: 1.2rem;
+
+    overflow-y: auto;
+  }
+
+  /* 스크롤바 설정 */
+
+  ::-webkit-scrollbar {
+    width: 1.2rem; /* 스크롤바 너비 */
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: #c1c1c1; /* 스크롤바 색상 */
+    border-radius: 0.8rem;
+  }
+
+  ::-webkit-scrollbar-track {
+    background: #f1f2f4; /*스크롤바 배경 색상 (lightGray)*/
+    border-radius: 0.8rem;
   }
 `;
 

--- a/frontend/src/styles/globalStyles.ts
+++ b/frontend/src/styles/globalStyles.ts
@@ -18,8 +18,6 @@ const globalStyles = css`
     font-size: 1.6rem;
 
     padding-right: 1.2rem;
-
-    overflow-y: auto;
   }
 
   /* 스크롤바 설정 */


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #312 

---

### 🚀 어떤 기능을 구현했나요 ?
- 스크롤바 스타일을 커스텀했습니다.
- 스크롤바 스타일을 전역 스타일에 적용했습니다.
![image](https://github.com/user-attachments/assets/a88bb19d-fb51-44f1-ba96-a0b96c7c1ff5)


### 🔥 어떻게 해결했나요 ?
- `::-webkit-scrollbar`는 전역 선택자라서 별도의 태그(`body`, `html` 등) 안에 넣을 필요가 없었습니다.
  - 오히려 `html`이나 `body` 안에 넣으면 브라우저의 기본 스타일이 우선이 되어 커스텀 스크롤이 나타나지 않을 수 있습니다.
- 스크롤바 자체에 달리 `margin`이나 `padding`을 줄 수는 없지만, 스크롤 대상인 요소에 `margin-right`를 줘서 스크롤바와 요소 사이에 gap을 줄 수 있습니다. (를 알아낸 쑤쑤 굿~)
```ts
export const Contents = styled.div`
  padding-right: 1.2rem;

  overflow-y: auto;
`;
```

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 과연 모달이 아닌 일반 페이지에서도 잘 적용되는지 확인해주세요

### 📚 참고 자료, 할 말
- **전역에 스크롤바 스타일을 적용해두긴 했는데 스크롤바를 사용하고 싶으면 해당 컴포넌트 안에서 `overflow-y:auto`나 `scroll`을 줘야 합니다.** (위 코드에서도 `content` 안에 `overflow-y`가 적용되어 있음)
- 왜 안 됐다가 됐는지 모르겠다...