### PR TITLE
[BE] 리뷰 단건 조회 시, 리뷰이 이름으로 치환되지 않는 오류 수정

### DIFF
--- a/backend/src/main/java/reviewme/review/service/ReviewDetailLookupService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewDetailLookupService.java
@@ -51,7 +51,7 @@ public class ReviewDetailLookupService {
         List<SectionAnswerResponse> sectionResponses = sectionRepository.findAllByTemplateId(templateId)
                 .stream()
                 .filter(section -> section.isVisibleBySelectedOptionIds(selectedOptionItemIds))
-                .map(section -> getSectionAnswerResponse(reviewGroup, review, section))
+                .map(section -> getSectionAnswerResponse(review, section, reviewGroup))
                 .toList();
 
         return new TemplateAnswerResponse(
@@ -63,16 +63,16 @@ public class ReviewDetailLookupService {
         );
     }
 
-    private SectionAnswerResponse getSectionAnswerResponse(ReviewGroup reviewGroup, Review2 review, Section section) {
+    private SectionAnswerResponse getSectionAnswerResponse(Review2 review, Section section, ReviewGroup reviewGroup) {
         TextAnswers textAnswers = new TextAnswers(review.getTextAnswers());
         ArrayList<QuestionAnswerResponse> questionResponses = new ArrayList<>();
 
         for (Question2 question : questionRepository.findAllBySectionId(section.getId())) {
             if (question.isSelectable()) {
-                questionResponses.add(getCheckboxAnswerResponse(reviewGroup, review, question));
+                questionResponses.add(getCheckboxAnswerResponse(review, question, reviewGroup));
                 continue;
             }
-            questionResponses.add(getTextAnswerResponse(reviewGroup, question, textAnswers));
+            questionResponses.add(getTextAnswerResponse(textAnswers, question, reviewGroup));
         }
 
         return new SectionAnswerResponse(
@@ -82,7 +82,8 @@ public class ReviewDetailLookupService {
         );
     }
 
-    private QuestionAnswerResponse getTextAnswerResponse(ReviewGroup reviewGroup, Question2 question, TextAnswers textAnswers) {
+    private QuestionAnswerResponse getTextAnswerResponse(TextAnswers textAnswers, Question2 question,
+                                                         ReviewGroup reviewGroup) {
         TextAnswer textAnswer = textAnswers.getAnswerByQuestionId(question.getId());
         return new QuestionAnswerResponse(
                 question.getId(),
@@ -94,7 +95,8 @@ public class ReviewDetailLookupService {
         );
     }
 
-    private QuestionAnswerResponse getCheckboxAnswerResponse(ReviewGroup reviewGroup, Review2 review, Question2 question) {
+    private QuestionAnswerResponse getCheckboxAnswerResponse(Review2 review, Question2 question,
+                                                             ReviewGroup reviewGroup) {
         OptionGroup optionGroup = optionGroupRepository.getByQuestionId(question.getId());
         Set<Long> selectedOptionItemIds = optionItemRepository.findSelectedOptionItemIdsByReviewId(review.getId());
         List<OptionItemAnswerResponse> optionItemResponse =


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #326 

---

### 🚀 어떤 기능을 구현했나요 ?
-  리뷰 단건 조회 시, 리뷰이 이름으로 치환되지 않는 오류를 수정했습니다.

### 🔥 어떻게 해결했나요 ?
- 리뷰 단건 조회 응답 매핑 시 필요한 부분을 리뷰이 이름으로 변환하는 로직으로 대체했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 치환해야하는 데 안빼먹었는지 확인!

### 📚 참고 자료, 할 말
- 올리가 알려줘서 반영하고 바로 PR 올립니당~