### PR TITLE
[FE] fix: Checkbox 컴포넌트의 잘못된 css 수정

### DIFF
--- a/frontend/src/components/common/Checkbox/styles.ts
+++ b/frontend/src/components/common/Checkbox/styles.ts
@@ -15,6 +15,9 @@ export const CheckboxContainer = styled.div<CheckboxStyleProps>`
     display: hidden;
     width: 0;
     height: 0;
+
+    clip: rect(1px 1px 1px 1px);
+    clip-path: inset(1px);
   }
 
   ${(props) => props.$isReadonly && 'pointer-events: none;'}

--- a/frontend/src/components/common/Checkbox/styles.ts
+++ b/frontend/src/components/common/Checkbox/styles.ts
@@ -12,7 +12,7 @@ export const CheckboxContainer = styled.div<CheckboxStyleProps>`
 
   input {
     position: absolute;
-
+    clip: rect(1px 1px 1px 1px);
     clip-path: inset(1px);
   }
 

--- a/frontend/src/components/common/Checkbox/styles.ts
+++ b/frontend/src/components/common/Checkbox/styles.ts
@@ -12,11 +12,7 @@ export const CheckboxContainer = styled.div<CheckboxStyleProps>`
 
   input {
     position: absolute;
-    display: hidden;
-    width: 0;
-    height: 0;
 
-    clip: rect(1px 1px 1px 1px);
     clip-path: inset(1px);
   }
 


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #378 

---

### 🚀 어떤 기능을 구현했나요 ?
- input에 `visibility: hidden`을 적용해야 했는데 `display: hidden` (존재하지 않는 속성)으로 해 버려서 1차 이슈가 발생했습니다. 아마 크롬에서는 같이 적용했던 `width:0`같은 속성들이 먹혀서 input이 보이지 않았는데 사파리 등에서는 적용되지 않았나 봅니다.



### 🔥 어떻게 해결했나요 ?
### 3줄 정리
1. `display: hidden`은 존재하지 않는다.
2. 웹 접근성을 위해 `visibility: hidden` 대신 `clip-path` 등을 이용해 우회적으로 요소를 보이지 않도록 만들자.
3. `clip-path`는 요소의 시각적인 영역을 자르기 위해 사용된다.
  - `inset()` 함수는 요소의 사각형 안쪽에서 잘라낼 거리를 정의함
  - `clip-path: inset(1px);`: 모든 방향에서 1픽셀씩 안쪽으로 잘라냄 -> 사실상 요소가 보이지 않게 됨
  - `clip: rect(1px 1px 1px 1px);` : 요소가 1px 크기만큼만 보여지도록 동서남북으로 자름 -> 역시 사실상 안 보이게 됨

### 상세한 글
- 미션에서, svg 이미지로 체크박스를 만들 때 "css로 hidden 처리를 하고~" 라는 코멘트를 받았습니다.
  - 이건 hidden 속성을 냅다 주라는 게 아니라 hidden에 준하는 효과를 주라는 의미로 말씀하신 것 같은데 hidden을 쓴다는 말으로 알아듣고 말았습니다.
  - 그래서 "아 hidden 속성을 써야 하는구나" 라고 1차 오해를 했습니다.
  
 - 하지만 `visibility: hidden`은 스크린 리더가 무시하기 때문에 접근성 측면에서 좋지 않았습니다.
    > Using a visibility value of hidden on an element will remove it from the accessibility tree. This will cause the element and all its descendant elements to no longer be announced by screen reading technology.
  - 그래서 이걸 어떻게 보완할까 싶었는데 마침 `aria-hidden`이라는 스크린 리더 전용 속성이 있어서 이를 적용하려고 했습니다. true면 스크린 리더가 읽지 않게 하고 false면 읽는다고 합니다.
  - 하지만 이 속성에 대해서는 말이 갈리기도 하고, `hidden`을 쓰지 않아도 되는 방법이 있어 보류했습니다. (GPT가 `hidden`이 적용되어 있으면  `aria-hidden=false`가 적용되지 않는다고 하는데 그에 대한 명확한 근거를 못 찾았습니다)
    - 또 W3C에서 이 속성이 불안정하게 작동한다는 말도 봐서 일단 뺐습니다. 나중에 더 자세하게 알아볼게요
  -  대신 `clip-path`와 `clip`을 이용해 요소를 보이지 않게 만들 수 있다고 해서 이 방법을 적용했습니다.
  
  - ~~`clip`은 deprecated된 속성으로, 주로 IE를 위해 사용한다고 합니다. 리뷰미에서는 IE를 지원하지 않으므로 모든 현대 브라우저가 지원하는 `clip-path`만 도입했습니다.~~ 
  - deprecated인 건 맞지만 `clip-path`에서 사용할 `inset`이 파폭, 사파리에서 미지원인 관계로 `clip`을 사용해야 합니다.
### 3줄 정리

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- ~~To 쑤쑤. 아까 기존 코드에 clip 적용된 버전으로 확인해달라고 했는데 이 PR에서는 쓸데없는 속성을 다 잘랐기 때문에 지금도 사파리에서 잘 동작하는지 봐주세요!!~~
- 오 `clip-path`는 지원하는데 `inset` 함수는 미지원하는 브라우저가 또 파폭과 사파리네요 🙃🙃🙃 이걸 떠나서 한 속성을 지원하면 그 값에 올 수 있는 것들도 전부 지원하는 줄 알았는데 둘은 별개였다는 걸 알게 됐습니다..^^ㅠ

### 📚 참고 자료, 할 말
- [aria-hidden](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden)
- [visibility](https://developer.mozilla.org/en-US/docs/Web/CSS/visibility#accessibility)
- [clip-path](https://developer.mozilla.org/en-US/docs/Web/CSS/clip-path)
- [inset](https://developer.mozilla.org/en-US/docs/Web/CSS/inset) 
- 말뜻을 잘 파악하자.
- 브라우저 체크를 주기적으로 해야겠다.