### PR TITLE
[FE] design :  홈페이지에서 footer가 스크롤 없이 한 화면에 보이도록 수정

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,7 +19,7 @@ const App = () => {
       )} */}
       <Topbar openSidebar={openSidebar} />
       {breadcrumbPathList.length > 1 && <Breadcrumb pathList={breadcrumbPathList} />}
-      <Main>
+      <Main isBreadCrumb={!!(breadcrumbPathList.length > 1)}>
         <Outlet />
       </Main>
       <Footer />

--- a/frontend/src/components/common/Breadcrumb/styles.ts
+++ b/frontend/src/components/common/Breadcrumb/styles.ts
@@ -2,7 +2,10 @@ import styled from '@emotion/styled';
 
 export const BreadcrumbList = styled.ul`
   display: flex;
+
+  max-height: ${({ theme }) => theme.componentHeight.breadCrumb};
   padding: 2rem 0 0 2.5rem;
+
   font-size: 1.5rem;
   list-style: none;
 `;

--- a/frontend/src/components/layouts/Footer/style.ts
+++ b/frontend/src/components/layouts/Footer/style.ts
@@ -1,16 +1,17 @@
 import styled from '@emotion/styled';
 
 export const Footer = styled.footer`
-  display: flex;
-  gap: 3.2rem;
-  align-items: center;
-  justify-content: center;
   position: absolute;
   bottom: 0;
   left: 0;
 
+  display: flex;
+  gap: 3.2rem;
+  align-items: center;
+  justify-content: center;
+
   width: 100%;
-  height: ${({ theme }) => theme.footerHeight};
+  height: ${({ theme }) => theme.componentHeight.footer};
   padding: 2rem 1rem;
 
   font-size: ${({ theme }) => theme.fontSize.small};

--- a/frontend/src/components/layouts/Main/index.tsx
+++ b/frontend/src/components/layouts/Main/index.tsx
@@ -1,10 +1,14 @@
-import { PropsWithChildren } from 'react';
+import { EssentialPropsWithChildren } from '@/types';
 
 import * as S from './styles';
 
-const Main = ({ children }: PropsWithChildren) => {
+interface MainProps {
+  isBreadCrumb: boolean;
+}
+
+const Main = ({ children, isBreadCrumb }: EssentialPropsWithChildren<MainProps>) => {
   return (
-    <S.MainContainer>
+    <S.MainContainer $isBreadCrumb={isBreadCrumb}>
       <S.Contents>{children}</S.Contents>
     </S.MainContainer>
   );

--- a/frontend/src/components/layouts/Main/index.tsx
+++ b/frontend/src/components/layouts/Main/index.tsx
@@ -3,7 +3,7 @@ import { EssentialPropsWithChildren } from '@/types';
 import * as S from './styles';
 
 interface MainProps {
-  isBreadCrumb: boolean;
+  isBreadCrumb?: boolean;
 }
 
 const Main = ({ children, isBreadCrumb }: EssentialPropsWithChildren<MainProps>) => {

--- a/frontend/src/components/layouts/Main/styles.ts
+++ b/frontend/src/components/layouts/Main/styles.ts
@@ -5,8 +5,10 @@ export const MainContainer = styled.div`
   align-items: center;
   justify-content: center;
 
-  min-height: (100vh - 43rem);
-  margin-bottom: calc(${({ theme }) => theme.footerHeight});
+  min-height: calc(
+    100vh - ${({ theme }) => theme.componentHeight.topbar} - ${({ theme }) => theme.componentHeight.footer}
+  );
+  margin-bottom: ${({ theme }) => theme.componentHeight.footer};
 `;
 
 export const Contents = styled.div`
@@ -19,6 +21,7 @@ export const Contents = styled.div`
   width: 100%;
   max-width: ${({ theme }) => theme.breakpoints.desktop};
   height: 100%;
+  min-height: inherit;
 
   border-radius: 0.5rem;
 `;

