### PR TITLE
[FE] feat: 리뷰 작성 페이지 Progress Bar 구현

### DIFF
--- a/frontend/src/assets/navigateNext.svg
+++ b/frontend/src/assets/navigateNext.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12.6 12L8 7.4L9.4 6L15.4 12L9.4 18L8 16.6L12.6 12Z" fill="#8D8C8C"/>
+</svg>

--- a/frontend/src/hooks/review/writingCardForm/multiplceChoice/useCancelAnsweredCategory.ts
+++ b/frontend/src/hooks/review/writingCardForm/multiplceChoice/useCancelAnsweredCategory.ts
@@ -1,6 +1,6 @@
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 
-import { answerMapAtom, cardSectionListSelector } from '@/recoil';
+import { answerMapAtom, cardSectionListSelector, visitedCardListAtom } from '@/recoil';
 import { ReviewWritingCardQuestion } from '@/types';
 
 interface UseCancelAnsweredCategoryProps {
@@ -9,6 +9,8 @@ interface UseCancelAnsweredCategoryProps {
 const useCancelAnsweredCategory = ({ question }: UseCancelAnsweredCategoryProps) => {
   const cardSectionList = useRecoilValue(cardSectionListSelector);
   const answerMap = useRecoilValue(answerMapAtom);
+  const setVisitedCardList = useSetRecoilState(visitedCardListAtom);
+
   const isCategoryQuestion = () => {
     return question.questionId === cardSectionList[0].questions[0].questionId;
   };
@@ -41,6 +43,16 @@ const useCancelAnsweredCategory = ({ question }: UseCancelAnsweredCategoryProps)
     return !!answer?.selectedOptionIds?.length || !!answer?.text?.length;
   };
 
+  const updateVisitedCardList = (optionId: number) => {
+    if (!isCategoryQuestion) return false;
+
+    const targetSectionId = getCategoryByOptionId(optionId).sectionId;
+    setVisitedCardList((prev) => {
+      const newVisitedCardList = [...prev];
+      return newVisitedCardList.filter((card) => card !== targetSectionId);
+    });
+  };
+
   /**
    * 해제하기 위해 카테고리 문항을 선택한 경우, 이미 이에 대해 답변을 했는 지 여부
    * @param optionId : 문항의 optionId
@@ -52,6 +64,7 @@ const useCancelAnsweredCategory = ({ question }: UseCancelAnsweredCategoryProps)
 
   return {
     isAnsweredCategoryChanged,
+    updateVisitedCardList,
   };
 };
 

--- a/frontend/src/hooks/review/writingCardForm/multiplceChoice/useMultipleChoice.ts
+++ b/frontend/src/hooks/review/writingCardForm/multiplceChoice/useMultipleChoice.ts
@@ -16,7 +16,7 @@ interface UseMultipleChoiceProps {
 const useMultipleChoice = ({ question, handleModalOpen }: UseMultipleChoiceProps) => {
   const [unCheckTargetOptionId, setUnCheckTargetOptionId] = useState<number | null>(null);
 
-  const { isAnsweredCategoryChanged } = useCancelAnsweredCategory({ question });
+  const { isAnsweredCategoryChanged, updateVisitedCardList } = useCancelAnsweredCategory({ question });
 
   const { selectedOptionList, updateAnswerState } = useUpdateMultipleChoiceAnswer({ question });
 
@@ -28,6 +28,7 @@ const useMultipleChoice = ({ question, handleModalOpen }: UseMultipleChoiceProps
   const handleCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { id, checked } = event.currentTarget;
     const optionId = Number(id);
+
     if (isAboveSelectionLimit(optionId)) {
       return handleLimitGuideOpen(true);
     }
@@ -52,6 +53,8 @@ const useMultipleChoice = ({ question, handleModalOpen }: UseMultipleChoiceProps
     handleCheckboxChange,
     isSelectedCheckbox,
     unCheckTargetOption,
+    updateVisitedCardList,
+    unCheckTargetOptionId,
   };
 };
 export default useMultipleChoice;

--- a/frontend/src/hooks/review/writingCardForm/useCurrentCardIndex.ts
+++ b/frontend/src/hooks/review/writingCardForm/useCurrentCardIndex.ts
@@ -8,8 +8,12 @@ const STEP = {
 const useCurrentCardIndex = () => {
   const [currentCardIndex, setCurrentCardIndex] = useState(0);
 
-  const handleCurrentCardIndex = (direction: 'prev' | 'next') => {
-    setCurrentCardIndex((prev) => prev + STEP[direction]);
+  const handleCurrentCardIndex = (direction: 'prev' | 'next' | number) => {
+    if (typeof direction === 'number') {
+      setCurrentCardIndex(direction);
+    } else {
+      setCurrentCardIndex((prev) => prev + STEP[direction]);
+    }
   };
 
   return {

--- a/frontend/src/hooks/review/writingCardForm/useResetFormRecoil.ts
+++ b/frontend/src/hooks/review/writingCardForm/useResetFormRecoil.ts
@@ -1,6 +1,6 @@
 import { useResetRecoilState } from 'recoil';
 
-import { answerMapAtom, answerValidationMapAtom, selectedCategoryAtom } from '@/recoil';
+import { answerMapAtom, answerValidationMapAtom, selectedCategoryAtom, visitedCardListAtom } from '@/recoil';
 /**
  * 리뷰 작성 페이지에서 사용하는 recoil 상태들을 초기화하는 훅
  */
@@ -8,11 +8,13 @@ const useResetFormRecoil = () => {
   const resetSelectedCategoryAtom = useResetRecoilState(selectedCategoryAtom);
   const resetAnswerMapAtom = useResetRecoilState(answerMapAtom);
   const resetAnswerValidationMapAtom = useResetRecoilState(answerValidationMapAtom);
+  const resetVisitedCardListAtom = useResetRecoilState(visitedCardListAtom);
 
   const resetFormRecoil = () => {
     resetSelectedCategoryAtom();
     resetAnswerMapAtom();
     resetAnswerValidationMapAtom();
+    resetVisitedCardListAtom();
   };
 
   return { resetFormRecoil };

--- a/frontend/src/mocks/mockData/writingCardForm/reviewWritingCardFormData.ts
+++ b/frontend/src/mocks/mockData/writingCardForm/reviewWritingCardFormData.ts
@@ -9,6 +9,7 @@ export const REVIEW_WRITING_FORM_CARD_DATA: ReviewWritingFrom = {
   sections: [
     {
       sectionId: 1,
+      sectionName: '카테고리 선택',
       visible: 'ALWAYS',
       onSelectedOptionId: null,
       header: 'bada와 함께 한 기억을 떠올려볼게요.',
@@ -44,6 +45,7 @@ export const REVIEW_WRITING_FORM_CARD_DATA: ReviewWritingFrom = {
     },
     {
       sectionId: 2,
+      sectionName: '커뮤니케이션, 협업 능력',
       visible: 'CONDITIONAL',
       onSelectedOptionId: 1,
       header: '이제, 선택한 순간들을 바탕으로 bada에 대한 리뷰를 작성해볼게요.',
@@ -84,6 +86,7 @@ export const REVIEW_WRITING_FORM_CARD_DATA: ReviewWritingFrom = {
     },
     {
       sectionId: 3,
+      sectionName: '문제해결 능력',
       visible: 'CONDITIONAL',
       onSelectedOptionId: 2,
       header: '이제, 선택한 순간들을 바탕으로 bada에 대한 리뷰를 작성해볼게요.',
@@ -132,6 +135,7 @@ export const REVIEW_WRITING_FORM_CARD_DATA: ReviewWritingFrom = {
     },
     {
       sectionId: 4,
+      sectionName: '시간 관리 능력',
       visible: 'CONDITIONAL',
       onSelectedOptionId: 3,
       header: '이제, 선택한 순간들을 바탕으로 bada에 대한 리뷰를 작성해볼게요.',
@@ -173,6 +177,7 @@ export const REVIEW_WRITING_FORM_CARD_DATA: ReviewWritingFrom = {
     },
     {
       sectionId: 5,
+      sectionName: '기술 역량, 전문 지식',
       visible: 'CONDITIONAL',
       onSelectedOptionId: 4,
       header: '이제, 선택한 순간들을 바탕으로 bada에 대한 리뷰를 작성해볼게요.',
@@ -218,6 +223,7 @@ export const REVIEW_WRITING_FORM_CARD_DATA: ReviewWritingFrom = {
     },
     {
       sectionId: 6,
+      sectionName: '성장 마인드셋',
       visible: 'CONDITIONAL',
       onSelectedOptionId: 5,
       header: '이제, 선택한 순간들을 바탕으로 bada에 대한 리뷰를 작성해볼게요.',
@@ -261,6 +267,7 @@ export const REVIEW_WRITING_FORM_CARD_DATA: ReviewWritingFrom = {
     },
     {
       sectionId: 7,
+      sectionName: '단점 피드백',
       visible: 'ALWAYS',
       onSelectedOptionId: null,
       header: 'bada의 성장을 도와주세요!',
@@ -278,6 +285,7 @@ export const REVIEW_WRITING_FORM_CARD_DATA: ReviewWritingFrom = {
     },
     {
       sectionId: 8,
+      sectionName: '추가 리뷰 및 응원',
       visible: 'ALWAYS',
       onSelectedOptionId: null,
       header: '리뷰를 더 하고 싶은 리뷰어를 위한 추가 리뷰!',

--- a/frontend/src/pages/ReviewWritingCardFromPage/components/CardForm/index.tsx
+++ b/frontend/src/pages/ReviewWritingCardFromPage/components/CardForm/index.tsx
@@ -1,6 +1,6 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router';
-import { useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 
 import { ConfirmModal, AnswerListRecheckModal } from '@/components';
 import {
@@ -14,9 +14,10 @@ import {
   useUpdateDefaultAnswers,
 } from '@/hooks';
 import useModals from '@/hooks/useModals';
-import { answerMapAtom } from '@/recoil';
+import { answerMapAtom, answerValidationMapAtom, visitedCardListAtom } from '@/recoil';
 import { ReviewWritingFormResult } from '@/types';
 
+import ProgressBar from '../ProgressBar';
 import ReviewWritingCard from '../ReviewWritingCard';
 
 import * as S from './styles';
@@ -26,6 +27,21 @@ const INDEX_OFFSET = 1;
 const MODAL_KEYS = {
   confirm: 'CONFIRM',
   recheck: 'RECHECK',
+};
+
+type QuestionContent = {
+  [key: number]: string;
+};
+
+const QUESTION_CONTENTS: QuestionContent = {
+  1: '카테고리 선택',
+  2: '커뮤니케이션/협업',
+  3: '문제 해결',
+  4: '시간 관리',
+  5: '기술 역량/전문 지식',
+  6: '성장 마인드셋',
+  7: '단점 피드백',
+  8: '추가 리뷰/응원',
 };
 
 const CardForm = () => {
@@ -45,6 +61,7 @@ const CardForm = () => {
   // 생성된 질문지를 바탕으로 답변 기본값 및 답변의 유효성 기본값 설정
   useUpdateDefaultAnswers();
   const answerMap = useRecoilValue(answerMapAtom);
+  const answerValidateMap = useRecoilValue(answerValidationMapAtom);
 
   const { resetFormRecoil } = useResetFormRecoil();
 
@@ -57,9 +74,26 @@ const CardForm = () => {
     closeModal(MODAL_KEYS.confirm);
   };
   const { postReview } = useMutateReview({ executeAfterMutateSuccess });
+  const [visitedCardList, setVisitedCardList] = useRecoilState(visitedCardListAtom);
 
   const handleSubmitButtonClick = () => {
     openModal(MODAL_KEYS.confirm);
+  };
+
+  const handleNextClick = () => {
+    const nextIndex = currentCardIndex + 1;
+    if (nextIndex < cardSectionList.length) {
+      const nextSectionId = cardSectionList[nextIndex].sectionId;
+      setVisitedCardList((prev) => {
+        const newVisitedCardList = [...prev];
+        if (!newVisitedCardList.includes(nextSectionId)) {
+          newVisitedCardList.push(nextSectionId);
+        }
+        return newVisitedCardList;
+      });
+
+      handleCurrentCardIndex('next');
+    }
   };
 
   const submitAnswer = async () => {
@@ -83,6 +117,36 @@ const CardForm = () => {
     };
   }, []);
 
+  const STEP_LIST = cardSectionList?.reduce(
+    (acc, section, index) => {
+      const isPreviousDone = index === 0 || acc.every((step) => step.isDone);
+      const isMovingAvailable = isPreviousDone && visitedCardList.includes(section.sectionId);
+
+      acc.push({
+        sectionId: section.sectionId,
+        sectionName: section.sectionName ?? QUESTION_CONTENTS[section.sectionId],
+        isMovingAvailable,
+        isDone: section.questions.every((question) => answerValidateMap?.get(question.questionId)),
+        isCurrentStep: index === currentCardIndex,
+        handleClick: () => {
+          if (isMovingAvailable) {
+            handleCurrentCardIndex(index);
+          }
+        },
+      });
+
+      return acc;
+    },
+    [] as Array<{
+      sectionId: number;
+      sectionName: string;
+      isMovingAvailable: boolean;
+      isDone: boolean;
+      isCurrentStep: boolean;
+      handleClick: () => void;
+    }>,
+  );
+
   return (
     <>
       <S.CardForm>
@@ -95,6 +159,7 @@ const CardForm = () => {
             </p>
           </S.ProjectInfoContainer>
         </S.RevieweeDescription>
+        <ProgressBar stepList={STEP_LIST} />
         <S.SliderContainer ref={wrapperRef} $translateX={currentCardIndex * slideWidth} $height={slideHeight}>
           {cardSectionList?.map((section, index) => (
             <S.Slide id={makeId(index)} key={section.sectionId}>
@@ -103,6 +168,7 @@ const CardForm = () => {
                 currentCardIndex={currentCardIndex}
                 cardSection={section}
                 isLastCard={cardSectionList.length - INDEX_OFFSET === currentCardIndex}
+                handleNextClick={handleNextClick}
                 handleCurrentCardIndex={handleCurrentCardIndex}
                 handleRecheckButtonClick={handleRecheckButtonClick}
                 handleSubmitButtonClick={handleSubmitButtonClick}

--- a/frontend/src/pages/ReviewWritingCardFromPage/components/CardForm/index.tsx
+++ b/frontend/src/pages/ReviewWritingCardFromPage/components/CardForm/index.tsx
@@ -96,7 +96,6 @@ const CardForm = () => {
     }
   };
 
-  const submitAnswer = async () => {
   const submitAnswer = async (event: React.MouseEvent) => {
     event.preventDefault();
 

--- a/frontend/src/pages/ReviewWritingCardFromPage/components/MultipleChoiceQuestion/index.tsx
+++ b/frontend/src/pages/ReviewWritingCardFromPage/components/MultipleChoiceQuestion/index.tsx
@@ -20,7 +20,14 @@ const MultipleChoiceQuestion = ({ question }: MultipleChoiceQuestionProps) => {
     isOpen ? openModal(MODAL_KEY.confirm) : closeModal(MODAL_KEY.confirm);
   };
 
-  const { isOpenLimitGuide, handleCheckboxChange, isSelectedCheckbox, unCheckTargetOption } = useMultipleChoice({
+  const {
+    isOpenLimitGuide,
+    handleCheckboxChange,
+    isSelectedCheckbox,
+    unCheckTargetOption,
+    updateVisitedCardList,
+    unCheckTargetOptionId,
+  } = useMultipleChoice({
     question,
     handleModalOpen,
   });
@@ -31,6 +38,7 @@ const MultipleChoiceQuestion = ({ question }: MultipleChoiceQuestionProps) => {
 
   const handleModalConfirmButtonClick = () => {
     unCheckTargetOption();
+    updateVisitedCardList(unCheckTargetOptionId!);
     closeModal(MODAL_KEY.confirm);
   };
 

--- a/frontend/src/pages/ReviewWritingCardFromPage/components/ProgressBar/index.tsx
+++ b/frontend/src/pages/ReviewWritingCardFromPage/components/ProgressBar/index.tsx
@@ -1,0 +1,41 @@
+import NavigateNextIcon from '@/assets/navigateNext.svg';
+
+import * as S from './styles';
+
+interface Step {
+  sectionId: number;
+  sectionName: string;
+  isDone: boolean;
+  isMovingAvailable: boolean;
+  isCurrentStep: boolean;
+  handleClick: () => void;
+}
+
+interface ProgressBarProps {
+  stepList: Step[];
+}
+
+const ProgressBar = ({ stepList }: ProgressBarProps) => {
+  return (
+    <S.ProgressBar>
+      {stepList.map((step, index) => {
+        return (
+          <>
+            <S.StepButton
+              key={index}
+              $isDone={step.isDone}
+              $isMovingAvailable={step.isMovingAvailable}
+              $isCurrentStep={step.isCurrentStep}
+              onClick={step.handleClick}
+            >
+              {step.sectionName}
+            </S.StepButton>
+            {index < stepList.length - 1 && <img src={NavigateNextIcon} alt="다음 화살표" />}
+          </>
+        );
+      })}
+    </S.ProgressBar>
+  );
+};
+
+export default ProgressBar;

--- a/frontend/src/pages/ReviewWritingCardFromPage/components/ProgressBar/styles.ts
+++ b/frontend/src/pages/ReviewWritingCardFromPage/components/ProgressBar/styles.ts
@@ -1,0 +1,55 @@
+import { css, Theme } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const ProgressBar = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+`;
+
+interface StepButtonStyleProps {
+  $isDone: boolean;
+  $isMovingAvailable: boolean;
+  $isCurrentStep: boolean;
+}
+
+const defaultStyle = (theme: Theme) => css`
+  cursor: pointer;
+  background-color: ${theme.colors.white};
+`;
+
+const disabledStyle = (theme: Theme) => css`
+  pointer-events: none;
+  color: ${theme.colors.disabledText};
+  background-color: ${theme.colors.disabled};
+  border-color: ${theme.colors.disabled};
+`;
+
+const completedStyle = (theme: Theme) => css`
+  cursor: pointer;
+  background-color: ${theme.colors.palePurple};
+`;
+
+const getStepButtonStyle = ($isDone: boolean, $isMovingAvailable: boolean, theme: Theme) => {
+  if (!$isMovingAvailable) return disabledStyle(theme);
+  else if ($isDone && $isMovingAvailable) return completedStyle(theme);
+  else if (!$isDone && $isMovingAvailable) return defaultStyle(theme);
+  else return '';
+};
+
+export const StepButton = styled.button<StepButtonStyleProps>`
+  overflow: hidden;
+
+  width: 12rem;
+  height: 3rem;
+
+  font-size: ${({ theme }) => theme.fontSize.small};
+  font-weight: ${({ $isCurrentStep, theme }) => $isCurrentStep && theme.fontWeight.bold};
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  border: ${({ $isCurrentStep, theme }) => ($isCurrentStep ? `0.2rem solid ${theme.colors.primary}` : '')};
+  border-radius: ${({ theme }) => theme.borderRadius.basic};
+  ${({ $isDone, $isMovingAvailable, theme }) => getStepButtonStyle($isDone, $isMovingAvailable, theme)}
+`;

--- a/frontend/src/pages/ReviewWritingCardFromPage/components/ReviewWritingCard/index.tsx
+++ b/frontend/src/pages/ReviewWritingCardFromPage/components/ReviewWritingCard/index.tsx
@@ -10,6 +10,7 @@ interface ReviewWritingCardProps extends Omit<CardSliderControllerProps, 'isAble
   cardIndex: number;
   isLastCard: boolean;
   cardSection: ReviewWritingCardSection;
+  handleNextClick: () => void;
 }
 
 const ReviewWritingCard = ({
@@ -17,11 +18,13 @@ const ReviewWritingCard = ({
   currentCardIndex,
   isLastCard,
   cardSection,
+  handleNextClick,
   handleCurrentCardIndex,
   handleRecheckButtonClick,
   handleSubmitButtonClick,
 }: ReviewWritingCardProps) => {
   const { isAbleNextStep } = useCheckNextStepAvailability({ currentCardIndex });
+
   return (
     <S.ReviewWritingCard>
       <S.Header>{cardSection.header}</S.Header>
@@ -49,10 +52,7 @@ const ReviewWritingCard = ({
               />
             </>
           ) : (
-            <CardSliderController.NextButton
-              isAbleNextStep={isAbleNextStep}
-              handleCurrentCardIndex={handleCurrentCardIndex}
-            />
+            <CardSliderController.NextButton isAbleNextStep={isAbleNextStep} handleCurrentCardIndex={handleNextClick} />
           )}
         </S.ButtonContainer>
       </S.Main>

--- a/frontend/src/recoil/keys/index.ts
+++ b/frontend/src/recoil/keys/index.ts
@@ -5,6 +5,7 @@ export const ATOM_KEY = {
     selectedCategoryAtom: 'selectedCategoryAtom',
     answerMapAtom: 'answerMapAtom',
     answerValidationMapAtom: 'answerValidationMapAtom',
+    visitedCardList: 'visitedCardList',
   },
 };
 

--- a/frontend/src/recoil/reviewWritingForm/atom.ts
+++ b/frontend/src/recoil/reviewWritingForm/atom.ts
@@ -36,3 +36,12 @@ export const answerValidationMapAtom = atom<Map<number, boolean> | null>({
   key: ATOM_KEY.reviewWritingForm.answerValidationMapAtom,
   default: null,
 });
+
+/**
+ * 이미 방문한 카드의 section ID
+ * number: sectionId
+ */
+export const visitedCardListAtom = atom<number[]>({
+  key: ATOM_KEY.reviewWritingForm.visitedCardList,
+  default: [1],
+});

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -39,6 +39,7 @@ export const colors: ThemeProperty<CSSProperties['color']> = {
   primary: '#7361DF',
   primaryHover: '#9082E6',
   lightPurple: '#E6E3F6',
+  palePurple: '#F5F4FF',
   black: '#1E2022',
   white: '#FFFFFF',
   lightGray: '#F1F2F4',

--- a/frontend/src/types/review.ts
+++ b/frontend/src/types/review.ts
@@ -97,6 +97,7 @@ export interface ReviewWritingFrom {
 }
 export interface ReviewWritingCardSection {
   sectionId: number;
+  sectionName: string;
   visible: 'ALWAYS' | 'CONDITIONAL';
   onSelectedOptionId: number | null;
   header: string;


### PR DESCRIPTION
- resolves #363 

---

### 🚀 어떤 기능을 구현했나요 ?
- 리뷰 작성 페이지에 프로그레스 바를 구현했습니다.

- 카테고리 선택 시 선택한 카테고리를 프로그레스 바에 동적으로 생성합니다.
- 한 번이라도 방문한 카드 section의 경우, 이전 버튼을 눌러 뒤로 가도 프로스레스 바를 통해 바로 이동 가능합니다.
- 어떤 카드 section이 유효하지 않으면, 이후의 모든 section으로 이동이 불가능합니다(현재 제출까지의 로직이 이전 section이 유효해야 다음 section으로 이동할 수 있는데, 이 로직을 유지하면서 프로그레스 바를 구현했어요).

- 답변이 달려있던 카테고리를 선택 해제하면 confirm modal이 뜨는데, 선택 해제하게 되면 방문 처리가 해제되어 다시 선택해도 바로 이동이 불가능합니다.
- 하지만 답변이 달려있던 카테고리가 아니라면 해제 후 다시 선택했을 때 바로 이동이 가능합니다.

### 🔥 어떻게 해결했나요 ?
- cardSectionList를 바탕으로 stepList를 만들고, 해당 카드가 완성되었는지, 해당 카드로 이동 가능한지 등 여부를 계산해서 프로그레스 바를 보여줍니다.
- 프로그레스 바의 단위는 step이고, 각 step은 StepButton으로 화면에 표시됩니다. StepButton은 총 3가지 상태를 가져요.

1. default: 프로그레스 바를 통해 이동 가능, 다음 card로 넘어갈 수 없는 상태
2. completed: 프로그레스 바를 통해 이동 가능, 다음 card로 넘어갈 수 있는 상태
3. disabled: 프로그레스 바를 통해 이동 불가능

- 조금 더 자연스러운 사용자 경험을 위해, 한 번이라도 방문(활성화)한 card의 id를 recoil state로 저장해서, 이전 card로 돌아갔을 때도 프로그레스 바를 통해 바로 이동 가능하도록 구현했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 기존의 리뷰 작성 페이지 로직을 최대한 유지한 상태에서 프로그레스 바를 덧입혔는데, 추후 조금 더 유연한 사용성을 위해 리팩토링을 진행하려 해요.

### 📚 참고 자료, 할 말
![image](https://github.com/user-attachments/assets/e1c1d0a8-1f77-451a-a873-58b91e2142e4)
▲ 구현 화면