### PR TITLE
[FE] design: 캐러셀을 정가운데로 위치시킨 뒤, 자동 슬라이드 전환 시간을 6초로 설정한다. 그리고 전반적인 디자인을 수정한다.

### DIFF
--- a/frontend/src/components/common/Breadcrumb/styles.ts
+++ b/frontend/src/components/common/Breadcrumb/styles.ts
@@ -1,10 +1,9 @@
 import styled from '@emotion/styled';
 
 export const BreadcrumbList = styled.ul`
-  font-size: 1.5rem;
-
   display: flex;
   padding: 2rem 0 0 2.5rem;
+  font-size: 1.5rem;
   list-style: none;
 `;
 

--- a/frontend/src/components/layouts/Topbar/components/Logo/styles.ts
+++ b/frontend/src/components/layouts/Topbar/components/Logo/styles.ts
@@ -13,11 +13,12 @@ export const Logo = styled.div`
 
 export const LogoText = styled.div`
   cursor: pointer;
-  line-height: 8rem;
-  text-align: center;
 
   display: flex;
   align-items: center;
+
+  line-height: 8rem;
+  text-align: center;
 
   span {
     font-size: 3rem;

--- a/frontend/src/pages/HomePage/components/Carousel/index.tsx
+++ b/frontend/src/pages/HomePage/components/Carousel/index.tsx
@@ -36,7 +36,7 @@ const Carousel = ({ slides }: CarouselProps) => {
   useEffect(() => {
     const timeout = setTimeout(() => {
       nextSlide();
-    }, 10000); // 자동 슬라이드 이동 간격 (10초)
+    }, 6000); // 자동 슬라이드 이동 간격 (6초)
 
     return () => clearTimeout(timeout);
   }, [currentSlide]);

--- a/frontend/src/pages/HomePage/components/Carousel/styles.ts
+++ b/frontend/src/pages/HomePage/components/Carousel/styles.ts
@@ -2,42 +2,45 @@ import styled from '@emotion/styled';
 
 export const CarouselContainer = styled.div`
   position: relative;
-  width: 100%;
-  height: 55vh;
 
   overflow: hidden;
+
+  width: 100%;
   max-width: 80rem;
+  height: 55vh;
 `;
 
 export const SlideList = styled.div`
   display: flex;
   align-items: center;
-  transition: transform 0.5s ease-in-out;
+
   width: 100%;
   height: 100%;
+
+  transition: transform 0.5s ease-in-out;
 `;
 
 export const SlideItem = styled.div`
-  min-width: 100%;
-  height: 100%;
+  position: relative;
 
   display: flex;
   align-items: center;
   justify-content: center;
 
-  position: relative;
+  min-width: 100%;
+  height: 100%;
 `;
 
 export const SlideContent = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  align-items: center;
-
-  width: 100%;
-
   position: absolute;
   left: 0;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+
