### PR TITLE
[FE] refactor: 사용자 테스트에서 피드백 받은 사소한 버그 수정 

### DIFF
--- a/frontend/src/components/AnswerListRecheckModal/index.tsx
+++ b/frontend/src/components/AnswerListRecheckModal/index.tsx
@@ -1,5 +1,6 @@
 import { Fragment } from 'react';
 
+import { MultilineTextViewer } from '@/components';
 import { ReviewWritingAnswer, ReviewWritingCardSection } from '@/types';
 
 import CheckboxItem from '../common/CheckboxItem';
@@ -54,7 +55,9 @@ const AnswerListRecheckModal = ({ questionSectionList, answerMap, closeModal }: 
                           ))}
                         </div>
                       )}
-                      <div>{question.questionType === 'TEXT' && <div>{findTextAnswer(question.questionId)}</div>}</div>
+                      {question.questionType === 'TEXT' && (
+                        <MultilineTextViewer text={findTextAnswer(question.questionId) || ''} />
+                      )}
                     </S.ContentContainer>
                   </Fragment>
                 ))}

--- a/frontend/src/components/common/LongReviewItem/index.tsx
+++ b/frontend/src/components/common/LongReviewItem/index.tsx
@@ -8,6 +8,7 @@ interface LongReviewItemProps extends TextareaHTMLAttributes<HTMLTextAreaElement
   minLength: number;
   maxLength: number;
   initialValue?: string;
+  required: boolean;
   handleTextareaChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
 }
 
