### PR TITLE
[FE] design: 리뷰 상세, 작성 완료 페이지 디자인 수정

### DIFF
--- a/frontend/src/pages/DetailedReviewPage/components/KeywordSection/index.tsx
+++ b/frontend/src/pages/DetailedReviewPage/components/KeywordSection/index.tsx
@@ -1,7 +1,5 @@
 import { Options } from '@/types';
 
-// import ReviewSectionHeader from '../ReviewSectionHeader';
-
 import * as S from './styles';
 
 interface KeywordSectionProps {
@@ -11,11 +9,11 @@ interface KeywordSectionProps {
 const KeywordSection = ({ options }: KeywordSectionProps) => {
   return (
     <S.KeywordSection>
-      <S.KeywordContainer>
+      <S.KeywordList>
         {options.map(({ optionId, content }) => (
-          <S.KeywordBox key={optionId}>{content}</S.KeywordBox>
+          <S.KeywordItem key={optionId}>{content}</S.KeywordItem>
         ))}
-      </S.KeywordContainer>
+      </S.KeywordList>
     </S.KeywordSection>
   );
 };

--- a/frontend/src/pages/DetailedReviewPage/components/KeywordSection/styles.ts
+++ b/frontend/src/pages/DetailedReviewPage/components/KeywordSection/styles.ts
@@ -5,27 +5,11 @@ export const KeywordSection = styled.section`
   margin-top: 2rem;
 `;
 
-export const KeywordContainer = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  row-gap: 2.5rem;
-  column-gap: 2.4rem;
+export const KeywordList = styled.ul`
+  list-style-type: disc;
+  padding-left: 2rem;
 `;
 
-export const KeywordBox = styled.div`
-  display: flex;
-  align-items: center;
-
-  box-sizing: border-box;
-  height: 5rem;
-  height: fit-content;
-  padding: 0.8rem 2.5rem;
-
-  font-size: ${({ theme }) => theme.fontSize.small};
-  line-height: 2.4rem;
-  text-align: center;
-
-  background-color: ${({ theme }) => theme.colors.lightPurple};
-  border: 0.1rem solid ${({ theme }) => theme.colors.primary};
-  border-radius: ${({ theme }) => theme.borderRadius.basic};
+export const KeywordItem = styled.li`
+  margin-bottom: 0.5rem;
 `;

--- a/frontend/src/pages/DetailedReviewPage/components/KeywordSection/styles.ts
+++ b/frontend/src/pages/DetailedReviewPage/components/KeywordSection/styles.ts
@@ -6,8 +6,8 @@ export const KeywordSection = styled.section`
 `;
 
 export const KeywordList = styled.ul`
-  list-style-type: disc;
   padding-left: 2rem;
+  list-style-type: disc;
 `;
 
 export const KeywordItem = styled.li`

--- a/frontend/src/pages/DetailedReviewPage/components/ReviewDescription/index.tsx
+++ b/frontend/src/pages/DetailedReviewPage/components/ReviewDescription/index.tsx
@@ -1,4 +1,4 @@
-import { ProjectImg, ReviewDate } from '@/components';
+import { ReviewDate } from '@/components';
 import { ProjectImgProps } from '@/components/common/ProjectImg';
 import { ReviewDateProps } from '@/components/common/ReviewDate';
 
@@ -6,7 +6,7 @@ import { ReviewDateProps } from '@/components/common/ReviewDate';
 
 import * as S from './styles';
 
-const PROJECT_IMAGE_SIZE = '6rem';
+// const PROJECT_IMAGE_SIZE = '6rem';
 const DATE_TITLE = '리뷰 작성일';
 
 interface ReviewDescriptionProps extends Omit<ProjectImgProps, '$size'>, Omit<ReviewDateProps, 'dateTitle'> {
@@ -16,7 +16,7 @@ interface ReviewDescriptionProps extends Omit<ProjectImgProps, '$size'>, Omit<Re
 }
 
 const ReviewDescription = ({
-  thumbnailUrl,
+  // thumbnailUrl,
   projectName,
   revieweeName,
   // isPublic,
@@ -26,7 +26,8 @@ const ReviewDescription = ({
   return (
     <S.Description>
       <S.DescriptionSide>
-        <ProjectImg thumbnailUrl={thumbnailUrl} projectName={projectName} $size={PROJECT_IMAGE_SIZE} />
+        {/* NOTE: 추후에 깃허브 로고 대신 다른 이미지로 대체될 수 있어서 일단 주석 처리 */}
+        {/* <ProjectImg thumbnailUrl={thumbnailUrl} projectName={projectName} $size={PROJECT_IMAGE_SIZE} /> */}
         <S.ProjectInfoContainer>
           <S.ProjectName>{projectName}</S.ProjectName>
           <S.RevieweeNameAndDateContainer>

--- a/frontend/src/pages/DetailedReviewPage/components/ReviewDescription/styles.ts
+++ b/frontend/src/pages/DetailedReviewPage/components/ReviewDescription/styles.ts
@@ -25,8 +25,9 @@ export const ProjectInfoContainer = styled.div`
   flex-direction: column;
   justify-content: flex-start;
 
-  width: calc(100% - 6rem);
-  margin-left: 1rem;
+  /* width: calc(100% - 6rem); */
+  width: 100%;
+  margin: 0 1rem;
 `;
 
 export const ProjectName = styled.p`

--- a/frontend/src/pages/ReviewWritingCompletePage/index.tsx
+++ b/frontend/src/pages/ReviewWritingCompletePage/index.tsx
@@ -13,13 +13,15 @@ const ReviewWritingCompletePage = () => {
   };
 
   return (
-    <S.Container>
-      <S.Title>😊리뷰 작성을 완료했어요!</S.Title>
-      <Button styleType="secondary" type="button" onClick={handleClickHomeButton}>
-        <S.HomeIcon src={PrimaryHomeIcon} />
-        <S.HomeText>홈으로 돌아가기</S.HomeText>
-      </Button>
-    </S.Container>
+    <S.Layout>
+      <S.Container>
+        <S.Title>😊 리뷰 작성을 완료했어요!</S.Title>
+        <Button styleType="secondary" type="button" onClick={handleClickHomeButton}>
+          <S.HomeIcon src={PrimaryHomeIcon} />
+          <S.HomeText>홈으로 돌아가기</S.HomeText>
+        </Button>
+      </S.Container>
+    </S.Layout>
   );
 };
 

--- a/frontend/src/pages/ReviewWritingCompletePage/styles.ts
+++ b/frontend/src/pages/ReviewWritingCompletePage/styles.ts
@@ -1,14 +1,20 @@
 import styled from '@emotion/styled';
 
+export const Layout = styled.section`
+  height: 70vh;
+`;
+
 export const Container = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
   display: flex;
   flex-direction: column;
   gap: 5rem;
   align-items: center;
   justify-content: center;
-
-  width: 100%;
-  height: 100%;
 `;
 
 export const Title = styled.p`


### PR DESCRIPTION
- resolves #399

---

### 🚀 어떤 기능을 구현했나요 ?
- 리뷰 상세, 작성 완료 페이지 사소한 디자인을 수정했습니다.


### 🔥 어떻게 해결했나요 ?
#### 리뷰 상세 페이지
- 선택한 객관식 키워드 디자인을 리스트 형태로 점을 붙여서 표시하도록 수정했습니다. 
  - `ul, li` 태그를 사용했습니다.
- 추후에 깃허브 로고가 다른 이미지로 대체될 수 있기 때문에 관련 코드는 주석 처리했습니다.
![스크린샷 2024-08-17 오후 7 05 36](https://github.com/user-attachments/assets/113b9be2-bab7-42d2-8f69-132b0e353545)


#### 리뷰 작성 완료 페이지
`리뷰 작성을 완료했어요` 문구가 가운데에 올 수 있도록 css를 수정했습니다.
![스크린샷 2024-08-17 오후 7 08 34](https://github.com/user-attachments/assets/e90658e3-e078-4e16-9f2f-ecc2b57ebdfa)

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
- 화이팅!🍀