### PR TITLE
[FE] fix : 필수가 아닌 답변을 작성하려 하지 않았을 경우에 대한 오류 수정

### DIFF
--- a/frontend/src/hooks/review/writingCardForm/useReviewerAnswer.ts
+++ b/frontend/src/hooks/review/writingCardForm/useReviewerAnswer.ts
@@ -11,6 +11,24 @@ interface UseReviewerAnswerProps {
 const useReviewerAnswer = ({ currentCardIndex, questionList, updatedSelectedCategory }: UseReviewerAnswerProps) => {
   const [answerMap, setAnswerMap] = useState<Map<number, ReviewWritingAnswer>>();
   const [answerValidationMap, SetAnswerValidationMap] = useState<Map<number, boolean>>();
+
+  useEffect(() => {
+    const newAnswerMap: Map<number, ReviewWritingAnswer> = new Map();
+    const newAnswerValidationMap: Map<number, boolean> = new Map();
+    questionList?.forEach((section) => {
+      section.questions.forEach((question) => {
+        const answer = answerMap?.get(question.questionId);
+        newAnswerMap.set(question.questionId, {
+          questionId: question.questionId,
+          selectedOptionIds: question.questionType === 'CHECKBOX' ? (answer?.selectedOptionIds ?? []) : null,
+          text: question.questionType === 'TEXT' ? (answer?.text ?? '') : null,
+        });
+        newAnswerValidationMap.set(question.questionId, !question.required);
+      });
+    });
+    setAnswerMap(newAnswerMap);
+  }, [questionList]);
+
   const [isAbleNextStep, setIsAbleNextStep] = useState(false);
 
   const isCategoryAnswer = (answer: ReviewWritingAnswer) =>
@@ -38,9 +56,8 @@ const useReviewerAnswer = ({ currentCardIndex, questionList, updatedSelectedCate
     return questionList[currentCardIndex].questions.every((question) => {
       const { questionId, required } = question;
       const answerValidation = answerValidationMap?.get(questionId);
-      const answer = answerMap?.get(questionId);
 
-      if (!required && !answer) return true;
+      if (!required) return true;
       return !!answerValidation;
     });
   };

--- a/frontend/src/hooks/review/writingCardForm/useReviewerAnswer.ts
+++ b/frontend/src/hooks/review/writingCardForm/useReviewerAnswer.ts
@@ -23,10 +23,14 @@ const useReviewerAnswer = ({ currentCardIndex, questionList, updatedSelectedCate
           selectedOptionIds: question.questionType === 'CHECKBOX' ? (answer?.selectedOptionIds ?? []) : null,
           text: question.questionType === 'TEXT' ? (answer?.text ?? '') : null,
         });
-        newAnswerValidationMap.set(question.questionId, !question.required);
+        newAnswerValidationMap.set(
+          question.questionId,
+          answerValidationMap?.get(question.questionId) ?? !question.required,
+        );
       });
     });
     setAnswerMap(newAnswerMap);
+    SetAnswerValidationMap(newAnswerValidationMap);
   }, [questionList]);
 
   const [isAbleNextStep, setIsAbleNextStep] = useState(false);
@@ -57,7 +61,7 @@ const useReviewerAnswer = ({ currentCardIndex, questionList, updatedSelectedCate
       const { questionId, required } = question;
       const answerValidation = answerValidationMap?.get(questionId);
 
-      if (!required) return true;
+      if (!required && answerValidation) return true;
       return !!answerValidation;
     });
   };


### PR DESCRIPTION


- resolves #341

---

### 🚀 어떤 기능을 구현했나요 ?

### 🔥 어떻게 해결했나요 ?
- 답변을 작성할때, `answerMap`, `answerValidationMap `의 상태를 변경하기 때문에 작성하지 않은 필수가 아닌 답변의 값이 안들어가는 오류가 있었어요.
- questionList 가 변경될때,  답변의 기본값, 답변의 유효성 검사 기본값을 설정하게 했어요.
- 답변의 기본값에 기존에 작성한 답이 있을 경우 이를 반영하도록 했어요.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 코드 리뷰 시 프론트엔드가 여러 가지 경우를 같이 확인해봤으면 좋겠어요. 

### 📚 참고 자료, 할 말
- 오류 수정,....오류...오류 수정... 엣지 케이스 파악 잘 하고 싶다.