### PR TITLE
[FE] fix: 홈 페이지 캐러셀 초기 슬라이드 위치 조정 및 ConfirmModal에 props로 title을 받아서 디자인 수정

### DIFF
--- a/frontend/src/components/common/modals/ContentModal/index.tsx
+++ b/frontend/src/components/common/modals/ContentModal/index.tsx
@@ -7,15 +7,17 @@ import ModalPortal from '../ModalPortal';
 import * as S from './styles';
 
 interface ContentModalProps {
+  title?: string;
   handleClose: () => void;
 }
 
-const ContentModal = ({ handleClose, children }: EssentialPropsWithChildren<ContentModalProps>) => {
+const ContentModal = ({ title, handleClose, children }: EssentialPropsWithChildren<ContentModalProps>) => {
   return (
     <ModalPortal>
       <ModalBackground closeModal={handleClose}>
         <S.ContentModalContainer>
           <S.ContentModalHeader>
+            <S.Title>{title}</S.Title>
             <S.CloseButton onClick={handleClose}>
               <img src={CloseIcon} alt="모달 닫기" />
             </S.CloseButton>

--- a/frontend/src/components/common/modals/ContentModal/styles.ts
+++ b/frontend/src/components/common/modals/ContentModal/styles.ts
@@ -23,14 +23,22 @@ export const ContentModalContainer = styled.div`
 
 export const ContentModalHeader = styled.div`
   display: flex;
-  justify-content: flex-end;
+  gap: 2rem;
+  align-items: center;
+  justify-content: space-between;
+
   width: 100%;
   height: 3rem;
 `;
 
+export const Title = styled.span`
+  font-size: 1.8rem;
+  font-weight: ${({ theme }) => theme.fontWeight.bold};
+`;
+
 export const Contents = styled.div`
   overflow-y: auto;
-  padding-right: 1.2rem;
+  width: 100%;
 `;
 
 export const CloseButton = styled.button`

--- a/frontend/src/pages/HomePage/components/Carousel/index.tsx
+++ b/frontend/src/pages/HomePage/components/Carousel/index.tsx
@@ -26,12 +26,12 @@ const Carousel = ({ slideList }: CarouselProps) => {
   // NOTE: 첫 슬라이드와 마지막 슬라이드의 복제본을 각각 맨 뒤, 맨 처음에 추가
   const clonedSlideList = [slideList[slideLength - 1], ...slideList, slideList[0]];
 
-  const scrollToSlide = (index: number) => {
+  const scrollToSlide = (index: number, withTransition = true) => {
     if (slideRef.current) {
       setIsTransitioning(true);
 
       const slideWidth = slideRef.current.clientWidth;
-      slideRef.current.style.transition = 'transform 0.5s ease-in-out';
+      slideRef.current.style.transition = withTransition ? `transform ${TRANSITION_DURATION}ms ease-in-out` : 'none';
       slideRef.current.style.transform = `translateX(-${slideWidth * index * 0.1}rem)`;
     }
     setCurrentSlideIndex(index);
@@ -45,6 +45,11 @@ const Carousel = ({ slideList }: CarouselProps) => {
     scrollToSlide(currentSlideIndex - 1);
   };
 
+  // NOTE: // 초기 슬라이드 위치 설정
+  useEffect(() => {
+    scrollToSlide(REAL_START_INDEX, false);
+  }, []);
+
   // NOTE: 맨 처음/맨 끝 슬라이드 전환용 useEffect
   useEffect(() => {
     if (isTransitioning) {
@@ -52,22 +57,17 @@ const Carousel = ({ slideList }: CarouselProps) => {
         // 마지막 슬라이드 처리
         setTimeout(() => {
           setIsTransitioning(false);
-          slideRef.current!.style.transition = 'none';
-          slideRef.current!.style.transform = `translateX(-${slideRef.current!.clientWidth * 0.1}rem)`;
-          setCurrentSlideIndex(REAL_START_INDEX);
+          scrollToSlide(REAL_START_INDEX, false);
         }, TRANSITION_DURATION); // NOTE: 애니메이션 트랜지션 시간과 동일하게 설정 (0.5초)
-      }
-      if (currentSlideIndex === 0) {
+      } else if (currentSlideIndex === 0) {
         // 첫 번째 슬라이드 처리
         setTimeout(() => {
           setIsTransitioning(false);
-          slideRef.current!.style.transition = 'none';
-          slideRef.current!.style.transform = `translateX(-${slideRef.current!.clientWidth * slideLength * 0.1}rem)`;
-          setCurrentSlideIndex(slideLength);
+          scrollToSlide(slideLength, false);
         }, TRANSITION_DURATION);
       }
     }
-  }, [currentSlideIndex, slideLength]);
+  }, [currentSlideIndex, slideLength, isTransitioning]);
 
   // NOTE: 슬라이드 자동 이동용
   useEffect(() => {

--- a/frontend/src/pages/ReviewZonePage/components/PasswordModal/index.tsx
+++ b/frontend/src/pages/ReviewZonePage/components/PasswordModal/index.tsx
@@ -7,6 +7,9 @@ import { ROUTE } from '@/constants/route';
 import { useCheckPasswordValidation, useEyeButton, useGroupAccessCode } from '@/hooks';
 
 import * as S from './styles';
+
+const REVIEW_PASSWORD_INPUT_MESSAGE = '리뷰 확인을 위해 설정한 비밀번호를 입력해주세요';
+
 interface PasswordModalProps {
   closeModal: () => void;
   reviewRequestCode: string;
@@ -52,9 +55,8 @@ const PasswordModal = ({ closeModal, reviewRequestCode }: PasswordModalProps) =>
   };
 
   return (
-    <ContentModal handleClose={closeModal}>
+    <ContentModal title={REVIEW_PASSWORD_INPUT_MESSAGE} handleClose={closeModal}>
       <S.PasswordModal>
-        <S.ModalTitle>리뷰 확인을 위해 설정한 비밀번호를 입력해주세요</S.ModalTitle>
         <S.InputContainer>
           <S.PasswordInputContainer>
             <Input

--- a/frontend/src/pages/ReviewZonePage/components/PasswordModal/styles.ts
+++ b/frontend/src/pages/ReviewZonePage/components/PasswordModal/styles.ts
@@ -3,12 +3,7 @@ import styled from '@emotion/styled';
 export const PasswordModal = styled.div`
   display: flex;
   flex-direction: column;
-  height: 14rem;
-`;
-
-export const ModalTitle = styled.h3`
-  margin-bottom: 2rem;
-  font-weight: ${({ theme }) => theme.fontWeight.bold};
+  margin-top: 2rem;
 `;
 
 export const InputContainer = styled.form`
@@ -27,6 +22,8 @@ export const Label = styled.label`
 export const PasswordInputContainer = styled.div`
   position: relative;
   display: flex;
+  gap: 30rem;
+  width: 70%;
 `;
 
 export const ErrorMessage = styled.p`


### PR DESCRIPTION
- resolves #529

---

### 🚀 어떤 기능을 구현했나요 ?
- 홈 페이지 캐러셀의 초기 슬라이드 위치를 조정하여 첫 번째 슬라이드(= 리뷰 받는 사람)가 정확히 표시되도록 수정했습니다.
- ContentModal 컴포넌트에 title prop을 추가하여 모달 헤더에 제목을 표시하도록 변경했습니다. 그리고 확인 버튼과 인풋 사이의 간격을 조정하여 디자인을 개선했습니다.

### 🔥 어떻게 해결했나요 ?


0번째 복제본 슬라이드가 초기 슬라이드로 보이는 문제를 해결하기 위해 `useEffect`를 사용해서 초기 슬라이드 위치를 조정했습니다.

```tsx
  useEffect(() => {
    scrollToSlide(REAL_START_INDEX, false);
  }, []);
```

`transition` 효과 제어를 위한 `withTransition` 매개변수를 추가했습니다. 이 매개변수는 슬라이드 전환 시 애니메이션 효과를 적용할지 여부를 결정합니다

```tsx
  const scrollToSlide = (index: number, withTransition = true) => {
    if (slideRef.current) {
      setIsTransitioning(true);

      const slideWidth = slideRef.current.clientWidth;
      slideRef.current.style.transition = withTransition ? `transform ${TRANSITION_DURATION}ms ease-in-out` : 'none';
      slideRef.current.style.transform = `translateX(-${slideWidth * index * 0.1}rem)`;
    }
    setCurrentSlideIndex(index);
  };
```

`ContentModal`에 `props`로 `title`을 받아서 헤더에 타이틀과 `x 표시` 클로즈 버튼을 같은 라인에서 보여주는 식으로 변경했습니다. 그리고 인풋과 확인 버튼을 감싸는 컨테이너에 width를 늘려서 간격을 조정했습니다.


<table>
  <thead>
    <tr>
      <th>변경 전</th>
      <th>변경 후</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>
   <img width="500" alt="변경 전" src="https://github.com/user-attachments/assets/17256c37-8a8e-4a7d-88b6-40eb57a2aef3">
      </td>
      <td>
         <img width="500" alt="변경 후" src="https://github.com/user-attachments/assets/733017be-21c6-4905-8b72-6306f7874dbb">
      </td>
    </tr>
  </tbody>
</table>


### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
- 화이팅!