### PR TITLE
[FE] fix: Pretendard 폰트가 정상적으로 적용되도록 나눔고딕 제거

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -21,7 +21,6 @@
       href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,100..900;1,100..900&display=swap"
       rel="stylesheet"
     />
-    <link href="https://hangeul.pstatic.net/hangeul_static/css/nanum-gothic.css" rel="stylesheet" />
     <link
       rel="stylesheet"
       type="text/css"

--- a/frontend/src/styles/globalStyles.ts
+++ b/frontend/src/styles/globalStyles.ts
@@ -10,7 +10,7 @@ const globalStyles = css`
   }
 
   body {
-    font-family: 'Pretendard-Regular', 'NanumGothic', 'Noto Sans', sans-serif;
+    font-family: 'Pretendard-Regular', 'Noto Sans', sans-serif;
     margin: 0;
     padding: 0;
     box-sizing: border-box;


### PR DESCRIPTION
- resolves #359 

---

### 🚀 어떤 기능을 구현했나요 ?
Pretendard 폰트가 정상적으로 적용되도록 나눔고딕 폰트를 제거했습니다.


### 🔥 어떻게 해결했나요 ?

처음에는 제 로컬에서는 `Pretendard` 폰트가 제대로 적용되고 있었는데, 다른 팀원들의 로컬 환경에서는 `Pretendard` 폰트가 보이지 않고 나눔고딕이 적용되는 문제가 발생했습니다. 폰트 설정을 확인해 보니, `Pretendard`가 우선순위가 더 높게 설정되어 있었음에도 불구하고 나눔고딕이 적용되는 상황이었습니다. 이를 해결하기 위해, 나눔고딕 관련 코드를 모두 제거하여 `Pretendard` 폰트가 정상적으로 적용되도록 했습니다.


`frontend/public/index.html`에서 나눔고딕 관련 `<link>` 태그를 제거했습니다.
```html
    <link href="https://hangeul.pstatic.net/hangeul_static/css/nanum-gothic.css" rel="stylesheet" />
```
`frontend/src/styles/globalStyles.ts`에서 `font-family` 속성에서 나눔고딕을 제거했습니다.
```ts
    font-family: 'Pretendard-Regular', 'Noto Sans', sans-serif;
```

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- Pretendard 폰트 참말로 예쁘네요

### 📚 참고 자료, 할 말
- 공휴일에도 열일하는 리뷰미 여러분... 멋있어요!!!😘