### PR TITLE
[FE] design: confirm modal의 버튼 관련 디자인 수정

### DIFF
--- a/frontend/src/components/common/modals/ConfirmModal/index.tsx
+++ b/frontend/src/components/common/modals/ConfirmModal/index.tsx
@@ -30,7 +30,7 @@ const ConfirmModal: React.FC<React.PropsWithChildren<ConfirmModalProps>> = ({
   isClosableOnBackground,
   handleClose,
 }) => {
-  const buttonList = [confirmButton, cancelButton];
+  const buttonList = [cancelButton, confirmButton];
   return (
     <ModalPortal>
       <ModalBackground closeModal={isClosableOnBackground ? handleClose : null}>

--- a/frontend/src/components/common/modals/ConfirmModal/styles.ts
+++ b/frontend/src/components/common/modals/ConfirmModal/styles.ts
@@ -27,12 +27,11 @@ export const Contents = styled.div`
 
 export const ButtonContainer = styled.div`
   display: flex;
-  gap: 10%;
   align-items: center;
   justify-content: space-between;
 
   button {
-    width: 40%;
+    width: 46%;
     max-width: 20rem;
   }
 `;


### PR DESCRIPTION


- resolves #473

---

### 🚀 어떤 기능을 구현했나요 ?
- confirm modal 에서 확인, 취소 버튼의 위치를 변경했어요
- confirm modal의 버튼 너비를 키우고 버튼 간 간격을 줄였어요. 

### 🔥 어떻게 해결했나요 ?

<img src="https://github.com/user-attachments/assets/9559762b-b787-4425-bfe8-9d84c42381ff" alt="디자인 변경된 confirm modal" width="600px"/>

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 버튼 간의 간격을 줄이면서 confirm modal 내의 내용과의 레이아웃을 맞추기 위해서 버튼 너비를 키웠어요. 너비와 크기가 적정한지 봐주세요.

### 📚 참고 자료, 할 말
- 집가싶...