### PR TITLE
[FE] 비밀번호 조회 모달의 배경 화면 클릭 시 모달 닫히는 기능 제거

### DIFF
--- a/frontend/src/components/common/modals/ContentModal/index.tsx
+++ b/frontend/src/components/common/modals/ContentModal/index.tsx
@@ -9,12 +9,18 @@ import * as S from './styles';
 interface ContentModalProps {
   title?: string;
   handleClose: () => void;
+  isClosableOnBackground?: boolean;
 }
 
-const ContentModal = ({ title, handleClose, children }: EssentialPropsWithChildren<ContentModalProps>) => {
+const ContentModal = ({
+  title,
+  handleClose,
+  children,
+  isClosableOnBackground = true,
+}: EssentialPropsWithChildren<ContentModalProps>) => {
   return (
     <ModalPortal>
-      <ModalBackground closeModal={handleClose}>
+      <ModalBackground closeModal={isClosableOnBackground ? handleClose : null}>
         <S.ContentModalContainer>
           <S.ContentModalHeader>
             <S.Title>{title}</S.Title>

--- a/frontend/src/components/common/modals/ModalBackground/index.tsx
+++ b/frontend/src/components/common/modals/ModalBackground/index.tsx
@@ -7,7 +7,7 @@ import * as S from './styles';
 interface ModalBackgroundProps {
   closeModal: (() => void) | null;
 }
-
+// TODO: 배경, ESC를 통한 모달 닫히는 기능을 불리해야함
 const ModalBackground: React.FC<PropsWithChildren<ModalBackgroundProps>> = ({ children, closeModal }) => {
   const modalBackgroundRef = useRef<HTMLDivElement>(null);
   useModalClose({ closeModal, modalBackgroundRef });

--- a/frontend/src/pages/ReviewZonePage/components/PasswordModal/index.tsx
+++ b/frontend/src/pages/ReviewZonePage/components/PasswordModal/index.tsx
@@ -55,7 +55,7 @@ const PasswordModal = ({ closeModal, reviewRequestCode }: PasswordModalProps) =>
   };
 
   return (
-    <ContentModal title={REVIEW_PASSWORD_INPUT_MESSAGE} handleClose={closeModal}>
+    <ContentModal title={REVIEW_PASSWORD_INPUT_MESSAGE} handleClose={closeModal} isClosableOnBackground={false}>
       <S.PasswordModal>
         <S.InputContainer>
           <S.PasswordInputContainer>


### PR DESCRIPTION


- resolves #532

---

### 🚀 어떤 기능을 구현했나요 ?
- 해결하려는 오류 : 비밀 조회 모달에서, 입력한 비밀 번호를 드래그로 지우면 모달 배경이 클릭되어 모달이 닫히는 오류가 있어요.
-  ContentModal 에 isCloseOnBackground props 추가해서, isCloseOnBackground 값에 따라 배경화면 클릭,esc를 통한 모달 닫기 기능을 막을 수 있도록 했어요. (기본값은 true입니다.)

### 🔥 어떻게 해결했나요 ?
- 위와 동일

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 배경 클릭 시 닫는 기능만 막으면 되는데,  그러려면 ModalBackground를 수정해야해요. 이거를 수정하면 모달 관련된 부분들의 수정이 많이 이루어져야해서, 시연을 앞두고 위험 부담이 크다고 생각했어요. 시연 전에 빨리 버그를 수정해야하기 때문에 일단 이미 모달 닫기 기능을 props로 막고 있는 ConfirmModal의 벤치마킹해서 기능을 구현했어요. 

**추후에 배경화면 클릭과 esc를 통한 닫기 기능을 막는 작업을 분리해서 할 수 있도록 해야할 것 같아요.**

### 📚 참고 자료, 할 말
- 사용자 예외 케이스 예상하기 넘 어렵다