### PR TITLE
[FE] refactor: 리뷰 상세 페이지 QuestionData 인터페이스에서 hasGuideline, guideline 속성 제거

### DIFF
--- a/frontend/src/mocks/mockData/detailedReviewMockData.ts
+++ b/frontend/src/mocks/mockData/detailedReviewMockData.ts
@@ -2,7 +2,6 @@ import { DetailReviewData } from '@/types';
 
 export const DETAILED_PAGE_MOCK_API_SETTING_VALUES = {
   reviewId: 5,
-  memberId: 2,
 };
 
 const REVIEWEENAME = 'badahertz52';
@@ -63,8 +62,6 @@ export const DETAILED_REVIEW_MOCK_DATA: DetailReviewData = {
           questionType: 'TEXT',
           content: '위에서 선택한 사항에 대해 조금 더 자세히 설명해주세요.',
           optionGroup: null,
-          hasGuideline: true,
-          guideline: `상황을 자세하게 기록할수록 ${REVIEWEENAME}에게 도움이 돼요. OO 덕분에 팀이 원활한 소통을 이뤘거나, 함께 일하면서 배울 점이 있었는지 떠올려 보세요.`,
           answer: '쑤쑤 쑤퍼노바 인상깊어요',
         },
       ],
@@ -79,8 +76,6 @@ export const DETAILED_REVIEW_MOCK_DATA: DetailReviewData = {
           questionType: 'TEXT',
           content: `앞으로의 성장을 위해서 ${REVIEWEENAME}이 어떤 목표를 설정하면 좋을까요?`,
           optionGroup: null,
-          hasGuideline: true,
-          guideline: `어떤 점을 보완하면 좋을지와 함께 '이렇게 해보면 어떨까?'하는 간단한 솔루션을 제안해봐요.`,
           answer: '어디까지 성장할려구~?',
         },
       ],
@@ -95,8 +90,6 @@ export const DETAILED_REVIEW_MOCK_DATA: DetailReviewData = {
           questionType: 'TEXT',
           content: `${REVIEWEENAME}에게 전하고 싶은 다른 리뷰가 있거나 응원의 말이 있다면 적어주세요.`,
           optionGroup: null,
-          hasGuideline: false,
-          guideline: null,
           answer: '응원합니다 화이팅!!',
         },
       ],

--- a/frontend/src/pages/DetailedReviewPage/components/DetailedReviewPageContents/index.tsx
+++ b/frontend/src/pages/DetailedReviewPage/components/DetailedReviewPageContents/index.tsx
@@ -29,10 +29,6 @@ const DetailedReviewPageContents = ({ groupAccessCode }: DetailedReviewPageConte
         isPublic={true}
         handleClickToggleButton={() => console.log('click toggle ')}
       />
-      {/* 시연 때 숨김 <RevieweeComments comment={detailedReview.reviewerGroup.description} /> */}
-      {/* {detailedReview.contents.map(({ id, question, answer }, index) => (
-        <ReviewSection key={id} question={question} answer={answer} index={index} />
-      ))} */}
       {detailedReview.sections.map((section) =>
         section.questions.map((question) => (
           <S.ReviewContentContainer key={question.questionId}>

--- a/frontend/src/types/review.ts
+++ b/frontend/src/types/review.ts
@@ -29,8 +29,6 @@ export interface QuestionData {
   questionType: QuestionType;
   content: string;
   optionGroup: OptionGroup | null;
-  hasGuideline?: boolean;
-  guideline?: string | null;
   answer?: string;
 }
 


### PR DESCRIPTION
- resolves #337 

---

### 🚀 어떤 기능을 구현했나요 ?
- 리뷰 상세 페이지 `QuestionData` 인터페이스에서 `hasGuideline, guideline` 속성을 제거했습니다.

### 🔥 어떻게 해결했나요 ?
- 리뷰 상세 페이지 기존 api에 `hasGuideline, guideline` 속성을 내려줬는데 불필요하다고 판단했습니다. 그래서 `QuestionData` 인터페이스, 목 데이터에서 관련 속성을 모두 제거했습니다.

```ts
export interface QuestionData {
  questionId: number;
  required: boolean;
  questionType: QuestionType;
  content: string;
  optionGroup: OptionGroup | null;
  answer?: string;
}
```

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 변경된 부분이 크지 않아서 집중해서 리뷰할 필요가 있을까요~~

### 📚 참고 자료, 할 말
- 화이팅!