### PR TITLE
[BE] refactor: GroupAccessCode를 발급하지 않고 사용자가 직접 입력하면서 변경되는 사항을 반영

### DIFF
--- a/backend/src/main/java/reviewme/global/exception/UnexpectedRequestException.java
+++ b/backend/src/main/java/reviewme/global/exception/UnexpectedRequestException.java
@@ -1,8 +1,12 @@
 package reviewme.global.exception;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public abstract class UnexpectedRequestException extends ReviewMeException {
 
     protected UnexpectedRequestException(String errorMessage) {
         super(errorMessage);
+        log.warn("", this);
     }
 }

--- a/backend/src/main/java/reviewme/review/controller/ReviewController.java
+++ b/backend/src/main/java/reviewme/review/controller/ReviewController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import reviewme.global.HeaderProperty;
 import reviewme.review.service.CreateReviewService;
@@ -35,17 +36,22 @@ public class ReviewController {
 
     @GetMapping("/v2/reviews")
     public ResponseEntity<ReceivedReviewsResponse> findReceivedReviews(
+            @RequestParam String reviewRequestCode,
             @HeaderProperty(GROUP_ACCESS_CODE_HEADER) String groupAccessCode
     ) {
-        ReceivedReviewsResponse response = reviewService.findReceivedReviews(groupAccessCode);
+        ReceivedReviewsResponse response = reviewService.findReceivedReviews(reviewRequestCode, groupAccessCode);
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/v2/reviews/{id}")
     public ResponseEntity<TemplateAnswerResponse> findReceivedReviewDetail(
             @PathVariable long id,
-            @HeaderProperty(GROUP_ACCESS_CODE_HEADER) String groupAccessCode) {
-        TemplateAnswerResponse response = reviewDetailLookupService.getReviewDetail(groupAccessCode, id);
+            @RequestParam String reviewRequestCode,
+            @HeaderProperty(GROUP_ACCESS_CODE_HEADER) String groupAccessCode
+    ) {
+        TemplateAnswerResponse response = reviewDetailLookupService.getReviewDetail(
+                id, reviewRequestCode, groupAccessCode
+        );
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/reviewme/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/reviewme/review/repository/ReviewRepository.java
@@ -14,4 +14,14 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findReceivedReviewsByGroupId(long reviewGroupId);
 
     Optional<Review> findByIdAndReviewGroupId(long reviewId, long reviewGroupId);
+
+    @Query(value = """
+            SELECT r.* FROM review r
+            INNER JOIN review_group rg
+            ON rg.id = r.review_group_id
+            WHERE r.id = :reviewId
+            AND rg.review_request_code = :reviewRequestCode
+            AND rg.group_access_code = :groupAccessCode
+            """, nativeQuery = true)
+    Optional<Review> findByIdAndCodes(long reviewId, String reviewRequestCode, String groupAccessCode);
 }

--- a/backend/src/main/java/reviewme/review/service/ReviewDetailLookupService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewDetailLookupService.java
@@ -15,14 +15,14 @@ import reviewme.review.domain.CheckboxAnswers;
 import reviewme.review.domain.Review;
 import reviewme.review.domain.TextAnswer;
 import reviewme.review.domain.TextAnswers;
-import reviewme.review.domain.exception.InvalidReviewAccessByReviewGroupException;
-import reviewme.review.domain.exception.ReviewGroupNotFoundByGroupAccessCodeException;
 import reviewme.review.repository.ReviewRepository;
 import reviewme.review.service.dto.response.detail.OptionGroupAnswerResponse;
 import reviewme.review.service.dto.response.detail.OptionItemAnswerResponse;
 import reviewme.review.service.dto.response.detail.QuestionAnswerResponse;
 import reviewme.review.service.dto.response.detail.SectionAnswerResponse;
 import reviewme.review.service.dto.response.detail.TemplateAnswerResponse;
+import reviewme.review.service.exception.ReviewGroupNotFoundByReviewException;
+import reviewme.review.service.exception.ReviewNotFoundByIdAndCodesException;
 import reviewme.reviewgroup.domain.ReviewGroup;
 import reviewme.reviewgroup.repository.ReviewGroupRepository;
 import reviewme.template.domain.Section;
@@ -41,12 +41,13 @@ public class ReviewDetailLookupService {
     private final OptionItemRepository optionItemRepository;
     private final OptionGroupRepository optionGroupRepository;
 
-    public TemplateAnswerResponse getReviewDetail(String groupAccessCode, long reviewId) {
-        ReviewGroup reviewGroup = reviewGroupRepository.findByGroupAccessCode(groupAccessCode)
-                .orElseThrow(() -> new ReviewGroupNotFoundByGroupAccessCodeException(groupAccessCode));
+    public TemplateAnswerResponse getReviewDetail(long reviewId, String reviewRequestCode, String groupAccessCode) {
+        Review review = reviewRepository.findByIdAndCodes(reviewId, reviewRequestCode, groupAccessCode)
+                .orElseThrow(() -> new ReviewNotFoundByIdAndCodesException(reviewId, reviewRequestCode, groupAccessCode));
 
-        Review review = reviewRepository.findByIdAndReviewGroupId(reviewId, reviewGroup.getId())
-                .orElseThrow(() -> new InvalidReviewAccessByReviewGroupException(reviewId, reviewGroup.getId()));
+        ReviewGroup reviewGroup = reviewGroupRepository.findById(review.getReviewGroupId())
+                .orElseThrow(() -> new ReviewGroupNotFoundByReviewException(review.getId(), review.getReviewGroupId()));
+
         long templateId = review.getTemplateId();
 
         List<Section> sections = sectionRepository.findAllByTemplateId(templateId);

--- a/backend/src/main/java/reviewme/review/service/ReviewService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewService.java
@@ -8,7 +8,6 @@ import reviewme.question.domain.OptionItem;
 import reviewme.question.domain.OptionType;
 import reviewme.question.repository.OptionItemRepository;
 import reviewme.review.domain.Review;
-import reviewme.review.domain.exception.ReviewGroupNotFoundByGroupAccessCodeException;
 import reviewme.review.repository.ReviewRepository;
 import reviewme.review.service.dto.response.list.ReceivedReviewCategoryResponse;
 import reviewme.review.service.dto.response.list.ReceivedReviewResponse;
@@ -29,11 +28,9 @@ public class ReviewService {
 
     @Transactional(readOnly = true)
     public ReceivedReviewsResponse findReceivedReviews(String reviewRequestCode, String groupAccessCode) {
-        reviewGroupRepository.findByReviewRequestCodeAndGroupAccessCode(reviewRequestCode, groupAccessCode)
+        ReviewGroup reviewGroup = reviewGroupRepository
+                .findByReviewRequestCodeAndGroupAccessCode(reviewRequestCode, groupAccessCode)
                 .orElseThrow(() -> new ReviewGroupNotFoundByCodesException(reviewRequestCode, groupAccessCode));
-
-        ReviewGroup reviewGroup = reviewGroupRepository.findByGroupAccessCode(groupAccessCode)
-                .orElseThrow(() -> new ReviewGroupNotFoundByGroupAccessCodeException(groupAccessCode));
 
         List<ReceivedReviewResponse> reviewResponses =
                 reviewRepository.findReceivedReviewsByGroupId(reviewGroup.getId())

--- a/backend/src/main/java/reviewme/review/service/ReviewService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewService.java
@@ -13,6 +13,7 @@ import reviewme.review.repository.ReviewRepository;
 import reviewme.review.service.dto.response.list.ReceivedReviewCategoryResponse;
 import reviewme.review.service.dto.response.list.ReceivedReviewResponse;
 import reviewme.review.service.dto.response.list.ReceivedReviewsResponse;
+import reviewme.review.service.exception.ReviewGroupNotFoundByCodesException;
 import reviewme.reviewgroup.domain.ReviewGroup;
 import reviewme.reviewgroup.repository.ReviewGroupRepository;
 
@@ -27,7 +28,10 @@ public class ReviewService {
     private final ReviewPreviewGenerator reviewPreviewGenerator = new ReviewPreviewGenerator();
 
     @Transactional(readOnly = true)
-    public ReceivedReviewsResponse findReceivedReviews(String groupAccessCode) {
+    public ReceivedReviewsResponse findReceivedReviews(String reviewRequestCode, String groupAccessCode) {
+        reviewGroupRepository.findByReviewRequestCodeAndGroupAccessCode(reviewRequestCode, groupAccessCode)
+                .orElseThrow(() -> new ReviewGroupNotFoundByCodesException(reviewRequestCode, groupAccessCode));
+
         ReviewGroup reviewGroup = reviewGroupRepository.findByGroupAccessCode(groupAccessCode)
                 .orElseThrow(() -> new ReviewGroupNotFoundByGroupAccessCodeException(groupAccessCode));
 

--- a/backend/src/main/java/reviewme/review/service/ReviewService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewService.java
@@ -29,7 +29,7 @@ public class ReviewService {
     @Transactional(readOnly = true)
     public ReceivedReviewsResponse findReceivedReviews(String reviewRequestCode, String groupAccessCode) {
         ReviewGroup reviewGroup = reviewGroupRepository
-                .findByReviewRequestCodeAndGroupAccessCode(reviewRequestCode, groupAccessCode)
+                .findByReviewRequestCodeAndGroupAccessCode_Code(reviewRequestCode, groupAccessCode)
                 .orElseThrow(() -> new ReviewGroupNotFoundByCodesException(reviewRequestCode, groupAccessCode));
 
         List<ReceivedReviewResponse> reviewResponses =

--- a/backend/src/main/java/reviewme/review/service/exception/ReviewGroupNotFoundByCodesException.java
+++ b/backend/src/main/java/reviewme/review/service/exception/ReviewGroupNotFoundByCodesException.java
@@ -5,8 +5,10 @@ import reviewme.global.exception.BadRequestException;
 
 @Slf4j
 public class ReviewGroupNotFoundByCodesException extends BadRequestException {
+
     public ReviewGroupNotFoundByCodesException(String reviewRequestCode, String groupAccessCode) {
-        super("리뷰 그룹 정보와 일치하는 정보가 없어요");
-        log.info("");
+        super("코드에 해당하는 리뷰 그룹이 없어요.");
+        log.info("ReviewGroup not found by codes - reviewRequestCode: {}, groupAccessCode: {}",
+                reviewRequestCode, groupAccessCode);
     }
 }

--- a/backend/src/main/java/reviewme/review/service/exception/ReviewGroupNotFoundByCodesException.java
+++ b/backend/src/main/java/reviewme/review/service/exception/ReviewGroupNotFoundByCodesException.java
@@ -7,7 +7,7 @@ import reviewme.global.exception.BadRequestException;
 public class ReviewGroupNotFoundByCodesException extends BadRequestException {
 
     public ReviewGroupNotFoundByCodesException(String reviewRequestCode, String groupAccessCode) {
-        super("코드에 해당하는 리뷰 그룹이 없어요.");
+        super("인증 정보에 해당하는 리뷰 확인 코드와 리뷰 요청 코드를 통해 찾을 수 있는 리뷰 그룹이 없어요.");
         log.info("ReviewGroup not found by codes - reviewRequestCode: {}, groupAccessCode: {}",
                 reviewRequestCode, groupAccessCode);
     }

--- a/backend/src/main/java/reviewme/review/service/exception/ReviewGroupNotFoundByCodesException.java
+++ b/backend/src/main/java/reviewme/review/service/exception/ReviewGroupNotFoundByCodesException.java
@@ -1,0 +1,12 @@
+package reviewme.review.service.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import reviewme.global.exception.BadRequestException;
+
+@Slf4j
+public class ReviewGroupNotFoundByCodesException extends BadRequestException {
+    public ReviewGroupNotFoundByCodesException(String reviewRequestCode, String groupAccessCode) {
+        super("리뷰 그룹 정보와 일치하는 정보가 없어요");
+        log.info("");
+    }
+}

--- a/backend/src/main/java/reviewme/review/service/exception/ReviewGroupNotFoundByReviewException.java
+++ b/backend/src/main/java/reviewme/review/service/exception/ReviewGroupNotFoundByReviewException.java
@@ -1,0 +1,13 @@
+package reviewme.review.service.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import reviewme.global.exception.DataInconsistencyException;
+
+@Slf4j
+public class ReviewGroupNotFoundByReviewException extends DataInconsistencyException {
+
+    public ReviewGroupNotFoundByReviewException(long reviewId, long reviewGroupId) {
+        super("서버 내부에서 문제가 발생했어요. 서버에 문의해주세요.");
+        log.error("ReviewGroup not found from review - reviewId: {}, reviewGroupId: {}", reviewId, reviewGroupId);
+    }
+}

--- a/backend/src/main/java/reviewme/review/service/exception/ReviewNotFoundByIdAndCodesException.java
+++ b/backend/src/main/java/reviewme/review/service/exception/ReviewNotFoundByIdAndCodesException.java
@@ -1,0 +1,14 @@
+package reviewme.review.service.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import reviewme.global.exception.NotFoundException;
+
+@Slf4j
+public class ReviewNotFoundByIdAndCodesException extends NotFoundException {
+
+    public ReviewNotFoundByIdAndCodesException(long reviewId, String reviewRequestCode, String groupAccessCode) {
+        super("리뷰를 찾을 수 없어요");
+        log.info("Review not found - reviewId: {}, reviewRequestCode: {}, groupAccessCode: {}",
+                reviewId, reviewRequestCode, groupAccessCode);
+    }
+}

--- a/backend/src/main/java/reviewme/reviewgroup/domain/GroupAccessCode.java
+++ b/backend/src/main/java/reviewme/reviewgroup/domain/GroupAccessCode.java
@@ -17,11 +17,11 @@ public class GroupAccessCode {
     private static final Pattern PATTERN = Pattern.compile("^[a-zA-Z0-9]{4,20}$");
 
     @Column(name = "group_access_code", nullable = false)
-    private String groupAccessCode;
+    private String code;
 
-    public GroupAccessCode(String groupAccessCode) {
-        validateGroupAccessCode(groupAccessCode);
-        this.groupAccessCode = groupAccessCode;
+    public GroupAccessCode(String code) {
+        validateGroupAccessCode(code);
+        this.code = code;
     }
 
     private void validateGroupAccessCode(String groupAccessCode) {

--- a/backend/src/main/java/reviewme/reviewgroup/domain/GroupAccessCode.java
+++ b/backend/src/main/java/reviewme/reviewgroup/domain/GroupAccessCode.java
@@ -1,0 +1,34 @@
+package reviewme.reviewgroup.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import reviewme.reviewgroup.domain.exception.InvalidGroupAccessCodeFormatException;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class GroupAccessCode {
+
+    private static final Pattern PATTERN = Pattern.compile("^[a-zA-Z0-9]{4,20}$");
+
+    @Column(name = "group_access_code", nullable = false)
+    private String groupAccessCode;
+
+    public GroupAccessCode(String groupAccessCode) {
+        validateGroupAccessCode(groupAccessCode);
+        this.groupAccessCode = groupAccessCode;
+    }
+
+    private void validateGroupAccessCode(String groupAccessCode) {
+        Matcher matcher = PATTERN.matcher(groupAccessCode);
+        if (!matcher.matches()) {
+            throw new InvalidGroupAccessCodeFormatException(groupAccessCode);
+        }
+    }
+}
+

--- a/backend/src/main/java/reviewme/reviewgroup/domain/ReviewGroup.java
+++ b/backend/src/main/java/reviewme/reviewgroup/domain/ReviewGroup.java
@@ -67,6 +67,6 @@ public class ReviewGroup {
     }
 
     public String getGroupAccessCode() {
-        return groupAccessCode.getGroupAccessCode();
+        return groupAccessCode.getCode();
     }
 }

--- a/backend/src/main/java/reviewme/reviewgroup/domain/ReviewGroup.java
+++ b/backend/src/main/java/reviewme/reviewgroup/domain/ReviewGroup.java
@@ -1,6 +1,7 @@
 package reviewme.reviewgroup.domain;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -36,8 +37,8 @@ public class ReviewGroup {
     @Column(name = "review_request_code", nullable = false)
     private String reviewRequestCode;
 
-    @Column(name = "group_access_code", nullable = false)
-    private String groupAccessCode;
+    @Embedded
+    private GroupAccessCode groupAccessCode;
 
     @Column(name = "template_id", nullable = false)
     private long templateId = 1L;
@@ -48,7 +49,7 @@ public class ReviewGroup {
         this.reviewee = reviewee;
         this.projectName = projectName;
         this.reviewRequestCode = reviewRequestCode;
-        this.groupAccessCode = groupAccessCode;
+        this.groupAccessCode = new GroupAccessCode(groupAccessCode);
     }
 
     private void validateRevieweeLength(String reviewee) {
@@ -63,5 +64,9 @@ public class ReviewGroup {
                     projectName.length(), MIN_PROJECT_NAME_LENGTH, MAX_PROJECT_NAME_LENGTH
             );
         }
+    }
+
+    public String getGroupAccessCode() {
+        return groupAccessCode.getGroupAccessCode();
     }
 }

--- a/backend/src/main/java/reviewme/reviewgroup/domain/exception/InvalidGroupAccessCodeFormatException.java
+++ b/backend/src/main/java/reviewme/reviewgroup/domain/exception/InvalidGroupAccessCodeFormatException.java
@@ -1,0 +1,13 @@
+package reviewme.reviewgroup.domain.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import reviewme.global.exception.BadRequestException;
+
+@Slf4j
+public class InvalidGroupAccessCodeFormatException extends BadRequestException {
+
+    public InvalidGroupAccessCodeFormatException(String groupAccessCode) {
+        super("그룹 액세스 코드 형식이 올바르지 않아요.");
+        log.warn("Invalid groupAccessCode format - groupAccessCode: {}", groupAccessCode);
+    }
+}

--- a/backend/src/main/java/reviewme/reviewgroup/repository/ReviewGroupRepository.java
+++ b/backend/src/main/java/reviewme/reviewgroup/repository/ReviewGroupRepository.java
@@ -2,7 +2,6 @@ package reviewme.reviewgroup.repository;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import reviewme.reviewgroup.domain.ReviewGroup;
 
@@ -11,23 +10,9 @@ public interface ReviewGroupRepository extends JpaRepository<ReviewGroup, Long> 
 
     Optional<ReviewGroup> findByReviewRequestCode(String reviewRequestCode);
 
-    @Query(value = """
-            SELECT rg.* FROM review_group rg
-            WHERE rg.review_request_code = :reviewRequestCode
-            AND rg.group_access_code = :groupAccessCode
-            """, nativeQuery = true
-    )
-    Optional<ReviewGroup> findByReviewRequestCodeAndGroupAccessCode(String reviewRequestCode, String groupAccessCode);
+    Optional<ReviewGroup> findByReviewRequestCodeAndGroupAccessCode_Code(String reviewRequestCode, String groupAccessCode);
 
     boolean existsByReviewRequestCode(String reviewRequestCode);
 
-    @Query(value = """
-            SELECT EXISTS(
-                SELECT 1 FROM review_group rg
-                WHERE rg.review_request_code = :reviewRequestCode
-                AND rg.group_access_code = :groupAccessCode
-            )
-            """, nativeQuery = true
-    )
-    boolean existsByReviewRequestCodeAndGroupAccessCode(String reviewRequestCode, String groupAccessCode);
+    boolean existsByReviewRequestCodeAndGroupAccessCode_Code(String reviewRequestCode, String groupAccessCode);
 }

--- a/backend/src/main/java/reviewme/reviewgroup/repository/ReviewGroupRepository.java
+++ b/backend/src/main/java/reviewme/reviewgroup/repository/ReviewGroupRepository.java
@@ -12,6 +12,8 @@ public interface ReviewGroupRepository extends JpaRepository<ReviewGroup, Long> 
 
     Optional<ReviewGroup> findByGroupAccessCode(String groupAccessCode);
 
+    Optional<ReviewGroup> findByReviewRequestCodeAndGroupAccessCode(String reviewRequestCode, String groupAccessCode);
+
     boolean existsByReviewRequestCode(String reviewRequestCode);
 
     boolean existsByGroupAccessCode(String groupAccessCode);

--- a/backend/src/main/java/reviewme/reviewgroup/repository/ReviewGroupRepository.java
+++ b/backend/src/main/java/reviewme/reviewgroup/repository/ReviewGroupRepository.java
@@ -2,6 +2,7 @@ package reviewme.reviewgroup.repository;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import reviewme.reviewgroup.domain.ReviewGroup;
 
@@ -10,13 +11,23 @@ public interface ReviewGroupRepository extends JpaRepository<ReviewGroup, Long> 
 
     Optional<ReviewGroup> findByReviewRequestCode(String reviewRequestCode);
 
-    Optional<ReviewGroup> findByGroupAccessCode(String groupAccessCode);
-
+    @Query(value = """
+            SELECT rg.* FROM review_group rg
+            WHERE rg.review_request_code = :reviewRequestCode
+            AND rg.group_access_code = :groupAccessCode
+            """, nativeQuery = true
+    )
     Optional<ReviewGroup> findByReviewRequestCodeAndGroupAccessCode(String reviewRequestCode, String groupAccessCode);
 
     boolean existsByReviewRequestCode(String reviewRequestCode);
 
-    boolean existsByGroupAccessCode(String groupAccessCode);
-
+    @Query(value = """
+            SELECT EXISTS(
+                SELECT 1 FROM review_group rg
+                WHERE rg.review_request_code = :reviewRequestCode
+                AND rg.group_access_code = :groupAccessCode
+            )
+            """, nativeQuery = true
+    )
     boolean existsByReviewRequestCodeAndGroupAccessCode(String reviewRequestCode, String groupAccessCode);
 }

--- a/backend/src/main/java/reviewme/reviewgroup/service/ReviewGroupService.java
+++ b/backend/src/main/java/reviewme/reviewgroup/service/ReviewGroupService.java
@@ -15,7 +15,6 @@ import reviewme.reviewgroup.service.dto.ReviewGroupCreationResponse;
 public class ReviewGroupService {
 
     private static final int REVIEW_REQUEST_CODE_LENGTH = 8;
-    private static final int GROUP_ACCESS_CODE_LENGTH = 8;
 
     private final ReviewGroupRepository reviewGroupRepository;
     private final RandomCodeGenerator randomCodeGenerator;

--- a/backend/src/main/java/reviewme/reviewgroup/service/ReviewGroupService.java
+++ b/backend/src/main/java/reviewme/reviewgroup/service/ReviewGroupService.java
@@ -36,7 +36,7 @@ public class ReviewGroupService {
 
     @Transactional(readOnly = true)
     public CheckValidAccessResponse checkGroupAccessCode(CheckValidAccessRequest request) {
-        boolean hasAccess = reviewGroupRepository.existsByReviewRequestCodeAndGroupAccessCode(
+        boolean hasAccess = reviewGroupRepository.existsByReviewRequestCodeAndGroupAccessCode_Code(
                 request.reviewRequestCode(), request.groupAccessCode()
         );
         return new CheckValidAccessResponse(hasAccess);

--- a/backend/src/main/java/reviewme/reviewgroup/service/ReviewGroupService.java
+++ b/backend/src/main/java/reviewme/reviewgroup/service/ReviewGroupService.java
@@ -7,7 +7,6 @@ import reviewme.reviewgroup.domain.ReviewGroup;
 import reviewme.reviewgroup.repository.ReviewGroupRepository;
 import reviewme.reviewgroup.service.dto.CheckValidAccessRequest;
 import reviewme.reviewgroup.service.dto.CheckValidAccessResponse;
-import reviewme.reviewgroup.repository.ReviewGroupRepository;
 import reviewme.reviewgroup.service.dto.ReviewGroupCreationRequest;
 import reviewme.reviewgroup.service.dto.ReviewGroupCreationResponse;
 
@@ -24,18 +23,15 @@ public class ReviewGroupService {
     @Transactional
     public ReviewGroupCreationResponse createReviewGroup(ReviewGroupCreationRequest request) {
         String reviewRequestCode;
-        String groupAccessCode;
         do {
             reviewRequestCode = randomCodeGenerator.generate(REVIEW_REQUEST_CODE_LENGTH);
         } while (reviewGroupRepository.existsByReviewRequestCode(reviewRequestCode));
-        do {
-            groupAccessCode = randomCodeGenerator.generate(GROUP_ACCESS_CODE_LENGTH);
-        } while (reviewGroupRepository.existsByGroupAccessCode(groupAccessCode));
+
 
         ReviewGroup reviewGroup = reviewGroupRepository.save(
-                new ReviewGroup(request.revieweeName(), request.projectName(), reviewRequestCode, groupAccessCode)
+                new ReviewGroup(request.revieweeName(), request.projectName(), reviewRequestCode, request.groupAccessCode())
         );
-        return new ReviewGroupCreationResponse(reviewGroup.getReviewRequestCode(), reviewGroup.getGroupAccessCode());
+        return new ReviewGroupCreationResponse(reviewGroup.getReviewRequestCode());
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/reviewme/reviewgroup/service/dto/ReviewGroupCreationRequest.java
+++ b/backend/src/main/java/reviewme/reviewgroup/service/dto/ReviewGroupCreationRequest.java
@@ -3,10 +3,14 @@ package reviewme.reviewgroup.service.dto;
 import jakarta.validation.constraints.NotBlank;
 
 public record ReviewGroupCreationRequest(
-        @NotBlank(message = "리뷰이 이름은 공백일 수 없어요.")
+
+        @NotBlank(message = "리뷰이 이름을 입력해주세요.")
         String revieweeName,
 
-        @NotBlank(message = "프로젝트 이름은 공백일 수 없어요.")
-        String projectName
+        @NotBlank(message = "프로젝트 이름을 입력해주세요.")
+        String projectName,
+
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        String groupAccessCode
 ) {
 }

--- a/backend/src/main/java/reviewme/reviewgroup/service/dto/ReviewGroupCreationResponse.java
+++ b/backend/src/main/java/reviewme/reviewgroup/service/dto/ReviewGroupCreationResponse.java
@@ -1,7 +1,6 @@
 package reviewme.reviewgroup.service.dto;
 
 public record ReviewGroupCreationResponse(
-        String reviewRequestCode,
-        String groupAccessCode
+        String reviewRequestCode
 ) {
 }

--- a/backend/src/test/java/reviewme/api/ReviewApiTest.java
+++ b/backend/src/test/java/reviewme/api/ReviewApiTest.java
@@ -16,8 +16,6 @@ import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.restdocs.headers.HeaderDescriptor;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.payload.FieldDescriptor;
@@ -31,7 +29,6 @@ import reviewme.review.service.exception.ReviewGroupNotFoundByCodesException;
 
 class ReviewApiTest extends ApiTest {
 
-    private static final Logger log = LoggerFactory.getLogger(ReviewApiTest.class);
     private final String request = """
             {
                 "reviewRequestCode": "ABCD1234",

--- a/backend/src/test/java/reviewme/api/ReviewApiTest.java
+++ b/backend/src/test/java/reviewme/api/ReviewApiTest.java
@@ -150,7 +150,7 @@ class ReviewApiTest extends ApiTest {
         givenWithSpec().log().all()
                 .pathParam("id", "1")
                 .queryParam("reviewRequestCode", "00001234")
-                .header("groupAccessCode", "00001234")
+                .header("groupAccessCode", "abc12344")
                 .when().get("/v2/reviews/{id}")
                 .then().log().all()
                 .apply(handler)

--- a/backend/src/test/java/reviewme/api/ReviewGroupApiTest.java
+++ b/backend/src/test/java/reviewme/api/ReviewGroupApiTest.java
@@ -26,23 +26,24 @@ class ReviewGroupApiTest extends ApiTest {
     @Test
     void 리뷰_그룹을_생성한다() {
         BDDMockito.given(reviewGroupService.createReviewGroup(any(ReviewGroupCreationRequest.class)))
-                .willReturn(new ReviewGroupCreationResponse("ABCD1234", "00001234"));
+                .willReturn(new ReviewGroupCreationResponse("ABCD1234"));
 
         String request = """
                 {
                     "revieweeName": "아루",
-                    "projectName": "리뷰미"
+                    "projectName": "리뷰미",
+                    "groupAccessCode": "12341234"
                 }
                 """;
 
         FieldDescriptor[] requestFieldDescriptors = {
                 fieldWithPath("revieweeName").description("리뷰이 이름"),
-                fieldWithPath("projectName").description("프로젝트 이름")
+                fieldWithPath("projectName").description("프로젝트 이름"),
+                fieldWithPath("groupAccessCode").description("리뷰 확인 코드(비밀번호)")
         };
 
         FieldDescriptor[] responseFieldDescriptors = {
-                fieldWithPath("reviewRequestCode").description("리뷰 요청 코드"),
-                fieldWithPath("groupAccessCode").description("그룹 접근 코드")
+                fieldWithPath("reviewRequestCode").description("리뷰 요청 코드")
         };
 
         RestDocumentationResultHandler handler = document(

--- a/backend/src/test/java/reviewme/review/service/CreateReviewServiceTest.java
+++ b/backend/src/test/java/reviewme/review/service/CreateReviewServiceTest.java
@@ -66,7 +66,7 @@ class CreateReviewServiceTest {
     @BeforeEach
     void setUp() {
         reviewGroupRepository.save(
-                new ReviewGroup("리뷰어", "프로젝트", reviewRequestCode, "그룹접근코드")
+                new ReviewGroup("리뷰어", "프로젝트", reviewRequestCode, "12341234")
         );
         templateRepository.save(
                 new Template(List.of(1L))

--- a/backend/src/test/java/reviewme/reviewgroup/service/ReviewGroupServiceTest.java
+++ b/backend/src/test/java/reviewme/reviewgroup/service/ReviewGroupServiceTest.java
@@ -39,17 +39,16 @@ class ReviewGroupServiceTest {
         reviewGroupRepository.save(new ReviewGroup("reviewee", "project", "0000", "1111"));
         given(randomCodeGenerator.generate(anyInt()))
                 .willReturn("0000") // ReviewRequestCode
-                .willReturn("AAAA")
-                .willReturn("1111") // GroupAccessCode
-                .willReturn("BBBB");
-        ReviewGroupCreationRequest request = new ReviewGroupCreationRequest("sancho", "reviewme");
+                .willReturn("AAAA");
+
+        ReviewGroupCreationRequest request = new ReviewGroupCreationRequest("sancho", "reviewme", "groupAccessCode");
 
         // when
         ReviewGroupCreationResponse response = reviewGroupService.createReviewGroup(request);
 
         // then
-        assertThat(response).isEqualTo(new ReviewGroupCreationResponse("AAAA", "BBBB"));
-        then(randomCodeGenerator).should(times(4)).generate(anyInt());
+        assertThat(response).isEqualTo(new ReviewGroupCreationResponse("AAAA"));
+        then(randomCodeGenerator).should(times(2)).generate(anyInt());
     }
 
     @Test


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #433 

---

### 🚀 어떤 기능을 구현했나요 ?
- GroupAccessCode를 발급하지 않고 사용자가 직접 입력하면서 변경되는 사항을 반영했습니다.

### 🔥 어떻게 해결했나요 ?
- GroupAccessCode 도메인을 생성했습니다.
- API 문서대로 로직을 구현했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 잘 작동하는지!!

### 📚 참고 자료, 할 말
