### PR TITLE
[FE] fix: 캐러셀에서 마지막 슬라이드가 넘어갈 때 자연스럽게 첫 슬라이드로 넘어가도록 수정

### DIFF
--- a/frontend/src/pages/HomePage/components/Carousel/index.tsx
+++ b/frontend/src/pages/HomePage/components/Carousel/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect } from 'react';
+import { useRef, useState, useEffect } from 'react';
 
 import * as S from './styles';
 
@@ -8,43 +8,80 @@ export interface Slide {
 }
 
 interface CarouselProps {
-  slides: Slide[];
+  slideList: Slide[];
 }
 
-const Carousel = ({ slides }: CarouselProps) => {
-  const [currentSlide, setCurrentSlide] = useState(0);
+const REAL_START_INDEX = 1;
+
+const TRANSITION_DURATION = 500; // NOTE: 트랜지션(애니메이션) 시간
+const AUTO_SLIDE_INTERVAL = 6000; // NOTE: 자동 슬라이드 시간
+
+const Carousel = ({ slideList }: CarouselProps) => {
+  // NOTE: 마지막 슬라이드를 복제해서 slideList의 맨 앞에 추가하므로 처음에 보여져야 하는 슬라이드는 1번 인덱스
+  const [currentSlideIndex, setCurrentSlideIndex] = useState(REAL_START_INDEX);
+  const [isTransitioning, setIsTransitioning] = useState(false);
   const slideRef = useRef<HTMLDivElement>(null);
+
+  const slideLength = slideList.length;
+  // NOTE: 첫 슬라이드와 마지막 슬라이드의 복제본을 각각 맨 뒤, 맨 처음에 추가
+  const clonedSlideList = [slideList[slideLength - 1], ...slideList, slideList[0]];
 
   const scrollToSlide = (index: number) => {
     if (slideRef.current) {
+      setIsTransitioning(true);
+
       const slideWidth = slideRef.current.clientWidth;
-      slideRef.current.style.transform = `translateX(-${slideWidth * index}px)`;
+      slideRef.current.style.transition = 'transform 0.5s ease-in-out';
+      slideRef.current.style.transform = `translateX(-${slideWidth * index * 0.1}rem)`;
     }
-    setCurrentSlide(index);
+    setCurrentSlideIndex(index);
   };
 
   const nextSlide = () => {
-    const nextIndex = (currentSlide + 1) % slides.length;
-    scrollToSlide(nextIndex);
+    scrollToSlide(currentSlideIndex + 1);
   };
 
   const prevSlide = () => {
-    const prevIndex = (currentSlide - 1 + slides.length) % slides.length;
-    scrollToSlide(prevIndex);
+    scrollToSlide(currentSlideIndex - 1);
   };
 
+  // NOTE: 맨 처음/맨 끝 슬라이드 전환용 useEffect
+  useEffect(() => {
+    if (isTransitioning) {
+      if (currentSlideIndex === slideLength + 1) {
+        // 마지막 슬라이드 처리
+        setTimeout(() => {
+          setIsTransitioning(false);
+          slideRef.current!.style.transition = 'none';
+          slideRef.current!.style.transform = `translateX(-${slideRef.current!.clientWidth * 0.1}rem)`;
+          setCurrentSlideIndex(REAL_START_INDEX);
+        }, TRANSITION_DURATION); // NOTE: 애니메이션 트랜지션 시간과 동일하게 설정 (0.5초)
+      }
+      if (currentSlideIndex === 0) {
+        // 첫 번째 슬라이드 처리
+        setTimeout(() => {
+          setIsTransitioning(false);
+          slideRef.current!.style.transition = 'none';
+          slideRef.current!.style.transform = `translateX(-${slideRef.current!.clientWidth * slideLength * 0.1}rem)`;
+          setCurrentSlideIndex(slideLength);
+        }, TRANSITION_DURATION);
+      }
+    }
+  }, [currentSlideIndex, slideLength]);
+
+  // NOTE: 슬라이드 자동 이동용
   useEffect(() => {
     const timeout = setTimeout(() => {
       nextSlide();
-    }, 6000); // 자동 슬라이드 이동 간격 (6초)
+    }, AUTO_SLIDE_INTERVAL);
 
     return () => clearTimeout(timeout);
-  }, [currentSlide]);
+  }, [currentSlideIndex]);
 
   return (
     <S.CarouselContainer>
       <S.SlideList ref={slideRef}>
-        {slides.map((slide, index) => (
+        {clonedSlideList.map((slide, index) => (
           <S.SlideItem key={index}>
             <S.SlideContent>
               <img src={slide.imageSrc} alt={slide.alt} />
@@ -53,11 +90,11 @@ const Carousel = ({ slides }: CarouselProps) => {
         ))}
       </S.SlideList>
       <S.IndicatorWrapper>
-        {slides.map((_, index) => (
+        {slideList.map((_, index) => (
           <S.Indicator
             key={`indicator_${index}`}
-            focused={index === currentSlide}
-            onClick={() => scrollToSlide(index)}
+            focused={index === (currentSlideIndex - 1 + slideLength) % slideLength}
+            onClick={() => scrollToSlide(index + 1)}
           />
         ))}
       </S.IndicatorWrapper>

--- a/frontend/src/pages/HomePage/components/ReviewMeOverview/index.tsx
+++ b/frontend/src/pages/HomePage/components/ReviewMeOverview/index.tsx
@@ -32,7 +32,7 @@ const ReviewMeOverview = () => {
           <img src={WritingIcon} alt={OVERVIEW_TITLE} />
           <S.OverviewTitle>{OVERVIEW_TITLE}</S.OverviewTitle>
         </S.OverviewTitleContainer>
-        <Carousel slides={OVERVIEW_SLIDES_LIST} />
+        <Carousel slideList={OVERVIEW_SLIDES_LIST} />
       </S.ColumnSectionContainer>
     </S.ReviewMeOverview>
   );


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #507 

---

### 🚀 어떤 기능을 구현했나요 ?
- 캐러셀이 맨 뒤에 도달했을 때 첫 번째 슬라이드로 자연스럽게 이동하는 기능을 추가했습니다.

### 🔥 어떻게 해결했나요 ?
- 다음과 같은 트릭으로 해결했습니다.
1. 기존 배열의 맨 앞, 맨 뒤에 맨 마지막 요소와 첫 번째 요소 추가
  ```tsx
     const clonedSlideList = [slideList[slideLength - 1], ...slideList, slideList[0]];
  ```
2. 마지막 슬라이드에서 다음으로 넘어갈 때, 맨 마지막 요소로 복제해둔 첫 번째 슬라이드(위의 `slideList[0]`)로 일단 이동(이때 자연스러운 애니메이션-우측으로 1칸 이동-이 적용됨)
3. translate 시간이 지나면 애니메이션 효과를 잠시 끄고(`slideRef.current!.style.transition = 'none';`) 실제로 이동해야 하는 슬라이드(`slideList[1]`)로 바로 이동해서 실제 인덱스도 첫 슬라이드를 바라보게 함
(반대 경우인 첫 슬라이드 -> 마지막 슬라이드 이동도 위와 같은 원리로 진행됩니다)

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 주석이 코드 이해에 도움이 됐는지 궁금해요

### 📚 참고 자료, 할 말
- 나중에 훅으로 빼야 할 로직들이 있군요...
- 버그 보고!!!!!! 맨 처음에 렌더링됐을 때 첫 슬라이드 -> 마지막 슬라이드로 이동하면 화면 전환이 이루어지지 않는 문제가 있습니다!!!
- [참고한 블로그](https://doooodle932.tistory.com/130)