### PR TITLE
[BE] 리뷰 목록 카테고리 조회 시 네이티브 쿼리를 사용하도록 변경

### DIFF
--- a/backend/src/main/java/reviewme/question/repository/OptionItemRepository.java
+++ b/backend/src/main/java/reviewme/question/repository/OptionItemRepository.java
@@ -40,6 +40,17 @@ public interface OptionItemRepository extends JpaRepository<OptionItem, Long> {
             """, nativeQuery = true)
     List<OptionItem> findSelectedOptionItemsByReviewIdAndQuestionId(long reviewId, long questionId);
 
+    @Query(value = """
+            SELECT o.* FROM option_item o
+            LEFT JOIN checkbox_answer_selected_option cao
+            ON cao.selected_option_id = o.id
+            LEFT JOIN checkbox_answer ca
+            ON cao.checkbox_answer_id = ca.id
+            WHERE ca.review_id = :reviewId
+            AND o.option_type = :#{#optionType.name()}
+            """, nativeQuery = true)
+    List<OptionItem> findByOptionTypeAndReviewId(long reviewId, OptionType optionType);
+
     default OptionItem getOptionItemById(long id) {
         return findById(id).orElseThrow(() -> new OptionItemNotFoundException(id));
     }

--- a/backend/src/test/java/reviewme/question/repository/OptionItemRepositoryTest.java
+++ b/backend/src/test/java/reviewme/question/repository/OptionItemRepositoryTest.java
@@ -1,12 +1,14 @@
 package reviewme.question.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import reviewme.question.domain.OptionGroup;
 import reviewme.question.domain.OptionItem;
 import reviewme.question.domain.OptionType;
 import reviewme.question.domain.Question2;
@@ -15,6 +17,11 @@ import reviewme.review.domain.CheckboxAnswer;
 import reviewme.review.domain.Review2;
 import reviewme.review.repository.QuestionRepository2;
 import reviewme.review.repository.ReviewRepository2;
+import reviewme.reviewgroup.domain.ReviewGroup;
+import reviewme.reviewgroup.repository.ReviewGroupRepository;
+import reviewme.template.domain.Template;
+import reviewme.template.repository.SectionRepository;
+import reviewme.template.repository.TemplateRepository;
 
 @DataJpaTest
 class OptionItemRepositoryTest {
@@ -27,6 +34,18 @@ class OptionItemRepositoryTest {
 
     @Autowired
     private QuestionRepository2 questionRepository;
+
+    @Autowired
+    private ReviewGroupRepository reviewGroupRepository;
+
+    @Autowired
+    OptionGroupRepository optionGroupRepository;
+
+    @Autowired
+    SectionRepository sectionRepository;
+
+    @Autowired
+    TemplateRepository templateRepository;
 
     @Test
     void 리뷰_아이디로_선택한_옵션_아이템_아이디를_불러온다() {
@@ -59,12 +78,12 @@ class OptionItemRepositoryTest {
         long optionId4 = optionItemRepository.save(new OptionItem("4", 0, 1, OptionType.KEYWORD)).getId();
         optionItemRepository.save(new OptionItem("5", 0, 1, OptionType.KEYWORD));
 
-        List<CheckboxAnswer> checkboxAnswers = List.of(
-                new CheckboxAnswer(1, List.of(optionId1, optionId3)),
-                new CheckboxAnswer(2, List.of(optionId4))
-        );
         Question2 question1 = questionRepository.save(new Question2(true, QuestionType.CHECKBOX, "질문", null, 1));
-        questionRepository.save(new Question2(true, QuestionType.CHECKBOX, "질문", null, 1));
+        Question2 question2 = questionRepository.save(new Question2(true, QuestionType.CHECKBOX, "질문", null, 1));
+        List<CheckboxAnswer> checkboxAnswers = List.of(
+                new CheckboxAnswer(question1.getId(), List.of(optionId1, optionId3)),
+                new CheckboxAnswer(question2.getId(), List.of(optionId4))
+        );
 
         Review2 review = reviewRepository.save(new Review2(0, 0, List.of(), checkboxAnswers));
 
@@ -77,4 +96,47 @@ class OptionItemRepositoryTest {
         assertThat(actual).extracting(OptionItem::getId).containsExactly(optionId3, optionId1);
     }
 
+    @Test
+    void 리뷰_아이디와_옵션_타입으로_선택한_옵션_아이템을_불러온다() {
+        // given
+        String groupAccessCode = "groupAccessCode";
+        Question2 question1 = questionRepository.save(new Question2(true, QuestionType.CHECKBOX,
+                "프로젝트 기간 동안, 팀원의 강점이 드러났던 순간을 선택해주세요. (1~2개)", null, 1));
+        Question2 question2 = questionRepository.save(new Question2(true, QuestionType.CHECKBOX,
+                "커뮤니케이션, 협업 능력에서 어떤 부분이 인상 깊었는지 선택해주세요. (1개 이상)", null, 1));
+
+        OptionGroup categoryOptionGroup = optionGroupRepository.save(new OptionGroup(question1.getId(), 1, 2));
+        OptionGroup keywordOptionGroup = optionGroupRepository.save(new OptionGroup(question2.getId(), 1, 10));
+
+        OptionItem categoryOption1 = new OptionItem("커뮤니케이션 능력 ", categoryOptionGroup.getId(), 1, OptionType.CATEGORY);
+        OptionItem categoryOption2 = new OptionItem("시간 관리 능력", categoryOptionGroup.getId(), 2, OptionType.CATEGORY);
+        new OptionItem("문제해결 능력", categoryOptionGroup.getId(), 2, OptionType.CATEGORY);
+        OptionItem keywordOption = new OptionItem("얘기를 잘 들어줘요", keywordOptionGroup.getId(), 2, OptionType.KEYWORD);
+        optionItemRepository.saveAll(List.of(categoryOption1, categoryOption2, keywordOption));
+
+        Template template = templateRepository.save(new Template(List.of()));
+
+        ReviewGroup reviewGroup = reviewGroupRepository.save(
+                new ReviewGroup("커비", "리뷰미", "reviewRequestCode", groupAccessCode)
+        );
+        CheckboxAnswer categoryAnswer = new CheckboxAnswer(
+                question1.getId(), List.of(categoryOption1.getId(), categoryOption2.getId())
+        );
+        CheckboxAnswer keywordAnswer = new CheckboxAnswer(question2.getId(), List.of(keywordOption.getId()));
+        Review2 review = reviewRepository.save(
+                new Review2(template.getId(), reviewGroup.getId(), List.of(), List.of(categoryAnswer, keywordAnswer))
+        );
+
+        // when
+        List<OptionItem> optionItems = optionItemRepository.findByOptionTypeAndReviewId(
+                review.getId(), OptionType.CATEGORY
+        );
+
+        // then
+        assertAll(
+                () -> assertThat(optionItems).hasSize(2),
+                () -> assertThat(optionItems).allSatisfy(
+                        optionItem -> assertThat(optionItem.getOptionType()).isEqualTo(OptionType.CATEGORY))
+        );
+    }
 }

--- a/backend/src/test/java/reviewme/review/service/ReviewServiceTest.java
+++ b/backend/src/test/java/reviewme/review/service/ReviewServiceTest.java
@@ -24,12 +24,11 @@ import reviewme.question.repository.OptionItemRepository;
 import reviewme.review.domain.CheckboxAnswer;
 import reviewme.review.domain.Review;
 import reviewme.review.domain.Review2;
-import reviewme.review.domain.exception.ReviewGroupNotFoundByGroupAccessCodeException;
 import reviewme.review.domain.exception.InvalidReviewAccessByReviewGroupException;
+import reviewme.review.domain.exception.ReviewGroupNotFoundByGroupAccessCodeException;
 import reviewme.review.dto.request.CreateReviewContentRequest;
 import reviewme.review.dto.request.CreateReviewRequest;
 import reviewme.review.dto.response.QuestionSetupResponse;
-import reviewme.review.dto.response.ReceivedReviewCategoryResponse;
 import reviewme.review.dto.response.ReceivedReviewsResponse2;
 import reviewme.review.dto.response.ReviewDetailResponse;
 import reviewme.review.dto.response.ReviewSetupResponse;
@@ -42,9 +41,7 @@ import reviewme.review.repository.ReviewRepository;
 import reviewme.reviewgroup.domain.ReviewGroup;
 import reviewme.reviewgroup.repository.ReviewGroupRepository;
 import reviewme.support.ServiceTest;
-import reviewme.template.domain.Section;
 import reviewme.template.domain.Template;
-import reviewme.template.domain.VisibleType;
 import reviewme.template.repository.SectionRepository;
 import reviewme.template.repository.TemplateRepository;
 
@@ -240,54 +237,5 @@ class ReviewServiceTest {
 
         // then
         assertThat(questionResponse.content()).contains("에프이");
-    }
-
-    @Test
-    void 리뷰_목록을_반환할때_선택한_카테고리만_함께_반환한다() {
-        // given
-        String groupAccessCode = "groupAccessCode";
-        Question question1 = questionRepository.save(new Question("프로젝트 기간 동안, 팀원의 강점이 드러났던 순간을 선택해주세요. (1~2개)"));
-        Question question2 = questionRepository.save(new Question("커뮤니케이션, 협업 능력에서 어떤 부분이 인상 깊었는지 선택해주세요. (1개 이상)"));
-
-        OptionGroup categoryOptionGroup = optionGroupRepository.save(new OptionGroup(question1.getId(), 1, 2));
-        OptionGroup keywordOptionGroup = optionGroupRepository.save(new OptionGroup(question2.getId(), 1, 10));
-
-        OptionItem categoryOption1 = new OptionItem("커뮤니케이션 능력 ", categoryOptionGroup.getId(), 1, OptionType.CATEGORY);
-        OptionItem categoryOption2 = new OptionItem("시간 관리 능력", categoryOptionGroup.getId(), 2, OptionType.CATEGORY);
-        OptionItem keywordOption = new OptionItem("얘기를 잘 들어줘요", keywordOptionGroup.getId(), 2, OptionType.KEYWORD);
-        optionItemRepository.saveAll(List.of(categoryOption1, categoryOption2, keywordOption));
-
-        Section section1 = secionRepository.save(
-                new Section(VisibleType.ALWAYS, List.of(question1.getId()), null, "팀원과 함께 한 기억을 떠올려볼게요.", 1)
-        );
-        Section section2 = secionRepository.save(
-                new Section(VisibleType.CONDITIONAL, List.of(question2.getId()), null, "선택한 순간들을 바탕으로 리뷰를 작성해볼게요.", 1)
-        );
-        Template template = templateRepository.save(new Template(List.of(section1.getId(), section2.getId())));
-
-        ReviewGroup reviewGroup = reviewGroupRepository.save(
-                new ReviewGroup("커비", "리뷰미", "reviewRequestCode", groupAccessCode)
-        );
-        CheckboxAnswer categoryAnswer = new CheckboxAnswer(question1.getId(), List.of(categoryOption1.getId()));
-        CheckboxAnswer keywordAnswer = new CheckboxAnswer(question2.getId(), List.of(keywordOption.getId()));
-        review2Repository.save(
-                new Review2(template.getId(), reviewGroup.getId(), List.of(), List.of(categoryAnswer, keywordAnswer))
-        );
-
-        // when
-        ReceivedReviewsResponse2 response = reviewService.findReceivedReviews2(groupAccessCode);
-
-        // then
-        List<String> categoryContents = optionItemRepository.findAllByOptionType(OptionType.CATEGORY)
-                .stream()
-                .map(OptionItem::getContent)
-                .toList();
-
-        assertThat(response.reviews())
-                .map(review -> review.categories()
-                        .stream()
-                        .map(ReceivedReviewCategoryResponse::content)
-                        .toList())
-                .allSatisfy(content -> assertThat(categoryContents).containsAll(content));
     }
 }


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #328 

---

### 🚀 어떤 기능을 구현했나요 ?
- 리뷰 목록 카테고리 조회 시 네이티브 쿼리를 사용하도록 변경합니다.

### 🔥 어떻게 해결했나요 ?
- 리뷰 목록 카테고리 조회 시 네이티브 쿼리를 사용하여 쿼리를 한 번만 나가게 했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 네이티브 쿼리가 잘 쓰여졌는지 봐주쎄여~

### 📚 참고 자료, 할 말
- 저번에 미뤄둔 네이티브 쿼리 리팩토링 이제 합니당..ㅎㅎ
- 템플릿 생성에 대해서 fixture가 있어야겠네요!