### PR TITLE
[BE] infra: cd 스크립트 dev와 prod 분리

### DIFF
--- a/.github/workflows/backend-dev-cd.yml
+++ b/.github/workflows/backend-dev-cd.yml
@@ -1,0 +1,98 @@
+name: CD using Github self-hosted runner
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - develop
+    paths:
+      - 'backend/**'
+
+env:
+  ARTIFACT_NAME: review-me-dev
+  ARTIFACT_DIRECTORY: ./backend/build/libs
+  APPLICATION_DIRECTORY: ~/review-me-app
+
+jobs:
+  build:
+    name: Build Jar file and upload artifact
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout to current repository
+        uses: actions/checkout@v4
+
+      - name: Setup JDK Corretto using cached gradle dependencies
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: 17
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: 8.8
+
+      - name: Build and test with gradle
+        run: |
+          cd ./backend
+          ./gradlew clean bootJar
+
+      - name: Rename artifact file
+        run: |
+          mv ${{ env.ARTIFACT_DIRECTORY }}/*.jar ${{ env.ARTIFACT_DIRECTORY }}/${{ env.ARTIFACT_NAME }}.jar
+
+      - name: Upload created artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.ARTIFACT_DIRECTORY }}/${{ env.ARTIFACT_NAME }}.jar
+
+  deploy:
+    name: Deploy via self-hosted runner
+    needs: build
+    runs-on: [self-hosted, dev]
+
+    steps:
+      - name: Checkout to secret repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ secrets.PRIVATE_REPOSITORY_URL }}
+          token: ${{ secrets.PRIVATE_REPOSITORY_TOKEN }}
+
+      - name: Download uploaded artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+
+      - name: Copy application related files to other directory
+        run: |
+          sudo mv * ${{ env.APPLICATION_DIRECTORY }}
+
+      - name: Find ${{ env.ARTIFACT_NAME }} process
+        run: |
+          echo "Checking processes..."
+          PID=$(pgrep -f ${{ env.ARTIFACT_NAME }}.jar -d " " || true)
+          if [ -n "$PID" ]; then
+            echo "Found processes: $PID"
+            echo "server_running=true" >> "$GITHUB_ENV"
+            echo "PID=$PID" >> "$GITHUB_ENV"
+          else
+            echo "Process not found!"
+            echo "server_running=false" >> "$GITHUB_ENV"
+          fi
+
+      - name: Stop server if available (gracefully)
+        if: env.server_running == 'true'
+        run: |
+          echo "Gracefully shutting down process ${{ env.PID }}"
+          for PID in ${{ env.PID }}; do
+            sudo kill -15 $PID | true
+            tail --pid=$PID -f /dev/null | true
+          done
+
+      - name: Start server
+        run: |
+          cd ${{ env.APPLICATION_DIRECTORY }}
+          sudo nohup java -jar ${{ env.ARTIFACT_NAME }}.jar --server.port=80 --spring.config.location=application-dev.yml &

--- a/.github/workflows/backend-dev-cd.yml
+++ b/.github/workflows/backend-dev-cd.yml
@@ -1,4 +1,4 @@
-name: CD using Github self-hosted runner
+name: [DEVELOP] CD using Github self-hosted runner
 
 on:
   workflow_dispatch:

--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -95,4 +95,4 @@ jobs:
       - name: Start server
         run: |
           cd ${{ env.APPLICATION_DIRECTORY }}
-          sudo nohup java -jar ${{ env.ARTIFACT_NAME }}.jar --server.port=80 --spring.config.location=application-dev.yml &
+          sudo nohup java -jar ${{ env.ARTIFACT_NAME }}.jar --server.port=80 --spring.config.location=application-prod.yml &

--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -5,12 +5,11 @@ on:
   push:
     branches:
       - main
-      - develop
     paths:
       - 'backend/**'
 
 env:
-  ARTIFACT_NAME: review-me-dev
+  ARTIFACT_NAME: review-me-prod
   ARTIFACT_DIRECTORY: ./backend/build/libs
   APPLICATION_DIRECTORY: ~/review-me-app
 
@@ -53,7 +52,7 @@ jobs:
   deploy:
     name: Deploy via self-hosted runner
     needs: build
-    runs-on: self-hosted
+    runs-on: [self-hosted, prod]
 
     steps:
       - name: Checkout to secret repository

--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -1,10 +1,10 @@
-name: CD using Github self-hosted runner
+name: [RELEASE] CD using Github self-hosted runner
 
 on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - release
     paths:
       - 'backend/**'
 


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #350 

---

### 🚀 어떤 기능을 구현했나요 ?
- 운영 서버와 개발 서버 배포 분리를 위해 CD 스크립트를 수정했습니다.

### 🔥 어떻게 해결했나요 ?
- 개발 서버와 운영 서버에 각각 github runner를 설치하고, CD 스크립트를 분리하였습니다.
- main 브랜치 pr > pord 서버 배포
- develop 브랜치 pr > dev 서버 배포

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 잘 돌아갈까용?

### 📚 참고 자료, 할 말
