### PR TITLE
[BE] refactor: 리뷰 상세 조회 시, 답변이 있는 리뷰만 보여주도록 변경

### DIFF
--- a/backend/src/main/java/reviewme/review/domain/CheckboxAnswer.java
+++ b/backend/src/main/java/reviewme/review/domain/CheckboxAnswer.java
@@ -27,9 +27,6 @@ public class CheckboxAnswer {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "review_id", nullable = false, insertable = false, updatable = false)
-    private long reviewId;
-
     @Column(name = "question_id", nullable = false)
     private long questionId;
 

--- a/backend/src/main/java/reviewme/review/domain/CheckboxAnswer.java
+++ b/backend/src/main/java/reviewme/review/domain/CheckboxAnswer.java
@@ -27,6 +27,9 @@ public class CheckboxAnswer {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "review_id", nullable = false, insertable = false, updatable = false)
+    private long reviewId;
+
     @Column(name = "question_id", nullable = false)
     private long questionId;
 

--- a/backend/src/main/java/reviewme/review/domain/CheckboxAnswers.java
+++ b/backend/src/main/java/reviewme/review/domain/CheckboxAnswers.java
@@ -1,0 +1,28 @@
+package reviewme.review.domain;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import reviewme.review.domain.exception.MissingCheckboxAnswerForQuestionException;
+
+public class CheckboxAnswers {
+
+    private final Map<Long, CheckboxAnswer> checkboxAnswers;
+
+    public CheckboxAnswers(List<CheckboxAnswer> checkboxAnswers) {
+        this.checkboxAnswers = checkboxAnswers.stream()
+                .collect(Collectors.toMap(CheckboxAnswer::getQuestionId, Function.identity()));
+    }
+
+    public CheckboxAnswer getAnswerByQuestionId(long questionId) {
+        if (!checkboxAnswers.containsKey(questionId)) {
+            throw new MissingCheckboxAnswerForQuestionException(questionId);
+        }
+        return checkboxAnswers.get(questionId);
+    }
+
+    public boolean hasAnswerByQuestionId(long questionId) {
+        return checkboxAnswers.containsKey(questionId);
+    }
+}

--- a/backend/src/main/java/reviewme/review/domain/TextAnswers.java
+++ b/backend/src/main/java/reviewme/review/domain/TextAnswers.java
@@ -23,4 +23,8 @@ public class TextAnswers {
         }
         return textAnswers.get(questionId);
     }
+
+    public boolean hasAnswerByQuestionId(long questionId) {
+        return textAnswers.containsKey(questionId);
+    }
 }

--- a/backend/src/main/java/reviewme/review/domain/exception/MissingCheckboxAnswerForQuestionException.java
+++ b/backend/src/main/java/reviewme/review/domain/exception/MissingCheckboxAnswerForQuestionException.java
@@ -7,7 +7,7 @@ import reviewme.global.exception.NotFoundException;
 public class MissingCheckboxAnswerForQuestionException extends NotFoundException {
 
     public MissingCheckboxAnswerForQuestionException(long questionId) {
-        super("질문에 해당하는 선택형 답변을 찾지 못했어요.");
-        log.warn("Checkbox Answer not found for questionId: {}", questionId);
+        super("서버 내부에서 문제가 발생했어요. 서버에 문의해주세요.");
+        log.error("Checkbox Answer not found for questionId: {}", questionId);
     }
 }

--- a/backend/src/main/java/reviewme/review/domain/exception/MissingCheckboxAnswerForQuestionException.java
+++ b/backend/src/main/java/reviewme/review/domain/exception/MissingCheckboxAnswerForQuestionException.java
@@ -1,0 +1,13 @@
+package reviewme.review.domain.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import reviewme.global.exception.NotFoundException;
+
+@Slf4j
+public class MissingCheckboxAnswerForQuestionException extends NotFoundException {
+
+    public MissingCheckboxAnswerForQuestionException(long questionId) {
+        super("질문에 해당하는 선택형 답변을 찾지 못했어요.");
+        log.warn("Checkbox Answer not found for questionId: {}", questionId);
+    }
+}

