### PR TITLE
[BE] refactor: 초기 데이터 설정시 중복 삽입 방지, 선택지 최대 개수 적용

### DIFF
--- a/backend/src/main/java/reviewme/DatabaseInitializer.java
+++ b/backend/src/main/java/reviewme/DatabaseInitializer.java
@@ -40,7 +40,7 @@ public class DatabaseInitializer {
     @Transactional
     void setup() {
         // 템플릿이 이미 존재하면 종료
-        if (templateRepository.existsById(1L)) {
+        if (!templateRepository.findAll().isEmpty()) {
             return;
         }
 

--- a/backend/src/main/java/reviewme/DatabaseInitializer.java
+++ b/backend/src/main/java/reviewme/DatabaseInitializer.java
@@ -26,7 +26,9 @@ import reviewme.template.repository.TemplateRepository;
 public class DatabaseInitializer {
 
     private static final String CATEGORY_HEADER = "이제, 선택한 순간들을 바탕으로 {revieweeName}에 대한 리뷰를 작성해볼게요.";
-    private static final String CATEGORY_TEXT_QUESTION = "위에서 선택한 사항에 대해 조금 더 자세히 설명해주세요.";
+    private static final String CATEGORY_TEXT_QUESTION = "위에서 선택한 사항과 관련된 경험을 구체적으로 적어 주세요.";
+    private static final int KEYWORD_CHECKBOX_MIN_COUNT = 1;
+    private static final int KEYWORD_CHECKBOX_MAX_COUNT = 3;
 
     private final QuestionRepository questionRepository;
     private final OptionItemRepository optionItemRepository;
@@ -45,7 +47,7 @@ public class DatabaseInitializer {
         // 카테고리 선택 섹션
         long categoryQuestionId = questionRepository.save(new Question(true, QuestionType.CHECKBOX, "프로젝트 기간 동안, {revieweeName}의 강점이 드러났던 순간을 선택해주세요.", null, 1)).getId();
         long categorySectionId = sectionRepository.save(new Section(VisibleType.ALWAYS, List.of(categoryQuestionId), null, "{revieweeName}와 함께 한 기억을 떠올려볼게요.", 1)).getId();
-        long categoryOptionGroupId = optionGroupRepository.save(new OptionGroup(categoryQuestionId, 1, 2)).getId();
+        long categoryOptionGroupId = optionGroupRepository.save(new OptionGroup(categoryQuestionId, KEYWORD_CHECKBOX_MIN_COUNT, KEYWORD_CHECKBOX_MAX_COUNT)).getId();
         long communicationOptionId = optionItemRepository.save(new OptionItem("🗣️커뮤니케이션, 협업 능력  (ex: 팀원간의 원활한 정보 공유, 명확한 의사소통)", categoryOptionGroupId, 1, OptionType.CATEGORY)).getId();
         long problemSolvingOptionId = optionItemRepository.save(new OptionItem("💡문제 해결 능력  (ex: 프로젝트 중 만난 버그/오류를 분석하고 이를 해결하는 능력)",categoryOptionGroupId,2, OptionType.CATEGORY )).getId();
         long timeManagingOptionId = optionItemRepository.save(new OptionItem("⏰시간 관리 능력 (ex: 일정과 마감 기한 준수, 업무의 우선 순위 분배)",categoryOptionGroupId,3, OptionType.CATEGORY )).getId();
@@ -56,7 +58,7 @@ public class DatabaseInitializer {
         long checkBoxCommunicationQuestionId = questionRepository.save(new Question(true, QuestionType.CHECKBOX, "커뮤니케이션, 협업 능력에서 어떤 부분이 인상 깊었는지 선택해주세요.", null, 1)).getId();
         long textCommunicationQuestionId = questionRepository.save(new Question(true, QuestionType.TEXT, CATEGORY_TEXT_QUESTION, "상황을 자세하게 기록할수록 {revieweeName}에게 도움이 돼요. {revieweeName} 덕분에 팀이 원활한 소통을 이뤘거나, 함께 일하면서 배울 점이 있었는지 떠올려 보세요.", 2)).getId();
         long communicationSectionId = sectionRepository.save(new Section(VisibleType.CONDITIONAL, List.of(checkBoxCommunicationQuestionId, textCommunicationQuestionId), communicationOptionId, CATEGORY_HEADER, 2)).getId();
-        long communicationOptionGroupId = optionGroupRepository.save(new OptionGroup(checkBoxCommunicationQuestionId, 1, 7)).getId();
+        long communicationOptionGroupId = optionGroupRepository.save(new OptionGroup(checkBoxCommunicationQuestionId, KEYWORD_CHECKBOX_MIN_COUNT, KEYWORD_CHECKBOX_MAX_COUNT)).getId();
         optionItemRepository.save(new OptionItem("반대 의견을 내더라도 듣는 사람이 기분 나쁘지 않게 이야기해요.",communicationOptionGroupId,1, OptionType.KEYWORD ));
         optionItemRepository.save(new OptionItem("팀원들의 의견을 잘 모아서 회의가 매끄럽게 진행되도록 해요.",communicationOptionGroupId,2, OptionType.KEYWORD ));
         optionItemRepository.save(new OptionItem("팀의 분위기를 주도해요.",communicationOptionGroupId,3, OptionType.KEYWORD ));
@@ -69,7 +71,7 @@ public class DatabaseInitializer {
         long checkBoxProblemSolvingQuestionId = questionRepository.save(new Question(true, QuestionType.CHECKBOX, "문제해결 능력에서 어느 부분이 인상 깊었는지 선택해주세요.", null, 1)).getId();
         long textProblemSolvingQuestionId = questionRepository.save(new Question(true, QuestionType.TEXT, CATEGORY_TEXT_QUESTION, "상황을 자세하게 기록할수록 {revieweeName}에게 도움이 돼요.  어떤 문제 상황이 발생했고, {revieweeName}이/가 어떻게 해결했는지 그 과정을 떠올려 보세요.", 2)).getId();
         long problemSolvingSectionId = sectionRepository.save(new Section(VisibleType.CONDITIONAL, List.of(checkBoxProblemSolvingQuestionId, textProblemSolvingQuestionId), problemSolvingOptionId, CATEGORY_HEADER, 3)).getId();
-        long problemSolvingOptionGroupId = optionGroupRepository.save(new OptionGroup(checkBoxProblemSolvingQuestionId, 1, 8)).getId();
+        long problemSolvingOptionGroupId = optionGroupRepository.save(new OptionGroup(checkBoxProblemSolvingQuestionId, KEYWORD_CHECKBOX_MIN_COUNT, KEYWORD_CHECKBOX_MAX_COUNT)).getId();
         optionItemRepository.save(new OptionItem("큰 문제를 작은 단위로 쪼개서 단계별로 해결해나가요.",problemSolvingOptionGroupId,1, OptionType.KEYWORD ));
         optionItemRepository.save(new OptionItem("낯선 문제를 만나도 당황하지 않고 차분하게 풀어나가요.",problemSolvingOptionGroupId,2, OptionType.KEYWORD ));
         optionItemRepository.save(new OptionItem("문제 해결을 위해 GPT등의 자원을 적극적으로 활용해요.",problemSolvingOptionGroupId,3, OptionType.KEYWORD ));
@@ -83,7 +85,7 @@ public class DatabaseInitializer {
         long checkBoxTimeManagingQuestionId = questionRepository.save(new Question(true, QuestionType.CHECKBOX, "시간 관리 능력에서 어느 부분이 인상 깊었는지 선택해주세요.", null, 1)).getId();
         long textTimeManagingQuestionId = questionRepository.save(new Question(true, QuestionType.TEXT, CATEGORY_TEXT_QUESTION, "상황을 자세하게 기록할수록 {revieweeName}에게 도움이 돼요. {revieweeName} 덕분에 팀이 효율적으로 시간관리를 할 수 있었는지 떠올려 보세요.", 2)).getId();
         long timeManagingSectionId = sectionRepository.save(new Section(VisibleType.CONDITIONAL, List.of(checkBoxTimeManagingQuestionId, textTimeManagingQuestionId), timeManagingOptionId, CATEGORY_HEADER, 4)).getId();
-        long timeManagingOptionGroupId = optionGroupRepository.save(new OptionGroup(checkBoxTimeManagingQuestionId, 1, 5)).getId();
+        long timeManagingOptionGroupId = optionGroupRepository.save(new OptionGroup(checkBoxTimeManagingQuestionId, KEYWORD_CHECKBOX_MIN_COUNT, KEYWORD_CHECKBOX_MAX_COUNT)).getId();
         optionItemRepository.save(new OptionItem("프로젝트의 일정과 주요 마일스톤을 설정하여 체계적으로 일정을 관리해요.",timeManagingOptionGroupId,1, OptionType.KEYWORD ));
         optionItemRepository.save(new OptionItem("일정에 따라 마감 기한을 잘 지켜요.",timeManagingOptionGroupId,2, OptionType.KEYWORD ));
         optionItemRepository.save(new OptionItem("업무의 중요도와 긴급성을 고려하여 우선 순위를 정하고, 그에 따라 작업을 분배해요.",timeManagingOptionGroupId,3, OptionType.KEYWORD ));
@@ -94,7 +96,7 @@ public class DatabaseInitializer {
         long checkBoxTechnicalQuestionId = questionRepository.save(new Question(true, QuestionType.CHECKBOX, "기술 역량, 전문 지식에서 어떤 부분이 인상 깊었는지 선택해주세요.", null, 1)).getId();
         long textTechnicalQuestionId = questionRepository.save(new Question(true, QuestionType.TEXT, CATEGORY_TEXT_QUESTION, "상황을 자세하게 기록할수록 {revieweeName}에게 도움이 돼요. {revieweeName} 덕분에 기술적 역량, 전문 지식적으로 도움을 받은 경험을 떠올려 보세요.", 2)).getId();
         long technicalSectionId = sectionRepository.save(new Section(VisibleType.CONDITIONAL, List.of(checkBoxTechnicalQuestionId, textTechnicalQuestionId), technicalOptionId, CATEGORY_HEADER, 5)).getId();
-        long technicalOptionGroupId = optionGroupRepository.save(new OptionGroup(checkBoxTechnicalQuestionId, 1, 12)).getId();
+        long technicalOptionGroupId = optionGroupRepository.save(new OptionGroup(checkBoxTechnicalQuestionId, KEYWORD_CHECKBOX_MIN_COUNT, KEYWORD_CHECKBOX_MAX_COUNT)).getId();
         optionItemRepository.save(new OptionItem("관련 언어 / 라이브러리 / 프레임워크 지식이 풍부해요.",technicalOptionGroupId,1, OptionType.KEYWORD ));
         optionItemRepository.save(new OptionItem("인프라 지식이 풍부해요.",technicalOptionGroupId,2, OptionType.KEYWORD ));
         optionItemRepository.save(new OptionItem("CS 지식이 풍부해요.",technicalOptionGroupId,3, OptionType.KEYWORD ));
@@ -112,7 +114,7 @@ public class DatabaseInitializer {
         long checkBoxGrowthQuestionId = questionRepository.save(new Question(true, QuestionType.CHECKBOX, "성장 마인드셋에서 어떤 부분이 인상 깊었는지 선택해주세요.", null, 1)).getId();
         long textGrowthQuestionId = questionRepository.save(new Question(true, QuestionType.TEXT, CATEGORY_TEXT_QUESTION, "상황을 자세하게 기록할수록 {revieweeName}에게 도움이 돼요. 인상깊었던 {revieweeName}의 성장 마인드셋을 떠올려 보세요.", 2)).getId();
         long growthSectionId = sectionRepository.save(new Section(VisibleType.CONDITIONAL, List.of(checkBoxGrowthQuestionId, textGrowthQuestionId), growthOptionId, CATEGORY_HEADER, 6)).getId();
-        long growthOptionGroupId = optionGroupRepository.save(new OptionGroup(checkBoxGrowthQuestionId, 1, 10)).getId();
+        long growthOptionGroupId = optionGroupRepository.save(new OptionGroup(checkBoxGrowthQuestionId, KEYWORD_CHECKBOX_MIN_COUNT, KEYWORD_CHECKBOX_MAX_COUNT)).getId();
         optionItemRepository.save(new OptionItem("어떤 상황에도 긍정적인 태도로 임해요.",growthOptionGroupId,1, OptionType.KEYWORD ));
         optionItemRepository.save(new OptionItem("주변 사람들한테 질문하는 것을 부끄러워하지 않아요.",growthOptionGroupId,2, OptionType.KEYWORD ));
         optionItemRepository.save(new OptionItem("어려움이 있어도 끝까지 해내요.",growthOptionGroupId,3, OptionType.KEYWORD ));

--- a/backend/src/main/java/reviewme/DatabaseInitializer.java
+++ b/backend/src/main/java/reviewme/DatabaseInitializer.java
@@ -37,6 +37,11 @@ public class DatabaseInitializer {
     @PostConstruct
     @Transactional
     void setup() {
+        // 템플릿이 이미 존재하면 종료
+        if (templateRepository.existsById(1L)) {
+            return;
+        }
+
         // 카테고리 선택 섹션
         long categoryQuestionId = questionRepository.save(new Question(true, QuestionType.CHECKBOX, "프로젝트 기간 동안, {revieweeName}의 강점이 드러났던 순간을 선택해주세요.", null, 1)).getId();
         long categorySectionId = sectionRepository.save(new Section(VisibleType.ALWAYS, List.of(categoryQuestionId), null, "{revieweeName}와 함께 한 기억을 떠올려볼게요.", 1)).getId();

--- a/backend/src/test/java/reviewme/question/repository/OptionItemRepositoryTest.java
+++ b/backend/src/test/java/reviewme/question/repository/OptionItemRepositoryTest.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import reviewme.question.domain.OptionGroup;
 import reviewme.question.domain.OptionItem;
 import reviewme.question.domain.OptionType;
 import reviewme.question.domain.Question;
@@ -26,6 +27,9 @@ class OptionItemRepositoryTest {
 
     @Autowired
     private QuestionRepository questionRepository;
+
+    @Autowired
+    private OptionGroupRepository optionGroupRepository;
 
     @Test
     void 리뷰_아이디로_선택한_옵션_아이템_아이디를_불러온다() {
@@ -52,18 +56,20 @@ class OptionItemRepositoryTest {
     @Test
     void 리뷰_아이디와_질문_아이디로_선택한_옵션_아이템을_순서대로_불러온다() {
         // given
-        long optionId1 = optionItemRepository.save(new OptionItem("1", 0, 3, OptionType.KEYWORD)).getId();
-        long optionId2 = optionItemRepository.save(new OptionItem("2", 0, 2, OptionType.KEYWORD)).getId();
-        long optionId3 = optionItemRepository.save(new OptionItem("3", 0, 1, OptionType.KEYWORD)).getId();
-        long optionId4 = optionItemRepository.save(new OptionItem("4", 0, 1, OptionType.KEYWORD)).getId();
-        optionItemRepository.save(new OptionItem("5", 0, 1, OptionType.KEYWORD));
+        Question question1 = questionRepository.save(new Question(true, QuestionType.CHECKBOX, "질문1", null, 1));
+        Question question2 = questionRepository.save(new Question(true, QuestionType.CHECKBOX, "질문2", null, 2));
+
+        long optionGroupId = optionGroupRepository.save(new OptionGroup(question1.getId(), 1, 3)).getId();
+        long optionId1 = optionItemRepository.save(new OptionItem("1", optionGroupId, 3, OptionType.KEYWORD)).getId();
+        long optionId2 = optionItemRepository.save(new OptionItem("2", optionGroupId, 2, OptionType.KEYWORD)).getId();
+        long optionId3 = optionItemRepository.save(new OptionItem("3", optionGroupId, 1, OptionType.KEYWORD)).getId();
+        long optionId4 = optionItemRepository.save(new OptionItem("4", optionGroupId, 1, OptionType.KEYWORD)).getId();
+        long optionId5 = optionItemRepository.save(new OptionItem("5", optionGroupId, 1, OptionType.KEYWORD)).getId();
 
         List<CheckboxAnswer> checkboxAnswers = List.of(
-                new CheckboxAnswer(1, List.of(optionId1, optionId3)),
-                new CheckboxAnswer(2, List.of(optionId4))
+                new CheckboxAnswer(question1.getId(), List.of(optionId1, optionId3)),
+                new CheckboxAnswer(question2.getId(), List.of(optionId4))
         );
-        Question question1 = questionRepository.save(new Question(true, QuestionType.CHECKBOX, "질문", null, 1));
-        questionRepository.save(new Question(true, QuestionType.CHECKBOX, "질문", null, 1));
 
         Review review = reviewRepository.save(new Review(0, 0, List.of(), checkboxAnswers));
 
@@ -75,5 +81,4 @@ class OptionItemRepositoryTest {
         // then
         assertThat(actual).extracting(OptionItem::getId).containsExactly(optionId3, optionId1);
     }
-
 }


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #314 

---

### 🚀 어떤 기능을 구현했나요 ?
- 초기 데이터가 있으면 삽입하지 않는 로직을 추가했습니다.
- 꼬리질문 객관식 최대 선택 갯수를 3개로 수정했습니다.
- 꼬리질문 서술형 질문 내용을 수정했습니다. : 위에서 선택한 사항과 관련된 경험을 구체적으로 적어 주세요.

### 🔥 어떻게 해결했나요 ?
- templateRepository에 id가 1인 템플릿이 있으면 DataInitializer 속 로직을 실행하지 않도록 했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 위의 방법으로 중복을 방지했을 때 발생할만한 문제가 있는지 봐주세요!

### 📚 참고 자료, 할 말
