### PR TITLE
[FE] feat:  footer 생성 및 리뷰미 팀명과 icon8 저작권 표기

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import { Outlet } from 'react-router';
 
-import { Main, PageLayout, Sidebar, Topbar, SideModal } from './components';
+import { PageLayout, Sidebar, Topbar, SideModal, Footer, Main } from './components';
 import Breadcrumb from './components/common/Breadcrumb';
 import { useSidebar } from './hooks';
 import useBreadcrumbPaths from './hooks/useBreadcrumbPaths';
@@ -22,6 +22,7 @@ const App = () => {
       <Main>
         <Outlet />
       </Main>
+      <Footer />
     </PageLayout>
   );
 };

--- a/frontend/src/components/layouts/Footer/index.tsx
+++ b/frontend/src/components/layouts/Footer/index.tsx
@@ -5,7 +5,7 @@ const Footer = () => {
     <S.Footer>
       <div>
         <S.Link href="https://github.com/woowacourse-teams/2024-review-me" aria-label="리뷰미 깃헙 저장소">
-          © review-me
+          © 20204-review-me
         </S.Link>
       </div>
       <div>

--- a/frontend/src/components/layouts/Footer/index.tsx
+++ b/frontend/src/components/layouts/Footer/index.tsx
@@ -1,0 +1,21 @@
+import * as S from './style';
+
+const Footer = () => {
+  return (
+    <S.Footer>
+      <div>
+        <S.Link href="https://github.com/woowacourse-teams/2024-review-me" aria-label="리뷰미 깃헙 저장소">
+          © review-me
+        </S.Link>
+      </div>
+      <div>
+        Icon By &nbsp;
+        <S.Link href="https://icons8.com/" aria-label="icon8 홈페이지">
+          icon8
+        </S.Link>
+      </div>
+    </S.Footer>
+  );
+};
+
+export default Footer;

--- a/frontend/src/components/layouts/Footer/index.tsx
+++ b/frontend/src/components/layouts/Footer/index.tsx
@@ -5,7 +5,7 @@ const Footer = () => {
     <S.Footer>
       <div>
         <S.Link href="https://github.com/woowacourse-teams/2024-review-me" aria-label="리뷰미 깃헙 저장소">
-          © 20204-review-me
+          © review-me
         </S.Link>
       </div>
       <div>

--- a/frontend/src/components/layouts/Footer/style.ts
+++ b/frontend/src/components/layouts/Footer/style.ts
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+
+export const Footer = styled.footer`
+  position: absolute;
+  bottom: 0;
+  left: 0;
+
+  display: flex;
+  gap: 3.2rem;
+  align-items: center;
+  justify-content: center;
+
+  width: 100%;
+  height: ${({ theme }) => theme.footerHeight};
+  padding: 1rem;
+
+  font-size: ${({ theme }) => theme.fontSize.small};
+  color: ${({ theme }) => theme.colors.gray};
+
+  background-color: ${({ theme }) => theme.colors.white};
+`;
+
+export const Link = styled.a`
+  &,
+  &:visited,
+  &:hover,
+  &:focus,
+  &:active {
+    color: inherit;
+    text-decoration: none;
+  }
+`;

--- a/frontend/src/components/layouts/PageLayout/styles.ts
+++ b/frontend/src/components/layouts/PageLayout/styles.ts
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 
 export const Layout = styled.div`
   width: 100%;
-  background-color: ${({ theme }) => theme.colors.sidebarBackground};
 `;
 
 export const Wrapper = styled.div`
@@ -13,6 +12,7 @@ export const Wrapper = styled.div`
   flex-direction: column;
 
   width: 100%;
+  min-height: 100vh;
 
   background-color: ${({ theme }) => theme.colors.white};
 `;

--- a/frontend/src/components/layouts/index.tsx
+++ b/frontend/src/components/layouts/index.tsx
@@ -2,3 +2,4 @@ export { default as Main } from './Main';
 export { default as PageLayout } from './PageLayout';
 export { default as Sidebar } from './Sidebar';
 export { default as Topbar } from './Topbar';
+export { default as Footer } from './Footer';

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -4,10 +4,13 @@ import { CSSProperties } from 'react';
 import { ThemeProperty } from '../types';
 
 export const formWidth = '70rem';
+
 export const sidebarWidth: ThemeProperty<string> = {
   desktop: '25rem',
   mobile: '100vw',
 };
+export const footerHeight = '4rem';
+
 export const breakpoints: ThemeProperty<string> = {
   desktop: '102.4rem',
   tablet: '72rem',
@@ -63,6 +66,7 @@ const theme: Theme = {
   sidebarWidth,
   borderRadius,
   formWidth,
+  footerHeight,
 };
 
 export default theme;

--- a/frontend/src/types/emotion.ts
+++ b/frontend/src/types/emotion.ts
@@ -20,6 +20,7 @@ type ThemeType = {
   sidebarWidth: sidebarWidth;
   borderRadius: borderRadius;
   formWidth: string;
+  footerHeight: string;
 };
 
 declare module '@emotion/react' {


### PR DESCRIPTION


- resolves #418

---

### 🚀 어떤 기능을 구현했나요 ?
- footer를 생성해 리뷰미 팀명과 icon8사용에 대한 저작권 표기를 남겼어요.

### 🔥 어떻게 해결했나요 ?
#### 구현 모습
우선 footer의 배경을 기본 배경색이 흰색으로 했어요.
홈 페이지에서 리뷰미 사용법의 보라색 배경이 끝기는 느낌이 드는데, 이 부분은 프론트 회의에서 다뤄봐야할 것 같아요.
<img  src="https://github.com/user-attachments/assets/311c8f6c-7261-4f08-b2da-19050ac07a36" width="500px" alt ="footer 적용된 홈 페이지 모습"/>

<img  src="https://github.com/user-attachments/assets/e4b46cfe-ff73-487a-94f4-bf96fb5861a0" width="500px" alt ="footer 적용된 리뷰 작성 페이지 모습"/>


### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 월요일에 할게 많고 footer 디자인이 간단해서 디자인 회의 전에 일단 만들었어요. 폰트 크기, 들어가는 내용등에 대해서 수정의견이 있으면 이야기해주세요. 

### 📚 참고 자료, 할 말
- 저작권 무조건 지켜, 문제 생기면 머리 아프니까...
- 파비콘은 언제하지?