--- a/frontend/src/components/layouts/Main/styles.ts
+++ b/frontend/src/components/layouts/Main/styles.ts
@@ -2,7 +2,7 @@ import { css, Theme } from '@emotion/react';
 import styled from '@emotion/styled';
 
 interface MainContainerProps {
-  $isBreadCrumb: boolean;
+  $isBreadCrumb?: boolean;
 }
 const calculateMinHeight = ({ $isBreadCrumb, ...theme }: MainContainerProps & Theme) => {
   const topbarHeight = theme.componentHeight.topbar;

--- a/frontend/src/components/layouts/Main/styles.ts
+++ b/frontend/src/components/layouts/Main/styles.ts
@@ -1,13 +1,23 @@
+import { css, Theme } from '@emotion/react';
 import styled from '@emotion/styled';
 
-export const MainContainer = styled.div`
+interface MainContainerProps {
+  $isBreadCrumb: boolean;
+}
+const calculateMinHeight = ({ $isBreadCrumb, ...theme }: MainContainerProps & Theme) => {
+  const topbarHeight = theme.componentHeight.topbar;
+  const footerHeight = theme.componentHeight.footer;
+  const breadCrumbHeight = $isBreadCrumb ? theme.componentHeight.breadCrumb : '0rem';
+
+  return `calc(100vh - ${topbarHeight} - ${footerHeight} - ${breadCrumbHeight})`;
+};
+
+export const MainContainer = styled.div<MainContainerProps>`
   display: flex;
   align-items: center;
   justify-content: center;
 
-  min-height: calc(
-    100vh - ${({ theme }) => theme.componentHeight.topbar} - ${({ theme }) => theme.componentHeight.footer}
-  );
+  min-height: ${({ theme, $isBreadCrumb }) => css(calculateMinHeight({ $isBreadCrumb, ...theme }))};
   margin-bottom: ${({ theme }) => theme.componentHeight.footer};
 `;
 

--- a/frontend/src/components/layouts/Topbar/styles.ts
+++ b/frontend/src/components/layouts/Topbar/styles.ts
@@ -6,7 +6,7 @@ export const Layout = styled.section`
 
   box-sizing: border-box;
   width: 100%;
-  height: 7rem;
+  height: ${({ theme }) => theme.componentHeight.topbar};
   padding: 2rem 2.5rem;
 
   border-bottom: 0.1rem solid ${({ theme }) => theme.colors.lightGray};

--- a/frontend/src/pages/HomePage/components/ReviewMeOverview/styles.ts
+++ b/frontend/src/pages/HomePage/components/ReviewMeOverview/styles.ts
@@ -2,23 +2,18 @@ import styled from '@emotion/styled';
 
 export const ReviewMeOverview = styled.section`
   position: relative;
-
   overflow: hidden;
-
   width: 65%;
-  height: calc(100% - 4rem); // NOTE: 4rem은 footer 높이
-
   background-color: ${({ theme }) => theme.colors.lightPurple};
 `;
 
 export const ColumnSectionContainer = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
+  justify-content: center;
 
   height: 100%;
-
   padding: 3rem;
 `;
 

--- a/frontend/src/pages/HomePage/styles.ts
+++ b/frontend/src/pages/HomePage/styles.ts
@@ -3,5 +3,5 @@ import styled from '@emotion/styled';
 export const HomePage = styled.div`
   display: flex;
   width: 100vw;
-  height: calc(100vh - 7rem); // NOTE: 7rem은 Topbar 높이
+  min-height: inherit;
 `;

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -9,8 +9,12 @@ export const sidebarWidth: ThemeProperty<string> = {
   desktop: '25rem',
   mobile: '100vw',
 };
-export const footerHeight = '6rem';
 
+export const componentHeight = {
+  footer: '6rem',
+  topbar: '7rem',
+  breadCrumb: '43rem',
+};
 export const breakpoints: ThemeProperty<string> = {
   desktop: '102.4rem',
   tablet: '72rem',
@@ -67,7 +71,7 @@ const theme: Theme = {
   sidebarWidth,
   borderRadius,
   formWidth,
-  footerHeight,
+  componentHeight,
 };
 
 export default theme;

--- a/frontend/src/types/emotion.ts
+++ b/frontend/src/types/emotion.ts
@@ -8,6 +8,7 @@ import {
   breakpoints,
   sidebarWidth,
   borderRadius,
+  componentHeight,
 } from '../styles/theme';
 
 // TODO: export 해서 사용하지 않다면 리팩토링
@@ -18,6 +19,7 @@ export type FontWeight = typeof fontWeight;
 export type Breakpoints = typeof breakpoints;
 export type SidebarWidthStyle = typeof sidebarWidth;
 export type BorderRadius = typeof borderRadius;
+export type ComponentHeight = typeof componentHeight;
 
 type ThemeType = {
   fontSize: FontSize;
@@ -28,7 +30,7 @@ type ThemeType = {
   sidebarWidth: SidebarWidthStyle;
   borderRadius: BorderRadius;
   formWidth: string;
-  footerHeight: string;
+  componentHeight: ComponentHeight;
 };
 
 declare module '@emotion/react' {

--- a/frontend/src/types/emotion.ts
+++ b/frontend/src/types/emotion.ts
@@ -1,24 +1,32 @@
 import '@emotion/react';
 
-import { colors, fontSize, fontWeight, zIndex, breakpoints, sidebarWidth, borderRadius } from '../styles/theme';
+import {
+  colors,
+  fontSize,
+  fontWeight,
+  zIndex,
+  breakpoints,
+  sidebarWidth,
+  borderRadius,
+} from '../styles/theme';
 
 // TODO: export 해서 사용하지 않다면 리팩토링
-export type colorType = typeof colors;
-export type zIndexType = typeof zIndex;
-export type fontSizeType = typeof fontSize;
-export type fontWeightType = typeof fontWeight;
-export type breakpoints = typeof breakpoints;
-export type sidebarWidth = typeof sidebarWidth;
-export type borderRadius = typeof borderRadius;
+export type Color = typeof colors;
+export type ZIndex = typeof zIndex;
+export type FontSize = typeof fontSize;
+export type FontWeight = typeof fontWeight;
+export type Breakpoints = typeof breakpoints;
+export type SidebarWidthStyle = typeof sidebarWidth;
+export type BorderRadius = typeof borderRadius;
 
 type ThemeType = {
-  fontSize: fontSizeType;
-  fontWeight: fontWeightType;
-  colors: colorType;
-  zIndex: zIndexType;
-  breakpoints: breakpoints;
-  sidebarWidth: sidebarWidth;
-  borderRadius: borderRadius;
+  fontSize: FontSize;
+  fontWeight: FontWeight;
+  colors: Color;
+  zIndex: ZIndex;
+  breakpoints: Breakpoints;
+  sidebarWidth: SidebarWidthStyle;
+  borderRadius: BorderRadius;
   formWidth: string;
   footerHeight: string;
 };


### PR DESCRIPTION


- resolves #475

---

### 🚀 어떤 기능을 구현했나요 ?
-  홈페이지에서 footer가 스크롤 없이 한 화면에 보이도록 수정했어요.
- breadcrumbPathList에 따라 Main의 min-height를 동적으로 변경하도록 했어요. 

### 🔥 어떻게 해결했나요 ?
-  Main 컴포넌트의 min-height에 css 코드에서 오류가 있었어요. (calc를 넣지 않았음) 해당 오류를 수정했어요.
-  Main 하위의  Contents와 HomePage에서도  Main의 min-height를 상속 받을 수 있도록 `min-height=inherit`을 적용했어요.
- component에 대한 height를 관리하는 theme을 추가했어요.
- breadcrumbPathList에 따라 Main의 min-height를 동적으로 변경하는 기능을 추가했어요.

![스크린샷 2024-08-20 204626](https://github.com/user-attachments/assets/ead25fa7-c50a-4291-8748-dd53d3b95c3b)
![스크린샷 2024-08-20 204639](https://github.com/user-attachments/assets/f78fb281-e482-436d-9967-0f018bd0b4f6)


### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- theme을 정의하는 스타일 타입들이 소문자로 시작해서, 대문자로 변경하면서 타입명이 변경되었어요. 확인해주세요.

### 📚 참고 자료, 할 말
- 집에 가야지~~~