### PR TITLE
[FE] fix: 비밀번호 검증 훅 분리 및 비밀번호 길이 유효성 검사 문구 추가

### DIFF
--- a/frontend/src/components/common/Input/index.tsx
+++ b/frontend/src/components/common/Input/index.tsx
@@ -6,13 +6,14 @@ export interface InputStyleProps {
 interface InputProps extends InputStyleProps {
   value: string;
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onBlur?: () => void;
   type: string;
   id?: string;
   name?: string;
   placeholder?: string;
 }
 
-const Input = ({ id, value, name, onChange, type, placeholder, $style }: InputProps) => {
+const Input = ({ id, value, name, onChange, onBlur, type, placeholder, $style }: InputProps) => {
   return (
     <S.Input
       id={id}
@@ -20,6 +21,7 @@ const Input = ({ id, value, name, onChange, type, placeholder, $style }: InputPr
       type={type}
       name={name}
       onChange={onChange}
+      onBlur={onBlur}
       placeholder={placeholder}
       style={$style}
     />

--- a/frontend/src/hooks/usePasswordValidation.ts
+++ b/frontend/src/hooks/usePasswordValidation.ts
@@ -7,8 +7,8 @@ import {
   MIN_PASSWORD_INPUT,
 } from '@/pages/HomePage/utils/validateInput';
 
-const INVALID_CHAR_ERROR_MESSAGE = `영문(대/소문자) 및 숫자만 입력할 수 있습니다`;
-const PASSWORD_LENGTH_ERROR_MESSAGE = `${MIN_PASSWORD_INPUT}자부터 ${MAX_PASSWORD_INPUT}자까지 입력할 수 있습니다`;
+const INVALID_CHAR_ERROR_MESSAGE = `영문(대/소문자) 및 숫자만 입력해주세요`;
+const PASSWORD_LENGTH_ERROR_MESSAGE = `${MIN_PASSWORD_INPUT}자부터 ${MAX_PASSWORD_INPUT}자까지 입력할 수 있어요`;
 
 export const usePasswordValidation = (password: string) => {
   const [passwordErrorMessage, setPasswordErrorMessage] = useState('');

--- a/frontend/src/hooks/usePasswordValidation.ts
+++ b/frontend/src/hooks/usePasswordValidation.ts
@@ -5,35 +5,32 @@ import {
   isAlphanumeric,
   MAX_PASSWORD_INPUT,
   MIN_PASSWORD_INPUT,
-} from '../../src/pages/HomePage/utils/validateInput';
+} from '@/pages/HomePage/utils/validateInput';
 
 const INVALID_CHAR_ERROR_MESSAGE = `영문(대/소문자) 및 숫자만 입력할 수 있습니다`;
 const PASSWORD_LENGTH_ERROR_MESSAGE = `${MIN_PASSWORD_INPUT}자부터 ${MAX_PASSWORD_INPUT}자까지 입력할 수 있습니다`;
 
 export const usePasswordValidation = (password: string) => {
   const [passwordErrorMessage, setPasswordErrorMessage] = useState('');
-  const [hasBlurred, setHasBlurred] = useState(false); 
+  const [hasBlurred, setHasBlurred] = useState(false);
 
   const validatePassword = () => {
     if (!isWithinLengthRange(password, MAX_PASSWORD_INPUT, MIN_PASSWORD_INPUT)) {
-      setPasswordErrorMessage(PASSWORD_LENGTH_ERROR_MESSAGE);
-      return;
+      return setPasswordErrorMessage(PASSWORD_LENGTH_ERROR_MESSAGE);
     }
     if (!isAlphanumeric(password)) {
-      setPasswordErrorMessage(INVALID_CHAR_ERROR_MESSAGE);
-      return;
+      return setPasswordErrorMessage(INVALID_CHAR_ERROR_MESSAGE);
     }
-    setPasswordErrorMessage(''); 
+    return setPasswordErrorMessage('');
   };
 
   const handlePasswordBlur = () => {
-    setHasBlurred(true); 
+    setHasBlurred(true);
     validatePassword();
   };
 
   useEffect(() => {
     if (hasBlurred) validatePassword();
-    
   }, [password, hasBlurred]);
 
   return {

--- a/frontend/src/hooks/usePasswordValidation.ts
+++ b/frontend/src/hooks/usePasswordValidation.ts
@@ -12,7 +12,7 @@ const PASSWORD_LENGTH_ERROR_MESSAGE = `${MIN_PASSWORD_INPUT}자부터 ${MAX_PASS
 
 export const usePasswordValidation = (password: string) => {
   const [passwordErrorMessage, setPasswordErrorMessage] = useState('');
-  const [hasBlurred, setHasBlurred] = useState(false);
+  const [isBlurredOnce, setIsBlurredOnce] = useState(false);
 
   const validatePassword = () => {
     if (!isWithinLengthRange(password, MAX_PASSWORD_INPUT, MIN_PASSWORD_INPUT)) {
@@ -25,13 +25,13 @@ export const usePasswordValidation = (password: string) => {
   };
 
   const handlePasswordBlur = () => {
-    setHasBlurred(true);
+    setIsBlurredOnce(true);
     validatePassword();
   };
 
   useEffect(() => {
-    if (hasBlurred) validatePassword();
-  }, [password, hasBlurred]);
+    if (isBlurredOnce) validatePassword();
+  }, [password, isBlurredOnce]);
 
   return {
     passwordErrorMessage,

--- a/frontend/src/hooks/usePasswordValidation.ts
+++ b/frontend/src/hooks/usePasswordValidation.ts
@@ -1,0 +1,43 @@
+import { useState, useEffect } from 'react';
+
+import {
+  isWithinLengthRange,
+  isAlphanumeric,
+  MAX_PASSWORD_INPUT,
+  MIN_PASSWORD_INPUT,
+} from '../../src/pages/HomePage/utils/validateInput';
+
+const INVALID_CHAR_ERROR_MESSAGE = `영문(대/소문자) 및 숫자만 입력할 수 있습니다`;
+const PASSWORD_LENGTH_ERROR_MESSAGE = `${MIN_PASSWORD_INPUT}자부터 ${MAX_PASSWORD_INPUT}자까지 입력할 수 있습니다`;
+
+export const usePasswordValidation = (password: string) => {
+  const [passwordErrorMessage, setPasswordErrorMessage] = useState('');
+  const [hasBlurred, setHasBlurred] = useState(false); 
+
+  const validatePassword = () => {
+    if (!isWithinLengthRange(password, MAX_PASSWORD_INPUT, MIN_PASSWORD_INPUT)) {
+      setPasswordErrorMessage(PASSWORD_LENGTH_ERROR_MESSAGE);
+      return;
+    }
+    if (!isAlphanumeric(password)) {
+      setPasswordErrorMessage(INVALID_CHAR_ERROR_MESSAGE);
+      return;
+    }
+    setPasswordErrorMessage(''); 
+  };
+
+  const handlePasswordBlur = () => {
+    setHasBlurred(true); 
+    validatePassword();
+  };
+
+  useEffect(() => {
+    if (hasBlurred) validatePassword();
+    
+  }, [password, hasBlurred]);
+
+  return {
+    passwordErrorMessage,
+    handlePasswordBlur,
+  };
+};

--- a/frontend/src/pages/HomePage/components/URLGeneratorForm/index.tsx
+++ b/frontend/src/pages/HomePage/components/URLGeneratorForm/index.tsx
@@ -51,8 +51,8 @@ const URLGeneratorForm = () => {
     isValidReviewGroupDataInput(revieweeName) &&
     isValidReviewGroupDataInput(projectName) &&
     !isNotEmptyInput(passwordErrorMessage); // NOTE: 에러 메세지가 빈 문자열이라면 비밀번호는 유효하다.
-    // TODO: 현재 비밀번호만 다른 방식으로 유효성 검증을 하고 있으므로
-    // 코드의 통일성을 위해 revieweeName, projectName에 대한 검증도 비밀번호와 비슷한 형식으로 리팩토링하기
+  // TODO: 현재 비밀번호만 다른 방식으로 유효성 검증을 하고 있으므로
+  // 코드의 통일성을 위해 revieweeName, projectName에 대한 검증도 비밀번호와 비슷한 형식으로 리팩토링하기
 
   const postDataForURL = () => {
     const dataForReviewRequestCode: DataForReviewRequestCode = { revieweeName, projectName, groupAccessCode: password };
@@ -109,7 +109,7 @@ const URLGeneratorForm = () => {
 
   return (
     <S.URLGeneratorForm>
-      <FormLayout title="함께한 팀원에게 리뷰를 받아보세요!" direction="column">
+      <FormLayout title="함께한 팀원으로부터 리뷰를 받아보세요!" direction="column">
         <S.InputContainer>
           <S.Label htmlFor="reviewee-name">본인의 이름을 적어주세요</S.Label>
           <Input

--- a/frontend/src/pages/HomePage/components/URLGeneratorForm/index.tsx
+++ b/frontend/src/pages/HomePage/components/URLGeneratorForm/index.tsx
@@ -25,8 +25,8 @@ import * as S from './styles';
 const DEBOUNCE_TIME = 300;
 
 const INVALID_CHAR_ERROR_MESSAGE = `영문(대/소문자) 및 숫자만 입력할 수 있습니다`;
-const GROUP_DATA_LENGTH_ERROR_MESSAGE = `최대 ${MAX_VALID_REVIEW_GROUP_DATA_INPUT}자까지 입력할 수 있습니다.`;
-const PASSWORD_LENGTH_ERROR_MESSAGE = `${MIN_PASSWORD_INPUT}자부터 ${MAX_PASSWORD_INPUT}자까지 입력할 수 있습니다.`;
+const GROUP_DATA_LENGTH_ERROR_MESSAGE = `최대 ${MAX_VALID_REVIEW_GROUP_DATA_INPUT}자까지 입력할 수 있습니다`;
+const PASSWORD_LENGTH_ERROR_MESSAGE = `${MIN_PASSWORD_INPUT}자부터 ${MAX_PASSWORD_INPUT}자까지 입력할 수 있습니다`;
 
 const MODAL_KEYS = {
   confirm: 'CONFIRM',
@@ -95,6 +95,14 @@ const URLGeneratorForm = () => {
     openModal(MODAL_KEYS.confirm);
   }, DEBOUNCE_TIME);
 
+  const handlePasswordBlur = () => {
+    if (!isWithinLengthRange(password, MAX_PASSWORD_INPUT, MIN_PASSWORD_INPUT)) {
+      setPasswordErrorMessage(PASSWORD_LENGTH_ERROR_MESSAGE);
+    } else {
+      setPasswordErrorMessage('');
+    }
+  };
+
   useEffect(() => {
     isWithinLengthRange(revieweeName, MAX_VALID_REVIEW_GROUP_DATA_INPUT)
       ? setRevieweeNameErrorMessage('')
@@ -108,19 +116,15 @@ const URLGeneratorForm = () => {
   }, [revieweeName]);
 
   useEffect(() => {
-    // NOTE: URL 요청 버튼 활성화 조건에서는 최소 4자 조건도 체크하지만,
-    // 여기서(비밀번호 에러 메세지 설정)는 min 값을 검사하지 않음
-    // 현재 onFocus 등의 처리가 없어 항상 에러 메세지가 뜨기 때문
-    // 추후 textarea처럼 onfocus, onblur에 대한 훅 사용 예정
     if (!isWithinLengthRange(password, MAX_PASSWORD_INPUT)) {
       setPasswordErrorMessage(PASSWORD_LENGTH_ERROR_MESSAGE);
       return;
     }
+
     if (!isAlphanumeric(password)) {
       setPasswordErrorMessage(INVALID_CHAR_ERROR_MESSAGE);
       return;
     }
-
     setPasswordErrorMessage('');
   }, [password]);
 
@@ -157,6 +161,7 @@ const URLGeneratorForm = () => {
               id="password"
               value={password}
               onChange={handlePasswordInputChange}
+              onBlur={handlePasswordBlur}
               type={isOff ? 'password' : 'text'}
               placeholder="abc123"
               $style={{ width: '100%', paddingRight: '3rem' }}

--- a/frontend/src/pages/HomePage/components/URLGeneratorForm/index.tsx
+++ b/frontend/src/pages/HomePage/components/URLGeneratorForm/index.tsx
@@ -23,7 +23,7 @@ import * as S from './styles';
 // TODO: 디바운스 시간을 모든 경우에 0.3초로 고정할 것인지(전역 상수로 사용) 논의하기
 const DEBOUNCE_TIME = 300;
 
-const GROUP_DATA_LENGTH_ERROR_MESSAGE = `최대 ${MAX_VALID_REVIEW_GROUP_DATA_INPUT}자까지 입력할 수 있습니다`;
+const GROUP_DATA_LENGTH_ERROR_MESSAGE = `최대 ${MAX_VALID_REVIEW_GROUP_DATA_INPUT}자까지 입력할 수 있어요`;
 
 const MODAL_KEYS = {
   confirm: 'CONFIRM',

--- a/frontend/src/pages/HomePage/components/URLGeneratorForm/index.tsx
+++ b/frontend/src/pages/HomePage/components/URLGeneratorForm/index.tsx
@@ -11,22 +11,19 @@ import usePostDataForReviewRequestCode from '../../queries/usePostDataForReviewR
 import {
   isValidReviewGroupDataInput,
   isWithinLengthRange,
-  isAlphanumeric,
   MAX_PASSWORD_INPUT,
   MAX_VALID_REVIEW_GROUP_DATA_INPUT,
   MIN_PASSWORD_INPUT,
-  isValidPasswordInput,
 } from '../../utils/validateInput';
 import { FormLayout, ReviewZoneURLModal } from '../index';
 
+import { usePasswordValidation } from './../../../../hooks/usePasswordValidation';
 import * as S from './styles';
 
 // TODO: 디바운스 시간을 모든 경우에 0.3초로 고정할 것인지(전역 상수로 사용) 논의하기
 const DEBOUNCE_TIME = 300;
 
-const INVALID_CHAR_ERROR_MESSAGE = `영문(대/소문자) 및 숫자만 입력할 수 있습니다`;
 const GROUP_DATA_LENGTH_ERROR_MESSAGE = `최대 ${MAX_VALID_REVIEW_GROUP_DATA_INPUT}자까지 입력할 수 있습니다`;
-const PASSWORD_LENGTH_ERROR_MESSAGE = `${MIN_PASSWORD_INPUT}자부터 ${MAX_PASSWORD_INPUT}자까지 입력할 수 있습니다`;
 
 const MODAL_KEYS = {
   confirm: 'CONFIRM',
@@ -43,16 +40,17 @@ const URLGeneratorForm = () => {
 
   const [revieweeNameErrorMessage, setRevieweeNameErrorMessage] = useState('');
   const [projectNameErrorMessage, setProjectNameErrorMessage] = useState('');
-  const [passwordErrorMessage, setPasswordErrorMessage] = useState('');
+  //const [passwordErrorMessage, setPasswordErrorMessage] = useState('');
 
   const mutation = usePostDataForReviewRequestCode();
   const { isOff, handleEyeButtonToggle } = useEyeButton();
   const { isOpen, openModal, closeModal } = useModals();
+  const { passwordErrorMessage, handlePasswordBlur } = usePasswordValidation(password);
 
   const isFormValid =
     isValidReviewGroupDataInput(revieweeName) &&
     isValidReviewGroupDataInput(projectName) &&
-    isValidPasswordInput(password);
+    passwordErrorMessage === '';
 
   const postDataForURL = () => {
     const dataForReviewRequestCode: DataForReviewRequestCode = { revieweeName, projectName, groupAccessCode: password };
@@ -95,14 +93,6 @@ const URLGeneratorForm = () => {
     openModal(MODAL_KEYS.confirm);
   }, DEBOUNCE_TIME);
 
-  const handlePasswordBlur = () => {
-    if (!isWithinLengthRange(password, MAX_PASSWORD_INPUT, MIN_PASSWORD_INPUT)) {
-      setPasswordErrorMessage(PASSWORD_LENGTH_ERROR_MESSAGE);
-    } else {
-      setPasswordErrorMessage('');
-    }
-  };
-
   useEffect(() => {
     isWithinLengthRange(revieweeName, MAX_VALID_REVIEW_GROUP_DATA_INPUT)
       ? setRevieweeNameErrorMessage('')
@@ -114,19 +104,6 @@ const URLGeneratorForm = () => {
       ? setProjectNameErrorMessage('')
       : setProjectNameErrorMessage(GROUP_DATA_LENGTH_ERROR_MESSAGE);
   }, [projectName]);
-
-  useEffect(() => {
-    if (!isWithinLengthRange(password, MAX_PASSWORD_INPUT)) {
-      setPasswordErrorMessage(PASSWORD_LENGTH_ERROR_MESSAGE);
-      return;
-    }
-
-    if (!isAlphanumeric(password)) {
-      setPasswordErrorMessage(INVALID_CHAR_ERROR_MESSAGE);
-      return;
-    }
-    setPasswordErrorMessage('');
-  }, [password]);
 
   return (
     <S.URLGeneratorForm>

--- a/frontend/src/pages/HomePage/components/URLGeneratorForm/index.tsx
+++ b/frontend/src/pages/HomePage/components/URLGeneratorForm/index.tsx
@@ -32,15 +32,14 @@ const MODAL_KEYS = {
 const URLGeneratorForm = () => {
   const [revieweeName, setRevieweeName] = useState('');
   const [projectName, setProjectName] = useState('');
-  // NOTE: 이 password는 groupAccessCode로 사용됨.
+  // NOTE: 이 password는 groupAccessCode로 사용됩니다.
   // groupAccessCode로 통일하기로 했지만 이미 이 페이지에서는 pwd로 작업한 게 많아서 놔두고
-  // API 요청 함수와 리액트 쿼리 코드에서는 groupAccessCode: password로 전달합니다
+  // API 요청 함수와 리액트 쿼리 코드에서는 groupAccessCode: password로 전달합니다.
   const [password, setPassword] = useState('');
   const [reviewZoneURL, setReviewZoneURL] = useState('');
 
   const [revieweeNameErrorMessage, setRevieweeNameErrorMessage] = useState('');
   const [projectNameErrorMessage, setProjectNameErrorMessage] = useState('');
-  //const [passwordErrorMessage, setPasswordErrorMessage] = useState('');
 
   const mutation = usePostDataForReviewRequestCode();
   const { isOff, handleEyeButtonToggle } = useEyeButton();

--- a/frontend/src/pages/HomePage/components/URLGeneratorForm/index.tsx
+++ b/frontend/src/pages/HomePage/components/URLGeneratorForm/index.tsx
@@ -113,7 +113,7 @@ const URLGeneratorForm = () => {
     isWithinLengthRange(projectName, MAX_VALID_REVIEW_GROUP_DATA_INPUT)
       ? setProjectNameErrorMessage('')
       : setProjectNameErrorMessage(GROUP_DATA_LENGTH_ERROR_MESSAGE);
-  }, [revieweeName]);
+  }, [projectName]);
 
   useEffect(() => {
     if (!isWithinLengthRange(password, MAX_PASSWORD_INPUT)) {

--- a/frontend/src/pages/HomePage/components/URLGeneratorForm/index.tsx
+++ b/frontend/src/pages/HomePage/components/URLGeneratorForm/index.tsx
@@ -9,6 +9,7 @@ import { debounce } from '@/utils/debounce';
 
 import usePostDataForReviewRequestCode from '../../queries/usePostDataForReviewRequestCode';
 import {
+  isNotEmptyInput,
   isValidReviewGroupDataInput,
   isWithinLengthRange,
   MAX_PASSWORD_INPUT,
@@ -49,7 +50,9 @@ const URLGeneratorForm = () => {
   const isFormValid =
     isValidReviewGroupDataInput(revieweeName) &&
     isValidReviewGroupDataInput(projectName) &&
-    passwordErrorMessage === '';
+    !isNotEmptyInput(passwordErrorMessage); // NOTE: 에러 메세지가 빈 문자열이라면 비밀번호는 유효하다.
+    // TODO: 현재 비밀번호만 다른 방식으로 유효성 검증을 하고 있으므로
+    // 코드의 통일성을 위해 revieweeName, projectName에 대한 검증도 비밀번호와 비슷한 형식으로 리팩토링하기
 
   const postDataForURL = () => {
     const dataForReviewRequestCode: DataForReviewRequestCode = { revieweeName, projectName, groupAccessCode: password };


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #431 

---

### 🚀 어떤 기능을 구현했나요 ?
- 비밀번호 유효성 검증 훅을 분리했습니다.
- 비밀번호 Input에 onBlur 이벤트를 통해 사용자가 유효하지 않은 길이의 입력을 한 뒤 포커스를 옮기면 길이에 대한 에러 문구가 뜨도록 만들었습니다. 
- Input 컴포넌트에 onBlur 이벤트를 optional로 추가했습니다.

### 🔥 어떻게 해결했나요 ?
- 비밀번호 유효성 검증 훅
  - 역할/책임의 분리 측면도 있지만 비밀번호 검증을 다른 페이지에서도 사용하기 때문에 분리했습니다.
  - Input의 onBlur 이벤트 핸들러와 비밀번호 관련 에러 문구를 리턴합니다.
  - 비밀번호 입력이 변하고 블러 상태가 true일 때만 유효성 검증을 통해 에러 문구를 설정합니다.
 
### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 비밀번호 확인 모달에서도 onBlur를 사용해서 유효성 검증을 할까요?

### 📚 참고 자료, 할 말
- HomePage 폼 리팩토링 언제 하지