### PR TITLE
[FE] fix: Pretendard 오류 수정

### DIFF
--- a/frontend/src/styles/globalStyles.ts
+++ b/frontend/src/styles/globalStyles.ts
@@ -10,7 +10,7 @@ const globalStyles = css`
   }
 
   body {
-    font-family: 'Pretendard-Regular', 'Noto Sans', sans-serif;
+    font-family: 'Pretendard', 'Noto Sans', sans-serif;
     margin: 0;
     padding: 0;
     box-sizing: border-box;


### PR DESCRIPTION


- resolves #385

---

### 🚀 어떤 기능을 구현했나요 ?
#### 오류 설명
현재 Pretendard 의 font family이 잘못 설정되어서 Pretendard가 아닌 Noto sans 가 적용되고 있어요.

### 🔥 어떻게 해결했나요 ?
- Pretendard 의 font family 설정을 올바르게 변경했어요.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 피그마에 있는 Pretendard 와 같은 폰트가 적용되었는지 확인해주세요.

### 📚 참고 자료, 할 말
- 폰트 cdn을 들어가서 보자
-  마위네 버그 잡아주다가 우리 코드 버그도 발견함-> 결론: 착하게 살면 복이 온다.😊