@@ -15,6 +16,7 @@ const LongReviewItem = ({
   minLength,
   maxLength,
   initialValue = '',
+  required,
   handleTextareaChange,
   style,
   ...rest
@@ -23,6 +25,7 @@ const LongReviewItem = ({
     minLength,
     maxLength,
     initialValue,
+    required,
   });
 
   const handleWriteTextarea = (e: React.ChangeEvent<HTMLTextAreaElement>) => {

--- a/frontend/src/components/common/LongReviewItem/index.tsx
+++ b/frontend/src/components/common/LongReviewItem/index.tsx
@@ -41,6 +41,7 @@ const LongReviewItem = ({
         $style={style}
         onChange={handleWriteTextarea}
         onBlur={handleBlur}
+        placeholder={`최대 ${maxLength}자까지 입력 가능해요.`}
         {...rest}
       />
       <S.TextareaInfoContainer>

--- a/frontend/src/components/common/LongReviewItem/index.tsx
+++ b/frontend/src/components/common/LongReviewItem/index.tsx
@@ -41,7 +41,7 @@ const LongReviewItem = ({
         $style={style}
         onChange={handleWriteTextarea}
         onBlur={handleBlur}
-        placeholder={`최대 ${maxLength}자까지 입력 가능해요.`}
+        placeholder={`최소 ${minLength}자 이상, 최대 ${maxLength}자까지 입력 가능해요.`}
         {...rest}
       />
       <S.TextareaInfoContainer>

--- a/frontend/src/components/common/MultilineTextViewer/index.tsx
+++ b/frontend/src/components/common/MultilineTextViewer/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as S from './styles';
 
 interface MultilineTextViewerProps {
   text: string;
@@ -8,10 +8,10 @@ const MultilineTextViewer = ({ text }: MultilineTextViewerProps) => {
   return (
     <>
       {text.split('\n').map((line, index) => (
-        <React.Fragment key={index}>
+        <S.MultilineText key={index}>
           {line}
           <br />
-        </React.Fragment>
+        </S.MultilineText>
       ))}
     </>
   );

--- a/frontend/src/components/common/MultilineTextViewer/styles.ts
+++ b/frontend/src/components/common/MultilineTextViewer/styles.ts
@@ -1,0 +1,5 @@
+import styled from '@emotion/styled';
+
+export const MultilineText = styled.div`
+  word-wrap: break-word;
+`;

--- a/frontend/src/components/layouts/Topbar/components/Logo/index.tsx
+++ b/frontend/src/components/layouts/Topbar/components/Logo/index.tsx
@@ -1,12 +1,20 @@
 // import LogoIcon from '../../../../../assets/logo.svg';
 
+import { useNavigate } from 'react-router';
+
 import * as S from './styles';
 
 const Logo = () => {
+  const navigate = useNavigate();
+
+  const handleLogoClick = () => {
+    navigate('/');
+  };
+
   return (
     <S.Logo>
       {/* <img src={LogoIcon} alt="로고 아이콘" /> */}
-      <S.LogoText>
+      <S.LogoText onClick={handleLogoClick}>
         <span>REVIEW</span>
         <span>ME</span>
       </S.LogoText>

--- a/frontend/src/components/layouts/Topbar/components/Logo/styles.ts
+++ b/frontend/src/components/layouts/Topbar/components/Logo/styles.ts
@@ -12,6 +12,7 @@ export const Logo = styled.div`
 `;
 
 export const LogoText = styled.div`
+  cursor: pointer;
   line-height: 8rem;
   text-align: center;
 

--- a/frontend/src/components/layouts/Topbar/index.tsx
+++ b/frontend/src/components/layouts/Topbar/index.tsx
@@ -14,7 +14,7 @@ const Topbar = ({ openSidebar }: TopbarProps) => {
   return (
     <S.Layout>
       <S.Container>
-        <SidebarOpenButton openSidebar={openSidebar} />
+        {/* <SidebarOpenButton openSidebar={openSidebar} /> */}
         <Logo />
       </S.Container>
       <S.Container>

--- a/frontend/src/hooks/useLongReviewItem.ts
+++ b/frontend/src/hooks/useLongReviewItem.ts
@@ -4,9 +4,10 @@ interface UseLongReviewItemProps {
   minLength: number;
   maxLength: number;
   initialValue?: string;
+  required: boolean;
 }
 
-const useLongReviewItem = ({ minLength, maxLength, initialValue }: UseLongReviewItemProps) => {
+const useLongReviewItem = ({ minLength, maxLength, initialValue, required }: UseLongReviewItemProps) => {
   const [value, setValue] = useState(initialValue);
   const [isError, setIsError] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
@@ -19,7 +20,10 @@ const useLongReviewItem = ({ minLength, maxLength, initialValue }: UseLongReview
 
   const handleBlur = (e: React.FocusEvent<HTMLTextAreaElement>) => {
     const value = e.target.value;
-    if (value.length < minLength) {
+    const errorOnRequired = required && value.length < minLength;
+    const errorOnNotRequired = !required && value.length > 0 && value.length < minLength;
+
+    if (errorOnRequired || errorOnNotRequired) {
       setIsError(true);
       setErrorMessage(`최소 ${minLength}자 이상 작성해 주세요.`);
     } else {

--- a/frontend/src/pages/ReviewWritingCardFromPage/QnABox/index.tsx
+++ b/frontend/src/pages/ReviewWritingCardFromPage/QnABox/index.tsx
@@ -40,6 +40,7 @@ const QnABox = ({ question, updateAnswerMap, updateAnswerValidationMap }: QnABox
       <S.QuestionTitle>
         {question.content}
         {question.required && <S.QuestionRequiredMark>*</S.QuestionRequiredMark>}
+        {question.questionType === 'TEXT' && ` (최소 ${TEXT_ANSWER_LENGTH.min}자 이상)`}
         <S.MultipleGuideline>{multipleGuideline ?? ''}</S.MultipleGuideline>
       </S.QuestionTitle>
       {question.guideline && <S.QuestionGuideline>{question.guideline}</S.QuestionGuideline>}

--- a/frontend/src/pages/ReviewWritingCardFromPage/QnABox/index.tsx
+++ b/frontend/src/pages/ReviewWritingCardFromPage/QnABox/index.tsx
@@ -28,7 +28,9 @@ const QnABox = ({ question, updateAnswerMap, updateAnswerValidationMap }: QnABox
     if (!optionGroup) return;
 
     const { minCount, maxCount } = optionGroup;
-    if (!maxCount) return `(최소 ${minCount}개 이상)`;
+
+    const isAllSelectAvailable = maxCount === optionGroup.options.length;
+    if (!maxCount || isAllSelectAvailable) return `(최소 ${minCount}개 이상)`;
 
     return `(${minCount}개 ~ ${maxCount}개)`;
   })();
@@ -67,6 +69,7 @@ const QnABox = ({ question, updateAnswerMap, updateAnswerValidationMap }: QnABox
           minLength={TEXT_ANSWER_LENGTH.min}
           maxLength={TEXT_ANSWER_LENGTH.max}
           handleTextareaChange={handleTextAnswerChange}
+          required={question.required}
         />
       )}
     </S.QnASection>

--- a/frontend/src/pages/ReviewWritingCardFromPage/QnABox/index.tsx
+++ b/frontend/src/pages/ReviewWritingCardFromPage/QnABox/index.tsx
@@ -54,7 +54,7 @@ const QnABox = ({ question, updateAnswerMap, updateAnswerValidationMap }: QnABox
               isChecked={isSelectedCheckbox(option.optionId)}
               isDisabled={false}
               label={option.content}
-              onChange={handleCheckboxChange}
+              handleChange={handleCheckboxChange}
             />
           ))}
           <S.LimitGuideMessage>

--- a/frontend/src/pages/ReviewWritingCardFromPage/QnABox/index.tsx
+++ b/frontend/src/pages/ReviewWritingCardFromPage/QnABox/index.tsx
@@ -54,7 +54,7 @@ const QnABox = ({ question, updateAnswerMap, updateAnswerValidationMap }: QnABox
               isChecked={isSelectedCheckbox(option.optionId)}
               isDisabled={false}
               label={option.content}
-              handleChange={handleCheckboxChange}
+              onChange={handleCheckboxChange}
             />
           ))}
           <S.LimitGuideMessage>

--- a/frontend/src/styles/reset.ts
+++ b/frontend/src/styles/reset.ts
@@ -103,6 +103,7 @@ const reset = () => css`
 
   button {
     cursor: pointer;
+    user-select: none;
 
     box-sizing: border-box;
     margin: 0;


### PR DESCRIPTION
- resolves #323 

---

### 🚀 어떤 기능을 구현했나요 ?
- 객관식 질문에서 전부 선택이 가능한 경우(최대 선택 가능 개수가 전체 options의 개수와 일치하는 경우)에 `최소 ~개 이상` 문구를 띄우도록 수정
- 버튼에서 드래그가 불가능하도록 수정
- 필수가 아닌 서술형 문항에서 아무것도 입력하지 않았지만 focus한 이후에 에러 UI가 보여지는 문제 수정
- 서술형 문항의 최대/최소 글자수를 placeholder와 안내 문구로 작성
- 사용하지 않는 햄버거 아이콘 숨김 처리
- 로고 클릭 시 랜딩 페이지로 이동하도록 수정
- 작성한 리뷰 확인 모달에서 text wrap과 개행이 안 되던 문제 수정

### 🔥 어떻게 해결했나요 ?
- 디자인 요소가 포함되어 의논이 필요한 부분을 제외하고 피드백 받았던 안내 문구 누락이나 사소한 UI 오류를 수정했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