+  width: 100%;
 
   img {
     width: 80%;
@@ -47,30 +50,36 @@ export const SlideContent = styled.div`
 
 export const Component = styled.div`
   position: absolute;
-  right: 5rem;
   top: 10rem;
+  right: 5rem;
 `;
 
 export const PrevButton = styled.button`
+  cursor: pointer;
+
   position: absolute;
+  z-index: 1;
   top: 50%;
   left: 1rem;
   transform: translateY(-50%);
+
+  font-size: 2rem;
+
   background: none;
   border: none;
-  font-size: 2rem;
-  cursor: pointer;
-  z-index: 1;
 `;
 
 export const NextButton = styled.button`
+  cursor: pointer;
+
   position: absolute;
+  z-index: 1;
   top: 50%;
   right: 1rem;
   transform: translateY(-50%);
+
+  font-size: 2rem;
+
   background: none;
   border: none;
-  font-size: 2rem;
-  cursor: pointer;
-  z-index: 1;
 `;

--- a/frontend/src/pages/HomePage/components/ReviewMeOverview/styles.ts
+++ b/frontend/src/pages/HomePage/components/ReviewMeOverview/styles.ts
@@ -15,6 +15,7 @@ export const ColumnSectionContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
+  align-items: center;
 
   height: 100%;
 

--- a/frontend/src/pages/HomePage/components/URLGeneratorForm/index.tsx
+++ b/frontend/src/pages/HomePage/components/URLGeneratorForm/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useId, useState } from 'react';
 
 import { DataForReviewRequestCode } from '@/apis/group';
 import { Button, Input, EyeButton } from '@/components';
@@ -46,6 +46,14 @@ const URLGeneratorForm = () => {
   const { isOff, handleEyeButtonToggle } = useEyeButton();
   const { isOpen, openModal, closeModal } = useModals();
   const { passwordErrorMessage, handlePasswordBlur } = usePasswordValidation(password);
+
+  const useInputId = useId();
+
+  const INPUT_ID = {
+    reviewName: `review-name-${useInputId}`,
+    projectName: `project-name-${useInputId}`,
+    password: `password-${useInputId}`,
+  };
 
   const isFormValid =
     isValidReviewGroupDataInput(revieweeName) &&
@@ -111,21 +119,21 @@ const URLGeneratorForm = () => {
     <S.URLGeneratorForm>
       <FormLayout title="함께한 팀원으로부터 리뷰를 받아보세요!" direction="column">
         <S.InputContainer>
-          <S.Label htmlFor="reviewee-name">본인의 이름을 적어주세요</S.Label>
-          <Input id="reviewee-name" value={revieweeName} onChange={handleNameInputChange} type="text" />
+          <S.Label htmlFor={INPUT_ID.reviewName}>본인의 이름을 적어주세요</S.Label>
+          <Input id={INPUT_ID.reviewName} value={revieweeName} onChange={handleNameInputChange} type="text" />
           <S.ErrorMessage>{revieweeNameErrorMessage}</S.ErrorMessage>
         </S.InputContainer>
         <S.InputContainer>
-          <S.Label htmlFor="project-name">함께한 프로젝트 이름을 입력해주세요</S.Label>
-          <Input id="project-name" value={projectName} onChange={handleProjectNameInputChange} type="text" />
+          <S.Label htmlFor={INPUT_ID.projectName}>함께한 프로젝트 이름을 입력해주세요</S.Label>
+          <Input id={INPUT_ID.projectName} value={projectName} onChange={handleProjectNameInputChange} type="text" />
           <S.ErrorMessage>{projectNameErrorMessage}</S.ErrorMessage>
         </S.InputContainer>
         <S.InputContainer>
-          <S.Label htmlFor="password">리뷰 확인에 사용할 비밀번호를 적어주세요</S.Label>
+          <S.Label htmlFor={INPUT_ID.password}>리뷰 확인에 사용할 비밀번호를 적어주세요</S.Label>
           <S.InputInfo>{`${MIN_PASSWORD_INPUT}~${MAX_PASSWORD_INPUT}자의 영문(대/소문자),숫자만 사용가능해요`}</S.InputInfo>
           <S.PasswordInputContainer>
             <Input
-              id="password"
+              id={INPUT_ID.password}
               value={password}
               onChange={handlePasswordInputChange}
               onBlur={handlePasswordBlur}

--- a/frontend/src/pages/HomePage/components/URLGeneratorForm/index.tsx
+++ b/frontend/src/pages/HomePage/components/URLGeneratorForm/index.tsx
@@ -112,24 +112,12 @@ const URLGeneratorForm = () => {
       <FormLayout title="함께한 팀원으로부터 리뷰를 받아보세요!" direction="column">
         <S.InputContainer>
           <S.Label htmlFor="reviewee-name">본인의 이름을 적어주세요</S.Label>
-          <Input
-            id="reviewee-name"
-            value={revieweeName}
-            onChange={handleNameInputChange}
-            type="text"
-            placeholder="이름"
-          />
+          <Input id="reviewee-name" value={revieweeName} onChange={handleNameInputChange} type="text" />
           <S.ErrorMessage>{revieweeNameErrorMessage}</S.ErrorMessage>
         </S.InputContainer>
         <S.InputContainer>
           <S.Label htmlFor="project-name">함께한 프로젝트 이름을 입력해주세요</S.Label>
-          <Input
-            id="project-name"
-            value={projectName}
-            onChange={handleProjectNameInputChange}
-            type="text"
-            placeholder="review-me"
-          />
+          <Input id="project-name" value={projectName} onChange={handleProjectNameInputChange} type="text" />
           <S.ErrorMessage>{projectNameErrorMessage}</S.ErrorMessage>
         </S.InputContainer>
         <S.InputContainer>
@@ -142,7 +130,6 @@ const URLGeneratorForm = () => {
               onChange={handlePasswordInputChange}
               onBlur={handlePasswordBlur}
               type={isOff ? 'password' : 'text'}
-              placeholder="abc123"
               $style={{ width: '100%', paddingRight: '3rem' }}
             />
             <EyeButton isOff={isOff} handleEyeButtonToggle={handleEyeButtonToggle} />

--- a/frontend/src/pages/ReviewWritingCardFromPage/components/CardForm/styles.ts
+++ b/frontend/src/pages/ReviewWritingCardFromPage/components/CardForm/styles.ts
@@ -18,10 +18,9 @@ export const SliderContainer = styled.div<SlideContainerProps>`
 
   width: 100%;
   height: ${({ $height }) => $height};
+  margin-bottom: 2rem;
 
   transition: transform 0.5s ease-in-out;
-
-  margin-bottom: 2rem;
 `;
 
 export const Slide = styled.div`

--- a/frontend/src/pages/ReviewZonePage/styles.ts
+++ b/frontend/src/pages/ReviewZonePage/styles.ts
@@ -1,6 +1,11 @@
 import styled from '@emotion/styled';
 
 export const ReviewZonePage = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
- resolves #462

---

### 🚀 어떤 기능을 구현했나요 ?
* [ ] `ReviewZonePage` 및 홈 페이지 캐러셀을 정가운데로 위치시켰습니다.
* [ ] 자동 슬라이드 전환 시간을 6초로 변경했습니다.
* [ ] 홈 페이지 폼 영역에 모든 placeholder를 제거했습니다.

### 🔥 어떻게 해결했나요 ?
- 정가운데에 와야하는 컴포넌트 같은 경우 `align-items: center;`을 추가했습니다. 그리고 슬라이드 전환 시간은 `setTimeout` 을 6초로 변경했습니다.
- `Input` 공동 컴포넌트 `props`에 `placeholder`가 옵셔널로 되어 있어서 사용처에서 해당 속성을 제거했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
- 성장하는 괴물! 커비! 화이팅!!😘