### PR TITLE
[FE] refactor: 리뷰 상세 페이지 url path 관련 코드 수정 및 리팩터링

### DIFF
--- a/frontend/src/apis/endpoints.ts
+++ b/frontend/src/apis/endpoints.ts
@@ -18,8 +18,7 @@ export const REVIEW_WRITING_API_PARAMS = {
 
 const endPoint = {
   postingReview: `${process.env.API_BASE_URL}/${VERSION2}/reviews`,
-  gettingDetailedReview: (reviewId: number, memberId: number) =>
-    `${DETAILED_REVIEW_API_URL}/${reviewId}?${DETAILED_REVIEW_API_PARAMS.queryString.memberId}=${memberId}`,
+  gettingDetailedReview: (reviewId: number) => `${DETAILED_REVIEW_API_URL}/${reviewId}`,
   gettingDataToWriteReview: (reviewRequestCode: string) =>
     `${process.env.API_BASE_URL}/${VERSION2}/${REVIEW_WRITING_API_PARAMS.resource}/${REVIEW_WRITING_API_PARAMS.queryString.write}?${REVIEW_WRITING_API_PARAMS.queryString.reviewRequestCode}=${reviewRequestCode}`,
   gettingReviewList: `${process.env.API_BASE_URL}/${VERSION2}/reviews`,

--- a/frontend/src/apis/review.ts
+++ b/frontend/src/apis/review.ts
@@ -1,4 +1,4 @@
-import { DetailReviewData, ReviewData, ReviewList, ReviewWritingFormResult, ReviewWritingFrom } from '@/types';
+import { DetailReviewData, ReviewList, ReviewWritingFormResult, ReviewWritingFrom } from '@/types';
 
 import createApiErrorMessage from './apiErrorMessageCreator';
 import endPoint from './endpoints';
@@ -35,14 +35,12 @@ export const postReviewApi = async (formResult: ReviewWritingFormResult) => {
 // 상세 리뷰
 export const getDetailedReviewApi = async ({
   reviewId,
-  memberId,
   groupAccessCode,
 }: {
   reviewId: number;
-  memberId: number;
   groupAccessCode: string;
 }) => {
-  const response = await fetch(endPoint.gettingDetailedReview(reviewId, memberId), {
+  const response = await fetch(endPoint.gettingDetailedReview(reviewId), {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',

--- a/frontend/src/hooks/review/useGetDetailedReview/index.ts
+++ b/frontend/src/hooks/review/useGetDetailedReview/index.ts
@@ -6,25 +6,23 @@ import { DetailReviewData } from '@/types';
 
 interface UseGetDetailedReviewProps {
   reviewId: number;
-  memberId: number;
   groupAccessCode: string;
 }
 
 interface FetchDetailedReviewParams {
   reviewId: number;
-  memberId: number;
   groupAccessCode: string;
 }
 
-const useGetDetailedReview = ({ reviewId, memberId, groupAccessCode }: UseGetDetailedReviewProps) => {
-  const fetchDetailedReview = async ({ reviewId, memberId, groupAccessCode }: FetchDetailedReviewParams) => {
-    const result = await getDetailedReviewApi({ reviewId, memberId, groupAccessCode });
+const useGetDetailedReview = ({ reviewId, groupAccessCode }: UseGetDetailedReviewProps) => {
+  const fetchDetailedReview = async ({ reviewId, groupAccessCode }: FetchDetailedReviewParams) => {
+    const result = await getDetailedReviewApi({ reviewId, groupAccessCode });
     return result;
   };
 
   const result = useSuspenseQuery<DetailReviewData>({
-    queryKey: [REVIEW_QUERY_KEYS.detailedReview, reviewId, memberId],
-    queryFn: () => fetchDetailedReview({ reviewId, memberId, groupAccessCode }),
+    queryKey: [REVIEW_QUERY_KEYS.detailedReview, reviewId],
+    queryFn: () => fetchDetailedReview({ reviewId, groupAccessCode }),
   });
 
   return result;

--- a/frontend/src/mocks/handlers/review.ts
+++ b/frontend/src/mocks/handlers/review.ts
@@ -27,11 +27,11 @@ const getDetailedReview = () =>
     //요청 url에서 reviewId, memberId 추출
     const url = new URL(request.url);
     const urlReviewId = url.pathname.replace(`/${VERSION2}/${DETAILED_REVIEW_API_PARAMS.resource}/`, '');
-    const urlMemberId = url.searchParams.get(DETAILED_REVIEW_API_PARAMS.queryString.memberId);
+    // const urlMemberId = url.searchParams.get(DETAILED_REVIEW_API_PARAMS.queryString.memberId);
 
-    const { reviewId, memberId } = DETAILED_PAGE_MOCK_API_SETTING_VALUES;
+    const { reviewId } = DETAILED_PAGE_MOCK_API_SETTING_VALUES;
     // 유효한 reviewId, memberId일 경우에만 데이터 반환
-    if (Number(urlReviewId) == reviewId && Number(urlMemberId) === memberId) {
+    if (Number(urlReviewId) == reviewId) {
       return HttpResponse.json(DETAILED_REVIEW_MOCK_DATA);
     }
 

--- a/frontend/src/mocks/mockData/detailedReviewMockData.ts
+++ b/frontend/src/mocks/mockData/detailedReviewMockData.ts
@@ -5,23 +5,23 @@ export const DETAILED_PAGE_MOCK_API_SETTING_VALUES = {
   memberId: 2,
 };
 
-const revieweeName = 'badahertz52';
+const REVIEWEENAME = 'badahertz52';
 
 export const DETAILED_REVIEW_MOCK_DATA: DetailReviewData = {
   formId: 1,
-  revieweeName: revieweeName,
+  revieweeName: REVIEWEENAME,
   projectName: 'review-me',
   createdAt: '2024-05-05',
   sections: [
     {
       sectionId: 1,
-      header: `💡 ${revieweeName}와 함께 한 기억을 떠올려볼게요.`,
+      header: `💡 ${REVIEWEENAME}와 함께 한 기억을 떠올려볼게요.`,
       questions: [
         {
           questionId: 1,
           required: true,
           questionType: 'CHECKBOX',
-          content: `프로젝트 기간 동안, ${revieweeName}의 강점이 드러났던 순간을 선택해주세요.`,
+          content: `프로젝트 기간 동안, ${REVIEWEENAME}의 강점이 드러났던 순간을 선택해주세요.`,
           optionGroup: {
             optionGroupId: 1,
             minCount: 1,
@@ -42,7 +42,7 @@ export const DETAILED_REVIEW_MOCK_DATA: DetailReviewData = {
           questionId: 2,
           required: true,
           questionType: 'CHECKBOX',
-          content: `${revieweeName}에서 어떤 부분이 인상 깊었는지 선택해주세요.`,
+          content: `${REVIEWEENAME}에서 어떤 부분이 인상 깊었는지 선택해주세요.`,
           optionGroup: {
             optionGroupId: 1,
             minCount: 1,
@@ -64,7 +64,7 @@ export const DETAILED_REVIEW_MOCK_DATA: DetailReviewData = {
           content: '위에서 선택한 사항에 대해 조금 더 자세히 설명해주세요.',
           optionGroup: null,
           hasGuideline: true,
-          guideline: `상황을 자세하게 기록할수록 ${revieweeName}에게 도움이 돼요. OO 덕분에 팀이 원활한 소통을 이뤘거나, 함께 일하면서 배울 점이 있었는지 떠올려 보세요.`,
+          guideline: `상황을 자세하게 기록할수록 ${REVIEWEENAME}에게 도움이 돼요. OO 덕분에 팀이 원활한 소통을 이뤘거나, 함께 일하면서 배울 점이 있었는지 떠올려 보세요.`,
           answer: '쑤쑤 쑤퍼노바 인상깊어요',
         },
       ],
@@ -77,7 +77,7 @@ export const DETAILED_REVIEW_MOCK_DATA: DetailReviewData = {
           questionId: 4,
           required: true,
           questionType: 'TEXT',
-          content: `앞으로의 성장을 위해서 ${revieweeName}이 어떤 목표를 설정하면 좋을까요?`,
+          content: `앞으로의 성장을 위해서 ${REVIEWEENAME}이 어떤 목표를 설정하면 좋을까요?`,
           optionGroup: null,
           hasGuideline: true,
           guideline: `어떤 점을 보완하면 좋을지와 함께 '이렇게 해보면 어떨까?'하는 간단한 솔루션을 제안해봐요.`,
@@ -93,7 +93,7 @@ export const DETAILED_REVIEW_MOCK_DATA: DetailReviewData = {
           questionId: 5,
           required: false,
           questionType: 'TEXT',
-          content: `${revieweeName}에게 전하고 싶은 다른 리뷰가 있거나 응원의 말이 있다면 적어주세요.`,
+          content: `${REVIEWEENAME}에게 전하고 싶은 다른 리뷰가 있거나 응원의 말이 있다면 적어주세요.`,
           optionGroup: null,
           hasGuideline: false,
           guideline: null,

--- a/frontend/src/mocks/mockData/detailedReviewMockData.ts
+++ b/frontend/src/mocks/mockData/detailedReviewMockData.ts
@@ -21,7 +21,7 @@ export const DETAILED_REVIEW_MOCK_DATA: DetailReviewData = {
           questionId: 1,
           required: true,
           questionType: 'CHECKBOX',
-          content: `프로젝트 기간 동안, ${revieweeName}의 강점이 드러났던 순간을 선택해주세요. (1~2개)`,
+          content: `프로젝트 기간 동안, ${revieweeName}의 강점이 드러났던 순간을 선택해주세요.`,
           optionGroup: {
             optionGroupId: 1,
             minCount: 1,
@@ -42,7 +42,7 @@ export const DETAILED_REVIEW_MOCK_DATA: DetailReviewData = {
           questionId: 2,
           required: true,
           questionType: 'CHECKBOX',
-          content: `${revieweeName}에서 어떤 부분이 인상 깊었는지 선택해주세요. (1개 이상)`,
+          content: `${revieweeName}에서 어떤 부분이 인상 깊었는지 선택해주세요.`,
           optionGroup: {
             optionGroupId: 1,
             minCount: 1,

--- a/frontend/src/pages/DetailedReviewPage/components/DetailedReviewPageContents/index.tsx
+++ b/frontend/src/pages/DetailedReviewPage/components/DetailedReviewPageContents/index.tsx
@@ -9,14 +9,13 @@ interface DetailedReviewPageContentsProps {
 }
 
 const DetailedReviewPageContents = ({ groupAccessCode }: DetailedReviewPageContentsProps) => {
-  const { param: reviewId, queryString: memberId } = useSearchParamAndQuery({
+  const { param: reviewId } = useSearchParamAndQuery({
     paramKey: 'reviewId',
     queryStringKey: DETAILED_REVIEW_API_PARAMS.queryString.memberId,
   });
 
   const { data: detailedReview } = useGetDetailedReview({
     reviewId: Number(reviewId),
-    memberId: Number(memberId),
     groupAccessCode,
   });
 

--- a/frontend/src/pages/DetailedReviewPage/components/DetailedReviewPageContents/index.tsx
+++ b/frontend/src/pages/DetailedReviewPage/components/DetailedReviewPageContents/index.tsx
@@ -34,8 +34,8 @@ const DetailedReviewPageContents = ({ groupAccessCode }: DetailedReviewPageConte
         <ReviewSection key={id} question={question} answer={answer} index={index} />
       ))} */}
       {detailedReview.sections.map((section) =>
-        section.questions.map((question, index) => (
-          <S.ReviewContentContainer key={index}>
+        section.questions.map((question) => (
+          <S.ReviewContentContainer key={question.questionId}>
             <ReviewSection question={question.content} answer={question.answer!} />
             {question.questionType === 'CHECKBOX' && <KeywordSection options={question.optionGroup!.options} />}
           </S.ReviewContentContainer>

--- a/frontend/src/pages/DetailedReviewPage/components/ReviewSection/index.tsx
+++ b/frontend/src/pages/DetailedReviewPage/components/ReviewSection/index.tsx
@@ -4,7 +4,6 @@ import ReviewSectionHeader from '../ReviewSectionHeader';
 
 import * as S from './styles';
 
-// const INDEX_OFFSET = 1;
 interface ReviewSectionProps {
   question: string;
   answer: string;

--- a/frontend/src/pages/ReviewListPage/components/PageContents/index.tsx
+++ b/frontend/src/pages/ReviewListPage/components/PageContents/index.tsx
@@ -18,23 +18,23 @@ interface PageContentsProps {
 
 const PageContents = ({ groupAccessCode }: PageContentsProps) => {
   const navigate = useNavigate();
-  const { data: ReviewListData } = useGetReviewList(groupAccessCode);
+  const { data: reviewListData } = useGetReviewList(groupAccessCode);
 
   const handleReviewClick = (id: number) => {
-    navigate(`/user/detailed-review/${id}?memberId=${MEMBER_ID}`);
+    navigate(`/user/detailed-review/${id}`);
   };
 
   return (
     <>
       <S.Layout>
-        <ReviewInfoSection projectName={ReviewListData.projectName} revieweeName={ReviewListData.revieweeName} />
+        <ReviewInfoSection projectName={reviewListData.projectName} revieweeName={reviewListData.revieweeName} />
         {/* <SearchSection handleChange={() => {}} options={OPTIONS} placeholder={USER_SEARCH_PLACE_HOLDER} /> */}
         <S.ReviewSection>
-          {ReviewListData.reviews.map((review) => (
+          {reviewListData.reviews.map((review) => (
             // const isLastElement = pageIndex === data.pages.length - 1 && reviewIndex === page.reviews.length - 1;
             <div key={review.reviewId} onClick={() => handleReviewClick(review.reviewId)}>
               <ReviewCard
-                projectName={ReviewListData.projectName}
+                projectName={reviewListData.projectName}
                 createdAt={review.createdAt}
                 contentPreview={review.contentPreview}
                 categories={review.categories}

--- a/frontend/src/pages/ReviewListPage/components/PageContents/index.tsx
+++ b/frontend/src/pages/ReviewListPage/components/PageContents/index.tsx
@@ -4,13 +4,12 @@ import ReviewCard from '@/components/ReviewCard';
 import { useGetReviewList } from '@/hooks';
 
 import ReviewInfoSection from '../ReviewInfoSection';
-import SearchSection from '../SearchSection';
+// import SearchSection from '../SearchSection';
 
 import * as S from './styles';
 
-const USER_SEARCH_PLACE_HOLDER = '레포지토리명을 검색하세요.';
-const OPTIONS = ['최신순', '오래된순'];
-const MEMBER_ID = 2;
+// const USER_SEARCH_PLACE_HOLDER = '레포지토리명을 검색하세요.';
+// const OPTIONS = ['최신순', '오래된순'];
 
 interface PageContentsProps {
   groupAccessCode: string;

--- a/frontend/src/pages/ReviewListPage/components/ReviewInfoSection/index.tsx
+++ b/frontend/src/pages/ReviewListPage/components/ReviewInfoSection/index.tsx
@@ -5,7 +5,7 @@ interface ReviewInfoSectionProps {
   revieweeName: string;
 }
 
-const REVIEW_MESSAGE_SUFFIX = '님에게 달린 리뷰입니다!';
+const REVIEW_MESSAGE_SUFFIX = '에게 달린 리뷰입니다!';
 
 const ReviewInfoSection = ({ projectName, revieweeName }: ReviewInfoSectionProps) => {
   return (


### PR DESCRIPTION
- resolves #319 

---

### 🚀 어떤 기능을 구현했나요 ?
- 리뷰 상세 페이지 url path 관련 코드를 수정하고 리팩터링했습니다.

### 🔥 어떻게 해결했나요 ?

리뷰 상세 페이지에서 리뷰를 불러오는 API가 변경되어 `memberId` 가 더이상 필요하지 않게 되었습니다. 그래서 `memberId` 관련 코드를 모두 제거했습니다.

### 변경사항
- `getDetailedReviewApi`와 관련된 코드에서 `memberId` 파라미터를 제거하고, 관련된 모든 사용처에서도 `memberId`를 삭제했습니다.
- 목 데이터와 핸들러에서 `memberId` 관련 로직을 제거했습니다.
- `ReviewListPage`에서 리뷰 클릭 시, `navigate` 경로에 `memberId`를 제거했습니다.



#### 리팩터링
- `REVIEW_MESSAGE_SUFFIX`에서 님을 제외하여 "에게 달린 리뷰입니다!"로 수정했습니다.
- 리뷰 상세 페이지 목 데이터에서 `REVIEWEENAME` 상수를 대문자로 변경했습니다.
리뷰 상세 페이지 개선
  - `key` 값을 `questionId`로 변경했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- `memberId` 관련 코드가 모두 삭제되었을까요?

### 📚 참고 자료, 할 말
- 리뷰미 리뷰미 화이팅!