### PR TITLE
[BE] fix: 쿼리 문법 수정

### DIFF
--- a/backend/src/main/java/reviewme/question/repository/OptionItemRepository.java
+++ b/backend/src/main/java/reviewme/question/repository/OptionItemRepository.java
@@ -20,23 +20,23 @@ public interface OptionItemRepository extends JpaRepository<OptionItem, Long> {
 
     @Query(value = """
             SELECT o.id FROM option_item o
-            LEFT JOIN checkbox_answer ca
             LEFT JOIN checkbox_answer_selected_option c
+            ON c.selected_option_id = o.id
+            LEFT JOIN checkbox_answer ca
             ON c.checkbox_answer_id = ca.id
             WHERE ca.review_id = :reviewId
-            AND c.selected_option_id = o.id
             """, nativeQuery = true)
     Set<Long> findSelectedOptionItemIdsByReviewId(long reviewId);
 
     @Query(value = """
             SELECT o.* FROM option_item o
-            LEFT JOIN checkbox_answer ca
             LEFT JOIN checkbox_answer_selected_option c
+            ON c.selected_option_id = o.id
+            LEFT JOIN checkbox_answer ca
             ON c.checkbox_answer_id = ca.id
             WHERE ca.review_id = :reviewId
             AND ca.question_id = :questionId
-            AND c.selected_option_id = o.id
-            ORDER BY o.position ASC
+            ORDER BY o.position
             """, nativeQuery = true)
     List<OptionItem> findSelectedOptionItemsByReviewIdAndQuestionId(long reviewId, long questionId);
 

--- a/backend/src/main/java/reviewme/question/repository/OptionItemRepository.java
+++ b/backend/src/main/java/reviewme/question/repository/OptionItemRepository.java
@@ -36,7 +36,7 @@ public interface OptionItemRepository extends JpaRepository<OptionItem, Long> {
             ON c.checkbox_answer_id = ca.id
             WHERE ca.review_id = :reviewId
             AND ca.question_id = :questionId
-            ORDER BY o.position
+            ORDER BY o.position ASC
             """, nativeQuery = true)
     List<OptionItem> findSelectedOptionItemsByReviewIdAndQuestionId(long reviewId, long questionId);
 


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #356 

---

### 🚀 어떤 기능을 구현했나요 ?
- MySQL이 붙은 뒤로 동작하지 않던 쿼리문을 수정했습니다.

### 🔥 어떻게 해결했나요 ?
- 쿼리를 조금 만졌습니다. 이전 쿼리가 지금 봐도 이상~하긴 했네요

AS-IS
```sql
SELECT o.id FROM option_item o
LEFT JOIN checkbox_answer ca
LEFT JOIN checkbox_answer_selected_option c
ON c.checkbox_answer_id = ca.id
WHERE ca.review_id = :reviewId
AND c.selected_option_id = o.id
```

TO-BE
```sql
SELECT o.id FROM option_item o
LEFT JOIN checkbox_answer_selected_option c
ON c.selected_option_id = o.id
LEFT JOIN checkbox_answer ca
ON c.checkbox_answer_id = ca.id
WHERE ca.review_id = :reviewId
```

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 같은 부분 다른 sql도 고쳤습니다.

### 📚 참고 자료, 할 말
![image](https://github.com/user-attachments/assets/8824ae4c-40ae-4c70-8758-2bcfdc634d45)

SQL은 LEFT JOIN + ON이 필수인 듯하네요 😢 