### PR TITLE
[BE] 답변을 길게 작성하는 경우 발생하는 서버 에러 해결

### DIFF
--- a/backend/src/main/java/reviewme/review/domain/TextAnswer.java
+++ b/backend/src/main/java/reviewme/review/domain/TextAnswer.java
@@ -25,7 +25,7 @@ public class TextAnswer {
     @Column(name = "question_id", nullable = false)
     private long questionId;
 
-    @Column(name = "content", nullable = false)
+    @Column(name = "content", nullable = false, length = 5000)
     private String content;
 
     public TextAnswer(long questionId, String content) {

--- a/backend/src/test/java/reviewme/review/service/CreateReviewServiceTest.java
+++ b/backend/src/test/java/reviewme/review/service/CreateReviewServiceTest.java
@@ -151,4 +151,26 @@ class CreateReviewServiceTest {
         assertThat(reviewRepository.findAll()).hasSize(1);
         assertThat(checkboxAnswerRepository.findAll()).hasSize(1);
     }
+
+    @Test
+    void 적정_글자수인_텍스트_응답인_경우_정상_저장된다() {
+        // given
+        String expectedTextAnswer = "답".repeat(1000);
+        Question savedQuestion = questionRepository.save(
+                new Question(true, QuestionType.TEXT, "질문", "가이드라인", 1)
+        );
+        CreateReviewAnswerRequest createReviewAnswerRequest = new CreateReviewAnswerRequest(
+                savedQuestion.getId(), null, expectedTextAnswer
+        );
+        CreateReviewRequest createReviewRequest = new CreateReviewRequest(
+                reviewRequestCode, List.of(createReviewAnswerRequest)
+        );
+
+        // when
+        createReviewService.createReview(createReviewRequest);
+
+        // then
+        assertThat(reviewRepository.findAll()).hasSize(1);
+        assertThat(textAnswerRepository.findAll()).hasSize(1);
+    }
 }


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #471 

---

### 🚀 어떤 기능을 구현했나요 ?
- 답변을 길게 작성하는 경우 발생하는 서버 에러를 해결했습니다.

### 🔥 어떻게 해결했나요 ?
- 한글이 한글자에 평균 3byte라 기본 varchar 255 설정으로는 80자가 넘어가는 경우 db 에러가 발생합니다.
- 따라서, TextAnswer - content 컬럼의 length 속성을 5000으로 설정해주었습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 빠르게 짜서 잘못된 부분 없는지 봐주세요~

### 📚 참고 자료, 할 말
