### PR TITLE
[BE] test: fixture 추가

### DIFF
--- a/backend/src/test/java/reviewme/fixture/OptionGroupFixture.java
+++ b/backend/src/test/java/reviewme/fixture/OptionGroupFixture.java
@@ -1,0 +1,10 @@
+package reviewme.fixture;
+
+import reviewme.question.domain.OptionGroup;
+
+public class OptionGroupFixture {
+
+    public OptionGroup 선택지_그룹(long questionId) {
+        return new OptionGroup(questionId, 1, 2);
+    }
+}

--- a/backend/src/test/java/reviewme/fixture/OptionItemFixture.java
+++ b/backend/src/test/java/reviewme/fixture/OptionItemFixture.java
@@ -1,0 +1,11 @@
+package reviewme.fixture;
+
+import reviewme.question.domain.OptionItem;
+import reviewme.question.domain.OptionType;
+
+public class OptionItemFixture {
+
+    public OptionItem 선택지(long optionGroupId) {
+        return new OptionItem("선택지 본문", optionGroupId, 1, OptionType.CATEGORY);
+    }
+}

--- a/backend/src/test/java/reviewme/fixture/OptionItemFixture.java
+++ b/backend/src/test/java/reviewme/fixture/OptionItemFixture.java
@@ -8,4 +8,8 @@ public class OptionItemFixture {
     public OptionItem 선택지(long optionGroupId) {
         return new OptionItem("선택지 본문", optionGroupId, 1, OptionType.CATEGORY);
     }
+
+    public OptionItem 선택지(long optionGroupId, int position) {
+        return new OptionItem("선택지 본문", optionGroupId, 1, OptionType.CATEGORY);
+    }
 }

