### PR TITLE
[FE] chore: 리뷰 목록 및 상세 페이지에서 reviewRequestCode를 recoil 상태로 관리

### DIFF
--- a/frontend/src/apis/endpoints.ts
+++ b/frontend/src/apis/endpoints.ts
@@ -1,12 +1,5 @@
 export const VERSION2 = 'v2';
 
-export const REVIEW_LIST_API_PARAMS = {
-  resource: 'reviews',
-  queryString: {
-    reviewRequestCode: 'reviewRequestCode',
-  },
-};
-
 export const DETAILED_REVIEW_API_PARAMS = {
   resource: 'reviews',
   queryString: {
@@ -15,7 +8,12 @@ export const DETAILED_REVIEW_API_PARAMS = {
   },
 };
 
-export const DETAILED_REVIEW_API_URL = `${process.env.API_BASE_URL}/${VERSION2}/${DETAILED_REVIEW_API_PARAMS.resource}`;
+export const REVIEW_LIST_API_PARAMS = {
+  resource: 'reviews',
+  queryString: {
+    reviewRequestCode: 'reviewRequestCode',
+  },
+};
 
 export const REVIEW_WRITING_API_PARAMS = {
   resource: 'reviews',
@@ -32,8 +30,6 @@ export const REVIEW_PASSWORD_API_PARAMS = {
   },
 };
 
-export const REVIEW_WRITING_API_URL = `${process.env.API_BASE_URL}/${VERSION2}/${REVIEW_WRITING_API_PARAMS.resource}`;
-
 export const REVIEW_GROUP_DATA_API_PARAMS = {
   resource: 'groups',
   queryString: {
@@ -41,6 +37,9 @@ export const REVIEW_GROUP_DATA_API_PARAMS = {
   },
 };
 
+export const REVIEW_WRITING_API_URL = `${process.env.API_BASE_URL}/${VERSION2}/${REVIEW_WRITING_API_PARAMS.resource}`;
+export const REVIEW_LIST_API_URL = `${process.env.API_BASE_URL}/${VERSION2}/${REVIEW_LIST_API_PARAMS.resource}`;
+export const DETAILED_REVIEW_API_URL = `${process.env.API_BASE_URL}/${VERSION2}/${DETAILED_REVIEW_API_PARAMS.resource}`;
 export const REVIEW_GROUP_DATA_API_URL = `${process.env.API_BASE_URL}/${VERSION2}/${REVIEW_GROUP_DATA_API_PARAMS.resource}`;
 
 const endPoint = {
@@ -50,7 +49,7 @@ const endPoint = {
   gettingDataToWriteReview: (reviewRequestCode: string) =>
     `${REVIEW_WRITING_API_URL}/${REVIEW_WRITING_API_PARAMS.queryString.write}?${REVIEW_WRITING_API_PARAMS.queryString.reviewRequestCode}=${reviewRequestCode}`,
   gettingReviewList: (reviewRequestCode: string) =>
-    `${process.env.API_BASE_URL}/${VERSION2}/${REVIEW_LIST_API_PARAMS.resource}?${REVIEW_LIST_API_PARAMS.queryString.reviewRequestCode}=${reviewRequestCode}`,
+    `${REVIEW_LIST_API_URL}?${REVIEW_LIST_API_PARAMS.queryString.reviewRequestCode}=${reviewRequestCode}`,
   postingDataForReviewRequestCode: `${process.env.API_BASE_URL}/${VERSION2}/groups`,
   checkingPassword: `${process.env.API_BASE_URL}/${VERSION2}/${REVIEW_PASSWORD_API_PARAMS.resource}/${REVIEW_PASSWORD_API_PARAMS.queryString.check}`,
   gettingReviewGroupData: (reviewRequestCode: string) =>

--- a/frontend/src/apis/endpoints.ts
+++ b/frontend/src/apis/endpoints.ts
@@ -1,9 +1,17 @@
 export const VERSION2 = 'v2';
 
+export const REVIEW_LIST_API_PARAMS = {
+  resource: 'reviews',
+  queryString: {
+    reviewRequestCode: 'reviewRequestCode',
+  },
+};
+
 export const DETAILED_REVIEW_API_PARAMS = {
   resource: 'reviews',
   queryString: {
     memberId: 'memberId',
+    reviewRequestCode: 'reviewRequestCode',
   },
 };
 
@@ -38,11 +46,11 @@ export const REVIEW_GROUP_DATA_API_URL = `${process.env.API_BASE_URL}/${VERSION2
 const endPoint = {
   postingReview: `${process.env.API_BASE_URL}/${VERSION2}/reviews`,
   gettingDetailedReview: (reviewId: number, reviewRequestCode: string) =>
-    `${DETAILED_REVIEW_API_URL}/${reviewId}?${REVIEW_GROUP_DATA_API_PARAMS.queryString.reviewRequestCode}=${reviewRequestCode}`,
+    `${DETAILED_REVIEW_API_URL}/${reviewId}?${DETAILED_REVIEW_API_PARAMS.queryString.reviewRequestCode}=${reviewRequestCode}`,
   gettingDataToWriteReview: (reviewRequestCode: string) =>
     `${REVIEW_WRITING_API_URL}/${REVIEW_WRITING_API_PARAMS.queryString.write}?${REVIEW_WRITING_API_PARAMS.queryString.reviewRequestCode}=${reviewRequestCode}`,
   gettingReviewList: (reviewRequestCode: string) =>
-    `${process.env.API_BASE_URL}/${VERSION2}/reviews?${REVIEW_GROUP_DATA_API_PARAMS.queryString.reviewRequestCode}=${reviewRequestCode}`,
+    `${process.env.API_BASE_URL}/${VERSION2}/${REVIEW_LIST_API_PARAMS.resource}?${REVIEW_LIST_API_PARAMS.queryString.reviewRequestCode}=${reviewRequestCode}`,
   postingDataForReviewRequestCode: `${process.env.API_BASE_URL}/${VERSION2}/groups`,
   checkingPassword: `${process.env.API_BASE_URL}/${VERSION2}/${REVIEW_PASSWORD_API_PARAMS.resource}/${REVIEW_PASSWORD_API_PARAMS.queryString.check}`,
   gettingReviewGroupData: (reviewRequestCode: string) =>

--- a/frontend/src/apis/endpoints.ts
+++ b/frontend/src/apis/endpoints.ts
@@ -38,11 +38,11 @@ export const REVIEW_GROUP_DATA_API_URL = `${process.env.API_BASE_URL}/${VERSION2
 const endPoint = {
   postingReview: `${process.env.API_BASE_URL}/${VERSION2}/reviews`,
   gettingDetailedReview: (reviewId: number, reviewRequestCode: string) =>
-    `${DETAILED_REVIEW_API_URL}/${reviewId}?${reviewRequestCode}`,
+    `${DETAILED_REVIEW_API_URL}/${reviewId}?${REVIEW_GROUP_DATA_API_PARAMS.queryString.reviewRequestCode}=${reviewRequestCode}`,
   gettingDataToWriteReview: (reviewRequestCode: string) =>
     `${REVIEW_WRITING_API_URL}/${REVIEW_WRITING_API_PARAMS.queryString.write}?${REVIEW_WRITING_API_PARAMS.queryString.reviewRequestCode}=${reviewRequestCode}`,
   gettingReviewList: (reviewRequestCode: string) =>
-    `${process.env.API_BASE_URL}/${VERSION2}/reviews?${reviewRequestCode}`,
+    `${process.env.API_BASE_URL}/${VERSION2}/reviews?${REVIEW_GROUP_DATA_API_PARAMS.queryString.reviewRequestCode}=${reviewRequestCode}`,
   postingDataForReviewRequestCode: `${process.env.API_BASE_URL}/${VERSION2}/groups`,
   checkingPassword: `${process.env.API_BASE_URL}/${VERSION2}/${REVIEW_PASSWORD_API_PARAMS.resource}/${REVIEW_PASSWORD_API_PARAMS.queryString.check}`,
   gettingReviewGroupData: (reviewRequestCode: string) =>

--- a/frontend/src/apis/endpoints.ts
+++ b/frontend/src/apis/endpoints.ts
@@ -37,10 +37,12 @@ export const REVIEW_GROUP_DATA_API_URL = `${process.env.API_BASE_URL}/${VERSION2
 
 const endPoint = {
   postingReview: `${process.env.API_BASE_URL}/${VERSION2}/reviews`,
-  gettingDetailedReview: (reviewId: number) => `${DETAILED_REVIEW_API_URL}/${reviewId}`,
+  gettingDetailedReview: (reviewId: number, reviewRequestCode: string) =>
+    `${DETAILED_REVIEW_API_URL}/${reviewId}?${reviewRequestCode}`,
   gettingDataToWriteReview: (reviewRequestCode: string) =>
     `${REVIEW_WRITING_API_URL}/${REVIEW_WRITING_API_PARAMS.queryString.write}?${REVIEW_WRITING_API_PARAMS.queryString.reviewRequestCode}=${reviewRequestCode}`,
-  gettingReviewList: `${process.env.API_BASE_URL}/${VERSION2}/reviews`,
+  gettingReviewList: (reviewRequestCode: string) =>
+    `${process.env.API_BASE_URL}/${VERSION2}/reviews?${reviewRequestCode}`,
   postingDataForReviewRequestCode: `${process.env.API_BASE_URL}/${VERSION2}/groups`,
   checkingPassword: `${process.env.API_BASE_URL}/${VERSION2}/${REVIEW_PASSWORD_API_PARAMS.resource}/${REVIEW_PASSWORD_API_PARAMS.queryString.check}`,
   gettingReviewGroupData: (reviewRequestCode: string) =>

--- a/frontend/src/apis/review.ts
+++ b/frontend/src/apis/review.ts
@@ -32,16 +32,13 @@ export const postReviewApi = async (formResult: ReviewWritingFormResult) => {
   return;
 };
 
-// 상세 리뷰
-export const getDetailedReviewApi = async ({
-  reviewId,
-  groupAccessCode,
-  reviewRequestCode,
-}: {
+interface GetDetailedReviewApi {
   reviewId: number;
   groupAccessCode: string;
   reviewRequestCode: string;
-}) => {
+}
+// 상세 리뷰
+export const getDetailedReviewApi = async ({ reviewId, groupAccessCode, reviewRequestCode }: GetDetailedReviewApi) => {
   const response = await fetch(endPoint.gettingDetailedReview(reviewId, reviewRequestCode), {
     method: 'GET',
     headers: {

--- a/frontend/src/apis/review.ts
+++ b/frontend/src/apis/review.ts
@@ -36,11 +36,13 @@ export const postReviewApi = async (formResult: ReviewWritingFormResult) => {
 export const getDetailedReviewApi = async ({
   reviewId,
   groupAccessCode,
+  reviewRequestCode,
 }: {
   reviewId: number;
   groupAccessCode: string;
+  reviewRequestCode: string;
 }) => {
-  const response = await fetch(endPoint.gettingDetailedReview(reviewId), {
+  const response = await fetch(endPoint.gettingDetailedReview(reviewId, reviewRequestCode), {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
@@ -56,8 +58,8 @@ export const getDetailedReviewApi = async ({
   return data as DetailReviewData;
 };
 
-export const getReviewListApi = async (groupAccessCode: string) => {
-  const response = await fetch(endPoint.gettingReviewList, {
+export const getReviewListApi = async (groupAccessCode: string, reviewRequestCode: string) => {
+  const response = await fetch(endPoint.gettingReviewList(reviewRequestCode), {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',

--- a/frontend/src/hooks/review/useGetDetailedReview/index.ts
+++ b/frontend/src/hooks/review/useGetDetailedReview/index.ts
@@ -7,22 +7,24 @@ import { DetailReviewData } from '@/types';
 interface UseGetDetailedReviewProps {
   reviewId: number;
   groupAccessCode: string;
+  reviewRequestCode: string;
 }
 
 interface FetchDetailedReviewParams {
   reviewId: number;
   groupAccessCode: string;
+  reviewRequestCode: string;
 }
 
-const useGetDetailedReview = ({ reviewId, groupAccessCode }: UseGetDetailedReviewProps) => {
-  const fetchDetailedReview = async ({ reviewId, groupAccessCode }: FetchDetailedReviewParams) => {
-    const result = await getDetailedReviewApi({ reviewId, groupAccessCode });
+const useGetDetailedReview = ({ reviewId, groupAccessCode, reviewRequestCode }: UseGetDetailedReviewProps) => {
+  const fetchDetailedReview = async ({ reviewId, groupAccessCode, reviewRequestCode }: FetchDetailedReviewParams) => {
+    const result = await getDetailedReviewApi({ reviewId, groupAccessCode, reviewRequestCode });
     return result;
   };
 
   const result = useSuspenseQuery<DetailReviewData>({
     queryKey: [REVIEW_QUERY_KEY.detailedReview, reviewId],
-    queryFn: () => fetchDetailedReview({ reviewId, groupAccessCode }),
+    queryFn: () => fetchDetailedReview({ reviewId, groupAccessCode, reviewRequestCode }),
   });
 
   return result;

--- a/frontend/src/hooks/review/useGetReviewList/index.ts
+++ b/frontend/src/hooks/review/useGetReviewList/index.ts
@@ -3,10 +3,10 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { getReviewListApi } from '@/apis/review';
 import { REVIEW_QUERY_KEY } from '@/constants';
 
-const useGetReviewList = (groupAccessCode: string) => {
+const useGetReviewList = (groupAccessCode: string, reviewRequestCode: string) => {
   const { data, isLoading, error, isSuccess } = useSuspenseQuery({
     queryKey: [REVIEW_QUERY_KEY.reviews],
-    queryFn: () => getReviewListApi(groupAccessCode),
+    queryFn: () => getReviewListApi(groupAccessCode, reviewRequestCode),
   });
 
   // NOTE: 무한스크롤 관련 코드 일단 주석 처리

--- a/frontend/src/mocks/handlers/review.ts
+++ b/frontend/src/mocks/handlers/review.ts
@@ -51,8 +51,8 @@ const getDataToWriteReview = () =>
     return HttpResponse.json({ error: '잘못된 리뷰 작성 데이터 요청' }, { status: 404 });
   });
 
-const getReviewList = () => {
-  return http.get(endPoint.gettingReviewList, async ({ request }) => {
+const getReviewList = (reviewRequestCode: string) => {
+  return http.get(endPoint.gettingReviewList(reviewRequestCode), async ({ request }) => {
     // const url = new URL(request.url);
 
     // const lastReviewId = Number(url.searchParams.get('lastReviewId'));
@@ -83,6 +83,17 @@ const postReview = () =>
     return HttpResponse.json({ message: 'post 성공' }, { status: 201 });
   });
 
-const reviewHandler = [getDetailedReview(), getReviewList(), getDataToWriteReview(), postReview()];
+const postHasAccess = () =>
+  http.post(endPoint.checkingPassword, async () => {
+    return HttpResponse.json({ hasAccess: true });
+  });
+
+const reviewHandler = [
+  getDetailedReview(),
+  getReviewList('ABCD1234'),
+  getDataToWriteReview(),
+  postReview(),
+  postHasAccess(),
+];
 
 export default reviewHandler;

--- a/frontend/src/mocks/handlers/review.ts
+++ b/frontend/src/mocks/handlers/review.ts
@@ -83,17 +83,6 @@ const postReview = () =>
     return HttpResponse.json({ message: 'post 성공' }, { status: 201 });
   });
 
-const postHasAccess = () =>
-  http.post(endPoint.checkingPassword, async () => {
-    return HttpResponse.json({ hasAccess: true });
-  });
-
-const reviewHandler = [
-  getDetailedReview(),
-  getReviewList('ABCD1234'),
-  getDataToWriteReview(),
-  postReview(),
-  postHasAccess(),
-];
+const reviewHandler = [getDetailedReview(), getReviewList('ABCD1234'), getDataToWriteReview(), postReview()];
 
 export default reviewHandler;

--- a/frontend/src/pages/DetailedReviewPage/components/DetailedReviewPageContents/index.tsx
+++ b/frontend/src/pages/DetailedReviewPage/components/DetailedReviewPageContents/index.tsx
@@ -1,6 +1,9 @@
+import { useRecoilValue } from 'recoil';
+
 import { ROUTE_PARAM } from '@/constants';
 import { useGetDetailedReview, useSearchParamAndQuery } from '@/hooks';
 import { ReviewDescription, ReviewSection, KeywordSection } from '@/pages/DetailedReviewPage/components';
+import { reviewRequestCodeAtom } from '@/recoil';
 
 import * as S from './styles';
 
@@ -9,6 +12,7 @@ interface DetailedReviewPageContentsProps {
 }
 
 const DetailedReviewPageContents = ({ groupAccessCode }: DetailedReviewPageContentsProps) => {
+  const storedReviewRequestCode = useRecoilValue(reviewRequestCodeAtom);
   const { param: reviewId } = useSearchParamAndQuery({
     paramKey: ROUTE_PARAM.reviewId,
   });
@@ -16,6 +20,7 @@ const DetailedReviewPageContents = ({ groupAccessCode }: DetailedReviewPageConte
   const { data: detailedReview } = useGetDetailedReview({
     reviewId: Number(reviewId),
     groupAccessCode,
+    reviewRequestCode: storedReviewRequestCode,
   });
 
   // TODO: 리뷰 공개/비공개 토글 버튼 기능

--- a/frontend/src/pages/ReviewListPage/components/PageContents/index.tsx
+++ b/frontend/src/pages/ReviewListPage/components/PageContents/index.tsx
@@ -14,12 +14,13 @@ import * as S from './styles';
 
 interface PageContentsProps {
   groupAccessCode: string;
+  reviewRequestCode: string;
 }
 
-const PageContents = ({ groupAccessCode }: PageContentsProps) => {
+const PageContents = ({ groupAccessCode, reviewRequestCode }: PageContentsProps) => {
   const navigate = useNavigate();
 
-  const { data: reviewListData } = useGetReviewList(groupAccessCode);
+  const { data: reviewListData } = useGetReviewList(groupAccessCode, reviewRequestCode);
 
   const handleReviewClick = (id: number) => {
     navigate(`/user/detailed-review/${id}`);

--- a/frontend/src/pages/ReviewListPage/index.tsx
+++ b/frontend/src/pages/ReviewListPage/index.tsx
@@ -1,10 +1,14 @@
+import { useRecoilValue } from 'recoil';
+
 import { ErrorSuspenseContainer, LoginRedirectModal } from '@/components';
 import { useGroupAccessCode } from '@/hooks';
+import { reviewRequestCodeAtom } from '@/recoil';
 
 import PageContents from './components/PageContents';
 
 const ReviewListPage = () => {
   const { groupAccessCode } = useGroupAccessCode();
+  const storedReviewRequestCode = useRecoilValue(reviewRequestCodeAtom);
 
   // NOTE: 무한스크롤 코드 일단 주석 처리
   // const { data, fetchNextPage, hasNextPage, isLoading, error } = useGetReviewList();
@@ -28,9 +32,9 @@ const ReviewListPage = () => {
 
   return (
     <>
-      {groupAccessCode ? (
+      {groupAccessCode && storedReviewRequestCode ? (
         <ErrorSuspenseContainer>
-          <PageContents groupAccessCode={groupAccessCode} />
+          <PageContents groupAccessCode={groupAccessCode} reviewRequestCode={storedReviewRequestCode} />
         </ErrorSuspenseContainer>
       ) : (
         <LoginRedirectModal />

--- a/frontend/src/pages/ReviewZonePage/index.tsx
+++ b/frontend/src/pages/ReviewZonePage/index.tsx
@@ -1,4 +1,6 @@
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router';
+import { useRecoilState } from 'recoil';
 
 import ReviewZoneIcon from '@/assets/reviewZone.svg';
 import { Button } from '@/components';
@@ -6,6 +8,7 @@ import { Button } from '@/components';
 import { ROUTE } from '@/constants/route';
 import { useGetReviewGroupData, useSearchParamAndQuery } from '@/hooks';
 import useModals from '@/hooks/useModals';
+import { reviewRequestCodeAtom } from '@/recoil';
 
 import PasswordModal from './components/PasswordModal';
 import * as S from './styles';
@@ -16,6 +19,7 @@ const MODAL_KEYS = {
 
 const ReviewZonePage = () => {
   const { isOpen, openModal, closeModal } = useModals();
+  const [storedReviewRequestCode, setStoredReviewRequestCode] = useRecoilState(reviewRequestCodeAtom);
 
   const navigate = useNavigate();
 
@@ -24,6 +28,14 @@ const ReviewZonePage = () => {
   });
 
   if (!reviewRequestCode) throw new Error('유효하지 않은 리뷰 요청 코드입니다.');
+
+  useEffect(() => {
+    if (!storedReviewRequestCode && reviewRequestCode) {
+      setStoredReviewRequestCode(reviewRequestCode);
+    }
+  }, []);
+
+  console.log('zone: ', storedReviewRequestCode);
 
   const { data: reviewGroupData } = useGetReviewGroupData({ reviewRequestCode });
 

--- a/frontend/src/pages/ReviewZonePage/index.tsx
+++ b/frontend/src/pages/ReviewZonePage/index.tsx
@@ -35,8 +35,6 @@ const ReviewZonePage = () => {
     }
   }, []);
 
-  console.log('zone: ', storedReviewRequestCode);
-
   const { data: reviewGroupData } = useGetReviewGroupData({ reviewRequestCode });
 
   const handleReviewWritingButtonClick = () => {

--- a/frontend/src/recoil/index.ts
+++ b/frontend/src/recoil/index.ts
@@ -1,3 +1,4 @@
 export * from './groupAccessCode';
 export * from './keys';
 export * from './reviewWritingForm';
+export * from './reviewRequestCode';

--- a/frontend/src/recoil/keys/index.ts
+++ b/frontend/src/recoil/keys/index.ts
@@ -6,6 +6,7 @@ export const ATOM_KEY = {
     answerMapAtom: 'answerMapAtom',
     answerValidationMapAtom: 'answerValidationMapAtom',
     visitedCardList: 'visitedCardList',
+    reviewRequestCodeAtom: 'reviewRequestCode',
   },
 };
 

--- a/frontend/src/recoil/reviewRequestCode/index.ts
+++ b/frontend/src/recoil/reviewRequestCode/index.ts
@@ -1,0 +1,11 @@
+import { atom } from 'recoil';
+
+import { ATOM_KEY } from '../keys';
+
+/**
+ * 리뷰 URL 뒷부분의 난수에 해당하는 reviewRequestCode
+ */
+export const reviewRequestCodeAtom = atom<string>({
+  key: ATOM_KEY.reviewWritingForm.reviewRequestCodeAtom,
+  default: '',
+});

--- a/frontend/src/recoil/reviewWritingForm/atom.ts
+++ b/frontend/src/recoil/reviewWritingForm/atom.ts
@@ -45,3 +45,11 @@ export const visitedCardListAtom = atom<number[]>({
   key: ATOM_KEY.reviewWritingForm.visitedCardList,
   default: [1],
 });
+
+/**
+ * 리뷰 URL 뒷부분의 난수에 해당하는 reviewRequestCode
+ */
+export const reviewRequestCodeAtom = atom<string>({
+  key: ATOM_KEY.reviewWritingForm.reviewRequestCodeAtom,
+  default: '',
+});

--- a/frontend/src/recoil/reviewWritingForm/atom.ts
+++ b/frontend/src/recoil/reviewWritingForm/atom.ts
@@ -45,11 +45,3 @@ export const visitedCardListAtom = atom<number[]>({
   key: ATOM_KEY.reviewWritingForm.visitedCardList,
   default: [1],
 });
-
-/**
- * 리뷰 URL 뒷부분의 난수에 해당하는 reviewRequestCode
- */
-export const reviewRequestCodeAtom = atom<string>({
-  key: ATOM_KEY.reviewWritingForm.reviewRequestCodeAtom,
-  default: '',
-});


### PR DESCRIPTION
- resolves #435 

---

### 🚀 어떤 기능을 구현했나요 ?
- 리뷰 목록 및 상세 페이지에서 reviewRequestCode를 recoil 상태로 관리했습니다. 
- 목록 및 상세 리뷰 요청 시 reviewRequestCode를 함께 전달하는 것으로 API가 수정되었고, 그에 맞추어 목록 페이지와 상세 리뷰 페이지에서 reviewRequestCode가 없는 경우 접근이 불가능하도록 했습니다.
- 정상적인 접근은, 리뷰 연결 페이지를 통해 올바른 비밀번호를 입력하고 목록과 상세 리뷰에 접근하는 것입니다.  

### 🔥 어떻게 해결했나요 ?
- recoil 상태를 관리했고, 기존에 groupAccessCode로만 페이지 접근 권한을 확인했다면 이제는 reviewRequestCode도 함께 있는지 검증합니다.
- MSW로 목록 페이지와 상세 페이지의 url을 직접 수정할 때, 유효하지 않은 접근이라는 모달이 뜨는 것을 확인했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 혹시 검증 로직이 적용되지 않은 부분을 발견한다면 알려주세요!

### 📚 참고 자료, 할 말
테스트와 mock handler의 수정은 거의 없었는데, 우선 문제 없이 돌아가요. 아침에 맑은 정신으로 다시 적용해야 하는데 안 된 부분이 있는지 확인해볼게요.