### PR TITLE
[FE] fix: Checkbox의 onChange 이벤트 핸들러가 전달되지 않는 버그 수정

### DIFF
--- a/frontend/src/components/common/Checkbox/index.tsx
+++ b/frontend/src/components/common/Checkbox/index.tsx
@@ -19,11 +19,11 @@ export interface CheckboxProps extends CheckboxStyleProps {
   isDisabled?: boolean;
 }
 
-const Checkbox = ({ id, isChecked, handleChange, $style, $isReadonly = false, ...rest }: CheckboxProps) => {
+const Checkbox = ({ id, isChecked, handleChange, isDisabled, $style, $isReadonly = false, ...rest }: CheckboxProps) => {
   return (
     <S.CheckboxContainer $style={$style} $isReadonly={$isReadonly}>
       <S.CheckboxLabel>
-        <input id={id} checked={isChecked} type="checkbox" onChange={handleChange} {...rest} />
+        <input id={id} checked={isChecked} disabled={isDisabled} type="checkbox" onChange={handleChange} {...rest} />
         <img src={isChecked ? CheckedIcon : UncheckedIcon} alt="체크박스" />
       </S.CheckboxLabel>
     </S.CheckboxContainer>

--- a/frontend/src/components/common/Checkbox/index.tsx
+++ b/frontend/src/components/common/Checkbox/index.tsx
@@ -19,11 +19,11 @@ export interface CheckboxProps extends CheckboxStyleProps {
   isDisabled?: boolean;
 }
 
-const Checkbox = ({ id, isChecked, $style, $isReadonly = false, ...rest }: CheckboxProps) => {
+const Checkbox = ({ id, isChecked, handleChange, $style, $isReadonly = false, ...rest }: CheckboxProps) => {
   return (
     <S.CheckboxContainer $style={$style} $isReadonly={$isReadonly}>
       <S.CheckboxLabel>
-        <input id={id} checked={isChecked} type="checkbox" {...rest} />
+        <input id={id} checked={isChecked} type="checkbox" onChange={handleChange} {...rest} />
         <img src={isChecked ? CheckedIcon : UncheckedIcon} alt="체크박스" />
       </S.CheckboxLabel>
     </S.CheckboxContainer>


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #366 

---

### 🚀 어떤 기능을 구현했나요 ?
- 핸들러 이름을 `onChange`에서 `handleChange`로 변경하면서 `rest` props를 통해 핸들러가 전달되지 않던 문제를 해결했습니다.

### 🔥 어떻게 해결했나요 ?
- `input`에 명시적으로 handleChange를 전달했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
- `rest`에 대한 이해가 부족했습니다. 핸들러를 `rest`로 전달하고 있으니까 핸들러 이름이 변경되어도 괜찮을 거라고 생각했는데 기본 속성이 아니라 명시적으로 전달해줘야 했습니다.
- 혼란을 드려서 죄송합니다 ㅠㅠㅠㅠㅠ