### PR TITLE
[FE] fix: breadcrumb에서 연결 페이지를 눌렀을 때 홈페이지로 이동되는 문제 해결

### DIFF
--- a/frontend/src/hooks/useBreadcrumbPaths.ts
+++ b/frontend/src/hooks/useBreadcrumbPaths.ts
@@ -1,13 +1,16 @@
 import { useLocation } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
 
 import { Path } from '@/components/common/Breadcrumb';
 import { ROUTE } from '@/constants/route';
+import { reviewRequestCodeAtom } from '@/recoil';
 
 const useBreadcrumbPaths = () => {
   const { pathname } = useLocation();
+  const storedReviewRequestCode = useRecoilValue(reviewRequestCodeAtom);
 
   const breadcrumbPathList: Path[] = [
-    { pageName: '연결 페이지', path: ROUTE.home }, // TODO: 연결 페이지 경로 결정되면 수정 필요
+    { pageName: '연결 페이지', path: `${ROUTE.reviewZone}/${storedReviewRequestCode}` }, // TODO: 연결 페이지 경로 결정되면 수정 필요
   ];
 
   if (pathname === `/${ROUTE.reviewList}`) {

--- a/frontend/src/hooks/useBreadcrumbPaths.ts
+++ b/frontend/src/hooks/useBreadcrumbPaths.ts
@@ -10,7 +10,7 @@ const useBreadcrumbPaths = () => {
   const storedReviewRequestCode = useRecoilValue(reviewRequestCodeAtom);
 
   const breadcrumbPathList: Path[] = [
-    { pageName: '연결 페이지', path: `${ROUTE.reviewZone}/${storedReviewRequestCode}` }, // TODO: 연결 페이지 경로 결정되면 수정 필요
+    { pageName: '연결 페이지', path: `${ROUTE.reviewZone}/${storedReviewRequestCode}` },
   ];
 
   if (pathname === `/${ROUTE.reviewList}`) {


### PR DESCRIPTION
- resolves #447 

---

### 🚀 어떤 기능을 구현했나요 ?
- breadcrumb에서 연결 페이지를 눌렀을 때 홈페이지로 이동되는 문제를 해결했습니다.

### 🔥 어떻게 해결했나요 ?
- 정상적으로 접근하는 경우 recoil state로 reviewRequestCode가 저장되기 때문에, 이를 사용해서 breadcrumb 훅을 수정했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
