### PR TITLE
[FE] rafactor: isSuccess 상태에 따라 리뷰 목록 페이지 전체 레이아웃 렌더링 및 리뷰 목록 간격 수정

### DIFF
--- a/frontend/src/pages/ReviewListPage/components/PageContents/index.tsx
+++ b/frontend/src/pages/ReviewListPage/components/PageContents/index.tsx
@@ -20,32 +20,36 @@ interface PageContentsProps {
 const PageContents = ({ groupAccessCode, reviewRequestCode }: PageContentsProps) => {
   const navigate = useNavigate();
 
-  const { data: reviewListData } = useGetReviewList(groupAccessCode, reviewRequestCode);
+  const { data: reviewListData, isSuccess } = useGetReviewList(groupAccessCode, reviewRequestCode);
 
   const handleReviewClick = (id: number) => {
     navigate(`/user/detailed-review/${id}`);
   };
 
   return (
-    <S.Layout>
-      <ReviewInfoSection projectName={reviewListData.projectName} revieweeName={reviewListData.revieweeName} />
-      {reviewListData.reviews.length === 0 && <ReviewEmptySection />}
-      {/* <SearchSection handleChange={() => {}} options={OPTIONS} placeholder={USER_SEARCH_PLACE_HOLDER} /> */}
-      <S.ReviewSection>
-        {reviewListData.reviews.map((review) => (
-          // const isLastElement = pageIndex === data.pages.length - 1 && reviewIndex === page.reviews.length - 1;
-          <div key={review.reviewId} onClick={() => handleReviewClick(review.reviewId)}>
-            <ReviewCard
-              projectName={reviewListData.projectName}
-              createdAt={review.createdAt}
-              contentPreview={review.contentPreview}
-              categories={review.categories}
-            />
-            {/* <div ref={isLastElement ? lastReviewElementRef : null}></div> */}
-          </div>
-        ))}
-      </S.ReviewSection>
-    </S.Layout>
+    <>
+      {isSuccess && (
+        <S.Layout>
+          <ReviewInfoSection projectName={reviewListData.projectName} revieweeName={reviewListData.revieweeName} />
+          {reviewListData.reviews.length === 0 ? (
+            <ReviewEmptySection />
+          ) : (
+            <S.ReviewSection>
+              {reviewListData.reviews.map((review) => (
+                <div key={review.reviewId} onClick={() => handleReviewClick(review.reviewId)}>
+                  <ReviewCard
+                    projectName={reviewListData.projectName}
+                    createdAt={review.createdAt}
+                    contentPreview={review.contentPreview}
+                    categories={review.categories}
+                  />
+                </div>
+              ))}
+            </S.ReviewSection>
+          )}
+        </S.Layout>
+      )}
+    </>
   );
 };
 

--- a/frontend/src/pages/ReviewListPage/components/PageContents/styles.ts
+++ b/frontend/src/pages/ReviewListPage/components/PageContents/styles.ts
@@ -10,5 +10,5 @@ export const Layout = styled.div`
 export const ReviewSection = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 7rem;
+  gap: 4rem;
 `;


### PR DESCRIPTION
- resolves #480

---

### 🚀 어떤 기능을 구현했나요 ?
- `isSuccess` 상태에 따라 리뷰 목록 페이지 전체 레이아웃을 렌더링하고 리뷰 목록 간격을 조정했습니다.

### 🔥 어떻게 해결했나요 ?
- 기존에는 `isSuccess` 상태와 관계없이 리뷰를 받아오기 전에 `널~` 문구가 표시되는 문제가 있었습니다. 리뷰를 fetch하는 동안 `널~` 문구가 잠시 보이고, 몇 초 후에 리뷰가 렌더링되는 이슈를 해결하기 위해 `isSuccess` 상태가 `true`일 때만 전체 레이아웃을 렌더링하도록 변경했습니다.

```tsx
  return (
    <>
      {isSuccess && (
        <S.Layout>
          <ReviewInfoSection projectName={reviewListData.projectName} revieweeName={reviewListData.revieweeName} />
          {reviewListData.reviews.length === 0 ? (
            <ReviewEmptySection />
          ) : (
            <S.ReviewSection>
              {reviewListData.reviews.map((review) => (
                <div key={review.reviewId} onClick={() => handleReviewClick(review.reviewId)}>
                  <ReviewCard
                    projectName={reviewListData.projectName}
                    createdAt={review.createdAt}
                    contentPreview={review.contentPreview}
                    categories={review.categories}
                  />
                </div>
              ))}
            </S.ReviewSection>
          )}
        </S.Layout>
      )}
    </>
  );
```

- 리뷰 목록 간격을 `7rem`에서 `4rem`으로 수정했습니다.
<img width="787" alt="스크린샷 2024-08-21 오전 9 35 26" src="https://github.com/user-attachments/assets/dff911d5-d706-48dd-9d74-a07a37e99f35">


### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
- 우산 챙기세요~ 여러분~