### PR TITLE
[FE] ci: concurrency의 cancel-in-progress 설정을 false로 수정

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -10,9 +10,9 @@ permissions:
   contents: read
   pages: write
   id-token: write
-concurrency: # NOTE: action 도중 새 PR이 올라오면 기존 action 취소
+concurrency: 
   group: "ci-group"
-  cancel-in-progress: true
+  cancel-in-progress: false # NOTE: 기존 CI가 돌고 있는 상황에서 새 작업이 추가돼도 기존 작업 계속 수행
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #446 

---

### 🚀 어떤 기능을 구현했나요 ?
- 기존 PR에 push가 일어나 CI가 돌고 있을 때, 다른 PR의 push가 일어나면 기존 PR의 CI 작업이 취소되는 일을 막기 위한 작업을 했습니다.

### 🔥 어떻게 해결했나요 ?
- CI 설정 중 `concurrency`(동시성) 부분에서 `cancel-in-progress` (새 작업이 생기면 기존 작업 취소)가 true였는데, 
- 기본값이 false라 그냥 이 `concurrency` 부분을 삭제해버리려고 했는데 명시적으로 작성하는 게 나을 것 같아 false로 변경했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 기본값이 false니까 `concurrency` 부분을 아예 삭제해버릴까요?
- 해당 속성이 비교적 직관적이지 않은 것 같아 무슨 작업에 대한 설정인지를 설명하는 주석을 달아뒀었는데 이 주석이 필요할까요?

### 📚 참고 자료, 할 말
- 위 속성은 혼자 미션할 때는 유용했는데 이렇게 팀 협업을 할 때는 세세한 커스텀이 들어갈 게 아니라면 안 하는 게 나은 것 같습니다.