--- a/backend/src/main/java/reviewme/review/domain/exception/MissingTextAnswerForQuestionException.java
+++ b/backend/src/main/java/reviewme/review/domain/exception/MissingTextAnswerForQuestionException.java
@@ -7,7 +7,7 @@ import reviewme.global.exception.NotFoundException;
 public class MissingTextAnswerForQuestionException extends NotFoundException {
 
     public MissingTextAnswerForQuestionException(long questionId) {
-        super("질문에 해당하는 서술형 답변을 찾지 못했어요.");
-        log.warn("Text Answer not found for questionId: {}", questionId);
+        super("서버 내부에서 문제가 발생했어요. 서버에 문의해주세요.");
+        log.error("Text Answer not found for questionId: {}", questionId);
     }
 }

--- a/backend/src/main/java/reviewme/review/service/ReviewDetailLookupService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewDetailLookupService.java
@@ -71,9 +71,9 @@ public class ReviewDetailLookupService {
         for (Question question : questionRepository.findAllBySectionId(section.getId())) {
             if (question.isSelectable()) {
                 addCheckboxQuestionResponse(review, reviewGroup, question, questionResponses);
-                continue;
+            } else {
+                addTextQuestionResponse(review, reviewGroup, question, questionResponses);
             }
-            addTextQuestionResponse(review, reviewGroup, question, questionResponses);
         }
 
         if (!questionResponses.isEmpty()) {

--- a/backend/src/main/java/reviewme/review/service/ReviewDetailLookupService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewDetailLookupService.java
@@ -10,12 +10,13 @@ import reviewme.question.domain.OptionGroup;
 import reviewme.question.domain.Question;
 import reviewme.question.repository.OptionGroupRepository;
 import reviewme.question.repository.OptionItemRepository;
+import reviewme.question.repository.QuestionRepository;
+import reviewme.review.domain.CheckboxAnswers;
 import reviewme.review.domain.Review;
 import reviewme.review.domain.TextAnswer;
 import reviewme.review.domain.TextAnswers;
 import reviewme.review.domain.exception.InvalidReviewAccessByReviewGroupException;
 import reviewme.review.domain.exception.ReviewGroupNotFoundByGroupAccessCodeException;
-import reviewme.question.repository.QuestionRepository;
 import reviewme.review.repository.ReviewRepository;
 import reviewme.review.service.dto.response.detail.OptionGroupAnswerResponse;
 import reviewme.review.service.dto.response.detail.OptionItemAnswerResponse;
@@ -47,12 +48,12 @@ public class ReviewDetailLookupService {
                 .orElseThrow(() -> new InvalidReviewAccessByReviewGroupException(reviewId, reviewGroup.getId()));
         long templateId = review.getTemplateId();
 
-        Set<Long> selectedOptionItemIds = optionItemRepository.findSelectedOptionItemIdsByReviewId(reviewId);
-        List<SectionAnswerResponse> sectionResponses = sectionRepository.findAllByTemplateId(templateId)
-                .stream()
-                .filter(section -> section.isVisibleBySelectedOptionIds(selectedOptionItemIds))
-                .map(section -> getSectionAnswerResponse(review, section, reviewGroup))
-                .toList();
+        List<Section> sections = sectionRepository.findAllByTemplateId(templateId);
+        List<SectionAnswerResponse> sectionResponses = new ArrayList<>();
+
+        for (Section section : sections) {
+            addSectionResponse(review, reviewGroup, section, sectionResponses);
+        }
 
         return new TemplateAnswerResponse(
                 templateId,
@@ -63,36 +64,44 @@ public class ReviewDetailLookupService {
         );
     }
 
-    private SectionAnswerResponse getSectionAnswerResponse(Review review, Section section, ReviewGroup reviewGroup) {
-        TextAnswers textAnswers = new TextAnswers(review.getTextAnswers());
+    private void addSectionResponse(Review review, ReviewGroup reviewGroup,
+                                    Section section, List<SectionAnswerResponse> sectionResponses) {
         ArrayList<QuestionAnswerResponse> questionResponses = new ArrayList<>();
 
         for (Question question : questionRepository.findAllBySectionId(section.getId())) {
             if (question.isSelectable()) {
-                questionResponses.add(getCheckboxAnswerResponse(review, question, reviewGroup));
+                addCheckboxQuestionResponse(review, reviewGroup, question, questionResponses);
                 continue;
             }
-            questionResponses.add(getTextAnswerResponse(textAnswers, question, reviewGroup));
+            addTextQuestionResponse(review, reviewGroup, question, questionResponses);
         }
 
-        return new SectionAnswerResponse(
-                section.getId(),
-                section.convertHeader("{revieweeName}", reviewGroup.getReviewee()),
-                questionResponses
-        );
+        if (!questionResponses.isEmpty()) {
+            sectionResponses.add(new SectionAnswerResponse(
+                    section.getId(),
+                    section.getHeader(),
+                    questionResponses
+            ));
+        }
     }
 
-    private QuestionAnswerResponse getTextAnswerResponse(TextAnswers textAnswers, Question question,
-                                                         ReviewGroup reviewGroup) {
-        TextAnswer textAnswer = textAnswers.getAnswerByQuestionId(question.getId());
-        return new QuestionAnswerResponse(
-                question.getId(),
-                question.isRequired(),
-                question.getQuestionType(),
-                question.convertContent("{revieweeName}", reviewGroup.getReviewee()),
-                null,
-                textAnswer.getContent()
-        );
+    private void addCheckboxQuestionResponse(Review review, ReviewGroup reviewGroup,
+                                             Question question, ArrayList<QuestionAnswerResponse> questionResponses) {
+        CheckboxAnswers checkboxAnswers = new CheckboxAnswers(review.getCheckboxAnswers());
+
+        if (checkboxAnswers.hasAnswerByQuestionId(question.getId())) {
+            questionResponses.add(getCheckboxAnswerResponse(review, question, reviewGroup));
+        }
+
+    }
+
+    private void addTextQuestionResponse(Review review, ReviewGroup reviewGroup,
+                                         Question question, ArrayList<QuestionAnswerResponse> questionResponses) {
+        TextAnswers textAnswers = new TextAnswers(review.getTextAnswers());
+
+        if (textAnswers.hasAnswerByQuestionId(question.getId())) {
+            questionResponses.add(getTextAnswerResponse(textAnswers, question, reviewGroup));
+        }
     }
 
     private QuestionAnswerResponse getCheckboxAnswerResponse(Review review, Question question,
@@ -122,6 +131,19 @@ public class ReviewDetailLookupService {
                 question.convertContent("{revieweeName}", reviewGroup.getReviewee()),
                 optionGroupAnswerResponse,
                 null
+        );
+    }
+
+    private QuestionAnswerResponse getTextAnswerResponse(TextAnswers textAnswers, Question question,
+                                                         ReviewGroup reviewGroup) {
+        TextAnswer textAnswer = textAnswers.getAnswerByQuestionId(question.getId());
+        return new QuestionAnswerResponse(
+                question.getId(),
+                question.isRequired(),
+                question.getQuestionType(),
+                question.convertContent("{revieweeName}", reviewGroup.getReviewee()),
+                null,
+                textAnswer.getContent()
         );
     }
 }

--- a/backend/src/test/java/reviewme/review/domain/CheckboxAnswersTest.java
+++ b/backend/src/test/java/reviewme/review/domain/CheckboxAnswersTest.java
@@ -21,7 +21,7 @@ class CheckboxAnswersTest {
     }
 
     @Test
-    void 질문_ID로_서술형_답변을_반환한다() {
+    void 질문_ID로_선택형_답변을_반환한다() {
         // given
         CheckboxAnswers checkboxAnswers = new CheckboxAnswers(List.of(new CheckboxAnswer(1, List.of(1L))));
 

--- a/backend/src/test/java/reviewme/review/domain/CheckboxAnswersTest.java
+++ b/backend/src/test/java/reviewme/review/domain/CheckboxAnswersTest.java
@@ -1,0 +1,52 @@
+package reviewme.review.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import reviewme.review.domain.exception.MissingCheckboxAnswerForQuestionException;
+
+class CheckboxAnswersTest {
+
+    @Test
+    void 질문에_해당하는_답변이_없으면_예외를_발생한다() {
+        // given
+        CheckboxAnswers checkboxAnswers = new CheckboxAnswers(List.of(new CheckboxAnswer(1, List.of(1L))));
+
+        // when, then
+        assertThatThrownBy(() -> checkboxAnswers.getAnswerByQuestionId(2))
+                .isInstanceOf(MissingCheckboxAnswerForQuestionException.class);
+    }
+
+    @Test
+    void 질문_ID로_서술형_답변을_반환한다() {
+        // given
+        CheckboxAnswers checkboxAnswers = new CheckboxAnswers(List.of(new CheckboxAnswer(1, List.of(1L))));
+
+        // when
+        CheckboxAnswer actual = checkboxAnswers.getAnswerByQuestionId(1);
+
+        // then
+        assertThat(actual.getSelectedOptionIds())
+                .extracting(CheckBoxAnswerSelectedOption::getSelectedOptionId)
+                .containsExactly(1L);
+    }
+
+    @Test
+    void 질문_ID에_해당하는_답변이_있는지_확인한다() {
+        // given
+        CheckboxAnswers checkboxAnswers = new CheckboxAnswers(List.of(new CheckboxAnswer(1, List.of(1L))));
+
+        // when
+        boolean actual1 = checkboxAnswers.hasAnswerByQuestionId(1);
+        boolean actual2 = checkboxAnswers.hasAnswerByQuestionId(2);
+
+        // then
+        assertAll(
+                () -> assertThat(actual1).isTrue(),
+                () -> assertThat(actual2).isFalse()
+        );
+    }
+}

--- a/backend/src/test/java/reviewme/review/domain/TextAnswersTest.java
+++ b/backend/src/test/java/reviewme/review/domain/TextAnswersTest.java
@@ -2,6 +2,7 @@ package reviewme.review.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -29,5 +30,21 @@ class TextAnswersTest {
 
         // then
         assertThat(actual.getContent()).isEqualTo("답변");
+    }
+
+    @Test
+    void 질문_ID에_해당하는_답변이_있는지_확인한다() {
+        // given
+        TextAnswers textAnswers = new TextAnswers(List.of(new TextAnswer(1, "답변")));
+
+        // when
+        boolean actual1 = textAnswers.hasAnswerByQuestionId(1);
+        boolean actual2 = textAnswers.hasAnswerByQuestionId(2);
+
+        // then
+        assertAll(
+                () -> assertThat(actual1).isTrue(),
+                () -> assertThat(actual2).isFalse()
+        );
     }
 }


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #335

---

### 🚀 어떤 기능을 구현했나요 ?
- 위 관련 이슈 내용에 따라 선택형 질문의 경우 리뷰어가 작성하지 않을 경우 null이 반환되어 오류가 발생했습니다.
- 리뷰 상세 조회 시, 리뷰어가 답변한 리뷰로만 구성하여 보여줄 수 있도록 변경했습니다.

### 🔥 어떻게 해결했나요 ?
- 섹션의 visible과 질문의 required에 관계 없이, 리뷰어가 답변한 리뷰로만 템플릿을 구성하여 반환할 수 있도록 변경했습니다.
- 현재는 checkbox 질문은 모두 필수이지만, 추후 질문 유형에 관계없이 필수/선택이 들어올 수 있으므로 확장성을 고려하여 단순하게 '답변이 있는 질문' 으로만 구성하여 조회할 수 있도록 했습니다. 이 과정에서 불필요한 로직은 제거되었습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 구현된 내용이 괜찮은가?
- CheckboxAnswer에 reviewId 필드가 사용되지 않는 것 같아 제거했습니다. 필요한 경우라면 말씀해주세요~

### 📚 참고 자료, 할 말
- !!