### PR TITLE
[FE] refactor: 리뷰 작성 페이지 컴포넌트들의 gap 조정, footer 스타일 조정, 로고 가운데 정렬

### DIFF
--- a/frontend/src/components/common/Breadcrumb/styles.ts
+++ b/frontend/src/components/common/Breadcrumb/styles.ts
@@ -1,6 +1,8 @@
 import styled from '@emotion/styled';
 
 export const BreadcrumbList = styled.ul`
+  font-size: 1.5rem;
+
   display: flex;
   padding: 2rem 0 0 2.5rem;
   list-style: none;

--- a/frontend/src/components/layouts/Footer/style.ts
+++ b/frontend/src/components/layouts/Footer/style.ts
@@ -5,10 +5,13 @@ export const Footer = styled.footer`
   gap: 3.2rem;
   align-items: center;
   justify-content: center;
+  position: absolute;
+  bottom: 0;
+  left: 0;
 
   width: 100%;
   height: ${({ theme }) => theme.footerHeight};
-  padding: 1rem;
+  padding: 2rem 1rem;
 
   font-size: ${({ theme }) => theme.fontSize.small};
   color: ${({ theme }) => theme.colors.gray};

--- a/frontend/src/components/layouts/Footer/style.ts
+++ b/frontend/src/components/layouts/Footer/style.ts
@@ -1,10 +1,6 @@
 import styled from '@emotion/styled';
 
 export const Footer = styled.footer`
-  position: absolute;
-  bottom: 0;
-  left: 0;
-
   display: flex;
   gap: 3.2rem;
   align-items: center;

--- a/frontend/src/components/layouts/Main/styles.ts
+++ b/frontend/src/components/layouts/Main/styles.ts
@@ -4,6 +4,9 @@ export const MainContainer = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
+
+  min-height: (100vh - 43rem);
+  margin-bottom: calc(${({ theme }) => theme.footerHeight});
 `;
 
 export const Contents = styled.div`

--- a/frontend/src/components/layouts/Topbar/components/Logo/styles.ts
+++ b/frontend/src/components/layouts/Topbar/components/Logo/styles.ts
@@ -16,6 +16,9 @@ export const LogoText = styled.div`
   line-height: 8rem;
   text-align: center;
 
+  display: flex;
+  align-items: center;
+
   span {
     font-size: 3rem;
     font-weight: ${({ theme }) => theme.fontWeight.bolder};

--- a/frontend/src/pages/ReviewWritingCardFromPage/components/CardForm/styles.ts
+++ b/frontend/src/pages/ReviewWritingCardFromPage/components/CardForm/styles.ts
@@ -20,6 +20,8 @@ export const SliderContainer = styled.div<SlideContainerProps>`
   height: ${({ $height }) => $height};
 
   transition: transform 0.5s ease-in-out;
+
+  margin-bottom: 2rem;
 `;
 
 export const Slide = styled.div`

--- a/frontend/src/pages/ReviewWritingCardFromPage/components/ProgressBar/styles.ts
+++ b/frontend/src/pages/ReviewWritingCardFromPage/components/ProgressBar/styles.ts
@@ -5,7 +5,7 @@ export const ProgressBar = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 1rem;
+  margin-bottom: 1.7rem;
 `;
 
 interface StepButtonStyleProps {

--- a/frontend/src/pages/ReviewWritingCardFromPage/components/ReviewWritingCard/style.ts
+++ b/frontend/src/pages/ReviewWritingCardFromPage/components/ReviewWritingCard/style.ts
@@ -24,7 +24,7 @@ export const ButtonContainer = styled.div`
   display: flex;
   gap: 2rem;
   justify-content: flex-end;
-  padding: 2.5rem;
+  padding-right: 2.5rem;
 
   button {
     width: auto;

--- a/frontend/src/pages/ReviewZonePage/styles.ts
+++ b/frontend/src/pages/ReviewZonePage/styles.ts
@@ -5,8 +5,6 @@ export const ReviewZonePage = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-
-  height: 85vh;
 `;
 
 export const ReviewZoneMainImg = styled.img`

--- a/frontend/src/pages/ReviewZonePage/styles.ts
+++ b/frontend/src/pages/ReviewZonePage/styles.ts
@@ -5,6 +5,8 @@ export const ReviewZonePage = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
+
+  height: 85vh;
 `;
 
 export const ReviewZoneMainImg = styled.img`

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -9,7 +9,7 @@ export const sidebarWidth: ThemeProperty<string> = {
   desktop: '25rem',
   mobile: '100vw',
 };
-export const footerHeight = '4rem';
+export const footerHeight = '6rem';
 
 export const breakpoints: ThemeProperty<string> = {
   desktop: '102.4rem',


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #454 

---

### 🚀 어떤 기능을 구현했나요 ?
- 어색해 보이는 디자인들을 수정했습니다.
- ~~Footer의 position을 static으로 수정했습니다.~~
  - Footer가 absolute로 위치하니까 Main이 길어지면 Footer가 항상 본문을 가리는 문제가 있었습니다.
  - 하지만 static(기본)으로 바꾸니까 로딩 및 에러 fallback에서 footer가 화면 위에 같이 배치돼서 나오는 문제가 발생했습니다.
  - 따라서 다시 position을 absolute로 줬고, 그 대신 min-height를 명시적으로 주고 margin-bottom도 추가했습니다.
  - Footer의 스타일을 수정했습니다.
    - height를 늘리고 그에 따라 padding을 더 부여했습니다.
### 🔥 어떻게 해결했나요 ?
- 로고 텍스트 컴포넌트에 flex 및 center 정렬을 추가했습니다.
- 나머지는 아래 이미지로 대체합니다
![image](https://github.com/user-attachments/assets/61c9e3eb-50af-4f93-9707-8f313f89fd0c)


### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 임의로 작업한 부분들이 있기 때문에 의견 달게 받습니다~

### 📚 참고 자료, 할 말
- ~~Footer의 height를 조금 늘리고 padding을 추가해주는 것을 건의합니다!~~
 ㄴ 해결완
- 공통 디자인을 할 때 모든 페이지에서 자연스럽게 보이는지 체크하면 좋을 것 같아요