### PR TITLE
[FE] chore: 리뷰미 저작권 표시 및 Icons8 저작권 표기를 공식 문서대로 변경

### DIFF
--- a/frontend/src/components/layouts/Footer/index.tsx
+++ b/frontend/src/components/layouts/Footer/index.tsx
@@ -9,7 +9,7 @@ const Footer = () => {
         </S.Link>
       </div>
       <div>
-        {'Icons By '}
+        {'Icons by '}
         <S.Link href="https://icons8.com/" aria-label="Icons8 홈페이지">
           Icons8
         </S.Link>

--- a/frontend/src/components/layouts/Footer/index.tsx
+++ b/frontend/src/components/layouts/Footer/index.tsx
@@ -5,7 +5,7 @@ const Footer = () => {
     <S.Footer>
       <div>
         <S.Link href="https://github.com/woowacourse-teams/2024-review-me" aria-label="리뷰미 깃헙 저장소">
-          ⓒ 2024 Review me All rights reserved
+          ⓒ 2024 review-me All rights reserved
         </S.Link>
       </div>
       <div>

--- a/frontend/src/components/layouts/Footer/index.tsx
+++ b/frontend/src/components/layouts/Footer/index.tsx
@@ -5,13 +5,13 @@ const Footer = () => {
     <S.Footer>
       <div>
         <S.Link href="https://github.com/woowacourse-teams/2024-review-me" aria-label="리뷰미 깃헙 저장소">
-          © review-me
+          ⓒ 2024 Review me All rights reserved
         </S.Link>
       </div>
       <div>
-        Icon By &nbsp;
-        <S.Link href="https://icons8.com/" aria-label="icon8 홈페이지">
-          icon8
+        {'Icons By '}
+        <S.Link href="https://icons8.com/" aria-label="Icons8 홈페이지">
+          Icons8
         </S.Link>
       </div>
     </S.Footer>


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #493 

---

### 🚀 어떤 기능을 구현했나요 ?
![image](https://github.com/user-attachments/assets/11b1c985-ec7f-4b0c-a47c-95693176913e)

- 리뷰미 저작권 표기를 일반적인 형식대로 변경했습니다.
- Icons8의 저작권 표기를 공식 문서에 나온 대로 변경했습니다.
- `Icons By Icons8` 부분에서 By와 Icons8 사이를 `&nsbp`로 띄어쓰기하면 일반 문자열인 Icons By와 `&nsbp`를 사용한 부분의 간격이 다른 문제를 해결했습니다.

- ![image](https://github.com/user-attachments/assets/df880614-1166-4849-8825-397504de4198)
- ![image](https://github.com/user-attachments/assets/adc5d1d6-4a7f-4ea1-a23e-1bf373e25f47)

### 🔥 어떻게 해결했나요 ?
- `Icons By `로 문자열 상에서 띄어쓰기를 적용하고, `&nsbp`를 삭제했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
- 공식 문서를 확인하자!