--- a/backend/src/test/java/reviewme/fixture/QuestionFixture.java
+++ b/backend/src/test/java/reviewme/fixture/QuestionFixture.java
@@ -5,35 +5,35 @@ import reviewme.question.domain.QuestionType;
 
 public class QuestionFixture {
 
-    public Question 필수_선택형_질문() {
-        return this.필수_선택형_질문(1);
+    public Question 선택형_필수_질문() {
+        return this.선택형_필수_질문(1);
     }
 
-    public Question 필수_선택형_질문(int position) {
+    public Question 선택형_필수_질문(int position) {
         return new Question(true, QuestionType.CHECKBOX, "본문", null, position);
     }
 
-    public Question 필수_서술형_질문() {
-        return this.필수_서술형_질문(1);
+    public Question 선택형_옵션_질문() {
+        return this.선택형_옵션_질문(1);
     }
 
-    public Question 필수_서술형_질문(int position) {
-        return new Question(true, QuestionType.TEXT, "본문", null, position);
-    }
-
-    public Question 필수_아닌_선택형_질문() {
-        return this.필수_아닌_선택형_질문(1);
-    }
-
-    public Question 필수_아닌_선택형_질문(int position) {
+    public Question 선택형_옵션_질문(int position) {
         return new Question(false, QuestionType.CHECKBOX, "본문", null, position);
     }
 
-    public Question 필수_아닌_서술형_질문() {
-        return this.필수_아닌_서술형_질문(1);
+    public Question 서술형_필수_질문() {
+        return this.서술형_필수_질문(1);
     }
 
-    public Question 필수_아닌_서술형_질문(int position) {
+    public Question 서술형_필수_질문(int position) {
+        return new Question(true, QuestionType.TEXT, "본문", null, position);
+    }
+
+    public Question 서술형_옵션_질문() {
+        return this.서술형_옵션_질문(1);
+    }
+
+    public Question 서술형_옵션_질문(int position) {
         return new Question(false, QuestionType.TEXT, "본문", null, position);
     }
 }

--- a/backend/src/test/java/reviewme/fixture/QuestionFixture.java
+++ b/backend/src/test/java/reviewme/fixture/QuestionFixture.java
@@ -1,0 +1,39 @@
+package reviewme.fixture;
+
+import reviewme.question.domain.Question;
+import reviewme.question.domain.QuestionType;
+
+public class QuestionFixture {
+
+    public Question 필수_선택형_질문() {
+        return this.필수_선택형_질문(1);
+    }
+
+    public Question 필수_선택형_질문(int position) {
+        return new Question(true, QuestionType.CHECKBOX, "본문", null, position);
+    }
+
+    public Question 필수_서술형_질문() {
+        return this.필수_서술형_질문(1);
+    }
+
+    public Question 필수_서술형_질문(int position) {
+        return new Question(true, QuestionType.TEXT, "본문", null, position);
+    }
+
+    public Question 필수_아닌_선택형_질문() {
+        return this.필수_아닌_선택형_질문(1);
+    }
+
+    public Question 필수_아닌_선택형_질문(int position) {
+        return new Question(false, QuestionType.CHECKBOX, "본문", null, position);
+    }
+
+    public Question 필수_아닌_서술형_질문() {
+        return this.필수_아닌_서술형_질문(1);
+    }
+
+    public Question 필수_아닌_서술형_질문(int position) {
+        return new Question(false, QuestionType.TEXT, "본문", null, position);
+    }
+}

--- a/backend/src/test/java/reviewme/fixture/ReviewGroupFixture.java
+++ b/backend/src/test/java/reviewme/fixture/ReviewGroupFixture.java
@@ -1,0 +1,14 @@
+package reviewme.fixture;
+
+import reviewme.reviewgroup.domain.ReviewGroup;
+
+public class ReviewGroupFixture {
+
+    public ReviewGroup 리뷰_그룹() {
+        return this.리뷰_그룹("reviewRequestCode", "groupAccessCode");
+    }
+
+    public ReviewGroup 리뷰_그룹(String reviewRequestCode, String groupAccessCode) {
+        return new ReviewGroup("revieweeName", "projectName", reviewRequestCode, groupAccessCode);
+    }
+}

--- a/backend/src/test/java/reviewme/fixture/SectionFixture.java
+++ b/backend/src/test/java/reviewme/fixture/SectionFixture.java
@@ -7,10 +7,18 @@ import reviewme.template.domain.VisibleType;
 public class SectionFixture {
 
     public Section 항상_보이는_섹션(List<Long> questionIds) {
-        return new Section(VisibleType.ALWAYS, questionIds, null, "섹션명", "머릿말", 1);
+        return this.항상_보이는_섹션(questionIds, 1);
+    }
+
+    public Section 항상_보이는_섹션(List<Long> questionIds, int position) {
+        return new Section(VisibleType.ALWAYS, questionIds, null, "섹션명", "머릿말", position);
     }
 
     public Section 조건부로_보이는_섹션(List<Long> questionIds, long onSelectedOptionId) {
-        return new Section(VisibleType.CONDITIONAL, questionIds, onSelectedOptionId, "섹션명", "머릿말", 1);
+        return this.조건부로_보이는_섹션(questionIds, onSelectedOptionId, 1);
+    }
+
+    public Section 조건부로_보이는_섹션(List<Long> questionIds, long onSelectedOptionId, int position) {
+        return new Section(VisibleType.CONDITIONAL, questionIds, onSelectedOptionId, "섹션명", "머릿말", position);
     }
 }

--- a/backend/src/test/java/reviewme/fixture/SectionFixture.java
+++ b/backend/src/test/java/reviewme/fixture/SectionFixture.java
@@ -1,0 +1,16 @@
+package reviewme.fixture;
+
+import java.util.List;
+import reviewme.template.domain.Section;
+import reviewme.template.domain.VisibleType;
+
+public class SectionFixture {
+
+    public Section 항상_보이는_섹션(List<Long> questionIds) {
+        return new Section(VisibleType.ALWAYS, questionIds, null, "섹션명", "머릿말", 1);
+    }
+
+    public Section 조건부로_보이는_섹션(List<Long> questionIds, long onSelectedOptionId) {
+        return new Section(VisibleType.CONDITIONAL, questionIds, onSelectedOptionId, "섹션명", "머릿말", 1);
+    }
+}

--- a/backend/src/test/java/reviewme/fixture/TemplateFixture.java
+++ b/backend/src/test/java/reviewme/fixture/TemplateFixture.java
@@ -1,0 +1,11 @@
+package reviewme.fixture;
+
+import java.util.List;
+import reviewme.template.domain.Template;
+
+public class TemplateFixture {
+
+    public Template 템플릿(List<Long> sectionIds) {
+        return new Template(sectionIds);
+    }
+}


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #524 

---

### 🚀 어떤 기능을 구현했나요 ?
- 테스트에 사용될 픽스쳐를 만들었습니다.

### 🔥 어떻게 해결했나요 ?
픽스처를 만든 조건은 아래와 같습니다.
1. 픽스처는 모두 한글로 만들었습니다. 따라서 영어인 다른 변수 & 함수명과 구분할 수 있게 했습니다.
2. 기존의 enum 방식과 `create()` 함수를 붙였던 방식을 적용하지 않았습니다. `리뷰_그룹.create()` 보다 `리뷰_그룹()`가 더 가독성이 좋다고 생각했기 때문입니다.
3. 픽스쳐는 그 세부 내용이 중요하지 않을 때에만 사용을 해야합니다. 세부적으로 설정할게 많아진다면, 픽스쳐가 아니라 생성자 호출로 그 인자를 노출시킬 필요가 있습니다. 따라서 '다른 데이터와 연관된 것' 만 인자로 받게 했습니다. 구체적으로 예를 들자면, OptionItemFixture 의 경우 long 으로 OptionGroupId 만 받게 했습니다. 따라서 optionItem 의 세부 내용은 중요하지 않고, 어떤 optionGroup 에 연관되어있는지만 설정하고 싶을 때 사용할 수 있습니다. 하지만 만약 '선택지를 순서대로 보여준다'와 같이 optionItem 의 position 인자가 중요한 경우에는 픽스처를 사용하기보다 생성자를 호출해서 테스트 코드를 짜는게 좋을 것입니다.

```java
public OptionItem 선택지(long optionGroupId) {
    return new OptionItem("선택지 본문", optionGroupId, 1, OptionType.CATEGORY);
}
```

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 괜찮은지 한번씩 봐주세영~

### 📚 참고 자료, 할 말
그리고 방학동안 이 픽스처를 사용하도록 테스트 코드를 작성하기로 저번에 이야기를 했었던거 기억 하시나요~
그래서 제가 임의로 역할을 나눠봤어요!
다들 괜찮은지 확인 부탁드려용~ 🙇🏻‍♀️

1. OptionItemRepositoryTest / QuestionRepositoryTest / CreateTextAnswerRequestValidatorTest
2. CreateCheckBoxAnswerRequestValidatorTest / CreateReviewServiceTest
3. ReviewServiceTest / ReviewDetailLookupServiceTest
4. TemplateMapperTest / TemplateServiceTest / SectionRepositoryTest

![image](https://github.com/user-attachments/assets/5dac4d22-6f67-414d-8b82-23a7896f146c)
사다리 타기 주작 아님!