### PR TITLE
[FE] fix: 객관식 내용과 주관식 질문 간의 gap 띄우기

### DIFF
--- a/frontend/src/pages/ReviewWritingCardFromPage/components/AnswerListRecheckModal/index.tsx
+++ b/frontend/src/pages/ReviewWritingCardFromPage/components/AnswerListRecheckModal/index.tsx
@@ -41,7 +41,7 @@ const AnswerListRecheckModal = ({ questionSectionList, answerMap, closeModal }: 
                     <QuestionCard questionType="normal" question={question.content} />
                     <S.ContentContainer>
                       {question.questionType === 'CHECKBOX' && (
-                        <div>
+                        <>
                           {question.optionGroup?.options.map((option, index) => (
                             <CheckboxItem
                               key={`${question.questionId}_${index}`}
@@ -53,17 +53,17 @@ const AnswerListRecheckModal = ({ questionSectionList, answerMap, closeModal }: 
                               $isReadonly={true}
                             />
                           ))}
-                        </div>
+                        </>
                       )}
 
                       {question.questionType === 'TEXT' && (
-                        <div>
+                        <>
                           {findTextAnswer(question.questionId) ? (
                             <MultilineTextViewer text={findTextAnswer(question.questionId) as string} />
                           ) : (
                             <S.EmptyTextAnswer>작성한 답변이 없어요</S.EmptyTextAnswer>
                           )}
-                        </div>
+                        </>
                       )}
                     </S.ContentContainer>
                   </S.QuestionCardContainer>

--- a/frontend/src/pages/ReviewWritingCardFromPage/components/AnswerListRecheckModal/index.tsx
+++ b/frontend/src/pages/ReviewWritingCardFromPage/components/AnswerListRecheckModal/index.tsx
@@ -1,5 +1,3 @@
-import { Fragment } from 'react';
-
 import { CheckboxItem, MultilineTextViewer } from '@/components';
 import ContentModal from '@/components/common/modals/ContentModal';
 import { ReviewWritingAnswer, ReviewWritingCardSection } from '@/types';
@@ -7,6 +5,10 @@ import { ReviewWritingAnswer, ReviewWritingCardSection } from '@/types';
 import QuestionCard from './components/QuestionCard';
 import ReviewCard from './components/ReviewCard';
 import * as S from './styles';
+
+export interface QuestionCardContainerStyleProps {
+  $index: number;
+}
 
 interface AnswerListRecheckModalProps {
   questionSectionList: ReviewWritingCardSection[];
@@ -34,36 +36,39 @@ const AnswerListRecheckModal = ({ questionSectionList, answerMap, closeModal }: 
           {questionSectionList.map((section) => (
             <S.ReviewCardWrapper key={section.sectionId}>
               <ReviewCard title={section.header}>
-                {section.questions.map((question) => (
-                  <Fragment key={question.questionId}>
+                {section.questions.map((question, index) => (
+                  <S.QuestionCardContainer key={question.questionId} $index={index}>
                     <QuestionCard questionType="normal" question={question.content} />
                     <S.ContentContainer>
-                      {question.questionType === 'CHECKBOX' && (
-                        <div>
-                          {question.optionGroup?.options.map((option, index) => (
-                            <CheckboxItem
-                              key={`${question.questionId}_${index}`}
-                              id={`${question.questionId}_${index}`}
-                              name={`${question.questionId}_${index}`}
-                              isChecked={isSelectedChoice(question.questionId, option.optionId)}
-                              isDisabled={true}
-                              label={option.content}
-                              $isReadonly={true}
-                            />
-                          ))}
-                        </div>
-                      )}
+                      <div>
+                        {question.questionType === 'CHECKBOX' && (
+                          <div>
+                            {question.optionGroup?.options.map((option, index) => (
+                              <CheckboxItem
+                                key={`${question.questionId}_${index}`}
+                                id={`${question.questionId}_${index}`}
+                                name={`${question.questionId}_${index}`}
+                                isChecked={isSelectedChoice(question.questionId, option.optionId)}
+                                isDisabled={true}
+                                label={option.content}
+                                $isReadonly={true}
+                              />
+                            ))}
+                          </div>
+                        )}
+                      </div>
+
                       {question.questionType === 'TEXT' && (
-                        <S.TextAnswerWrapper>
+                        <div>
                           {findTextAnswer(question.questionId) ? (
                             <MultilineTextViewer text={findTextAnswer(question.questionId) as string} />
                           ) : (
                             <S.EmptyTextAnswer>작성한 답변이 없어요</S.EmptyTextAnswer>
                           )}
-                        </S.TextAnswerWrapper>
+                        </div>
                       )}
                     </S.ContentContainer>
-                  </Fragment>
+                  </S.QuestionCardContainer>
                 ))}
               </ReviewCard>
             </S.ReviewCardWrapper>

--- a/frontend/src/pages/ReviewWritingCardFromPage/components/AnswerListRecheckModal/index.tsx
+++ b/frontend/src/pages/ReviewWritingCardFromPage/components/AnswerListRecheckModal/index.tsx
@@ -40,23 +40,21 @@ const AnswerListRecheckModal = ({ questionSectionList, answerMap, closeModal }: 
                   <S.QuestionCardContainer key={question.questionId} $index={index}>
                     <QuestionCard questionType="normal" question={question.content} />
                     <S.ContentContainer>
-                      <div>
-                        {question.questionType === 'CHECKBOX' && (
-                          <div>
-                            {question.optionGroup?.options.map((option, index) => (
-                              <CheckboxItem
-                                key={`${question.questionId}_${index}`}
-                                id={`${question.questionId}_${index}`}
-                                name={`${question.questionId}_${index}`}
-                                isChecked={isSelectedChoice(question.questionId, option.optionId)}
-                                isDisabled={true}
-                                label={option.content}
-                                $isReadonly={true}
-                              />
-                            ))}
-                          </div>
-                        )}
-                      </div>
+                      {question.questionType === 'CHECKBOX' && (
+                        <div>
+                          {question.optionGroup?.options.map((option, index) => (
+                            <CheckboxItem
+                              key={`${question.questionId}_${index}`}
+                              id={`${question.questionId}_${index}`}
+                              name={`${question.questionId}_${index}`}
+                              isChecked={isSelectedChoice(question.questionId, option.optionId)}
+                              isDisabled={true}
+                              label={option.content}
+                              $isReadonly={true}
+                            />
+                          ))}
+                        </div>
+                      )}
 
                       {question.questionType === 'TEXT' && (
                         <div>

--- a/frontend/src/pages/ReviewWritingCardFromPage/components/AnswerListRecheckModal/styles.ts
+++ b/frontend/src/pages/ReviewWritingCardFromPage/components/AnswerListRecheckModal/styles.ts
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
+import { QuestionCardContainerStyleProps } from '.';
+
 export const AnswerListContainer = styled.div``;
 
 export const CardLayout = styled.div`
@@ -13,6 +15,10 @@ export const CardLayout = styled.div`
   width: ${({ theme }) => theme.formWidth};
 `;
 
+export const QuestionCardContainer = styled.div<QuestionCardContainerStyleProps>`
+  margin-top: ${({ $index }) => ($index === 1 ? '3rem' : '0')};
+`;
+
 export const ContentContainer = styled.div`
   display: flex;
   flex-direction: column;
@@ -22,10 +28,6 @@ export const ReviewCardWrapper = styled.div`
   overflow: hidden;
   border: 0.2rem solid ${({ theme }) => theme.colors.lightPurple};
   border-radius: ${({ theme }) => theme.borderRadius.basic};
-`;
-
-export const TextAnswerWrapper = styled.div`
-  margin-top: 1rem;
 `;
 
 export const EmptyTextAnswer = styled.p`


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #477 

---

### 🚀 어떤 기능을 구현했나요 ?
- 리뷰 확인 모달에서 객관식 질문과 서술형 질문이 있을 때, 두 질문 사이의 gap이 없는 문제를 해결했습니다.

### 🔥 어떻게 해결했나요 ?
- 큰 질문(Section 주제 질문)에 딸린 작은 질문들(객관식, 서술향)을 감싸고 있는 Container에서, 작은 질문이 몇 번째 질문인지를 파악할 수 있는 index를 이용해 스타일을 조정했습니다.
- 두 번째 질문(서술형), 즉 인덱스가 1인 질문일 때만 margin-top을 적용합니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- `ReviewCard`의 `title`이 큰 질문이고 `question.questionType === 'CHECKBOX'`와 `question.questionType === 'TEXT'`가 각각 객관식, 서술형 질문입니다.

### 📚 참고 자료, 할 말
- 이렇게 복잡한 구조의 스타일을 리팩토링할 때는 컴포넌트와 css 그 자체보다는 데이터 형식을 보고 index같은 데이터의 도움을 받아 스타일을 작성하는 게 좋은 것 같습니다.
  - css 단독으로 문제를 해결하려 하지 말고 데이터 정보를 적극적으로 받아서 해결하자!
- 조건부 렌더링을 할 때 조건식에 스타일을 주는 건 힘들다. 부모를 통해서 우회적으로 적용하는 게 낫다.