### PR TITLE
[FE] refactor: react-query에 retry 설정 추가

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -41,9 +41,9 @@ export function retryFunction(failureCount: number, error: Error): boolean {
   const isServerError = message === API_ERROR_MESSAGE.serverError;
 
   // Fetch API로 인해 발생한 오류인지 확인
-  if (isServerError) {
-    return failureCount < 1; // 500번대 에러이면 한 번 더 재시도
-  }
+  // 500번대 에러이면 한 번 더 재시도
+  if (isServerError) return failureCount < 1;
+
   return false; // 그 외의 경우 재시도하지 않음
 }
 


### PR DESCRIPTION

- resolves #486

---

### 🚀 어떤 기능을 구현했나요 ?
- queryClient에서  500단 에러에서는 api  재요청하고, 그렇지 않은 경우에는 api 재요청를 하지 않도록 retry를 설정했어요.

### 🔥 어떻게 해결했나요 ?
#### 400단 에러 시 한번만 요청
![스크린샷 2024-08-21 101855](https://github.com/user-attachments/assets/c30a7b3a-7fb9-4a0b-b305-158a7005a579)

#### 500단 에러 시 두번 요청
![스크린샷 2024-08-21 101916](https://github.com/user-attachments/assets/1a1d6494-6f30-4efa-9c12-5a158be9955b)

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
#### 왜 400단 에러는 재요청하지 않고 500단 에러는 재요청하는가?
-  400단 에러는 요청 권한이 없거나, 요청 형식이 안맞는 등 클라이언트 책임 오류라 다시 시도 한다고 오류가 해결되지 않아요. 그러나 500단 에러는 서버쪽 오류로 일시적인 오류일 가능성이 있어요. 그래서 500단 에러는 재요청을 하도록 했어요 
- status.code에 따른 재요청 건수에 대해 다른 의견이 있다면 말씀해주세요.

### 📚 참고 자료, 할 말
- 슈슈슈슈슝~