### PR TITLE
[FE] refactor: Input의 type에 올 수 있는 값을 html에서 제공하는 값으로 제한

### DIFF
--- a/frontend/src/components/common/Input/index.tsx
+++ b/frontend/src/components/common/Input/index.tsx
@@ -3,11 +3,12 @@ import * as S from './styles';
 export interface InputStyleProps {
   $style?: React.CSSProperties;
 }
+
 interface InputProps extends InputStyleProps {
+  type: React.InputHTMLAttributes<HTMLInputElement>['type'];
   value: string;
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onBlur?: () => void;
-  type: string;
   id?: string;
   name?: string;
   placeholder?: string;


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #546 

---

### 🚀 어떤 기능을 구현했나요 ?
- Input의 type 속성을 원래 단순 string으로만 명시했는데, 이렇게 하면 타입 이름을 잘못 입력했을 때 오류가 나지 않기 때문에 더 명확한 타입을 지정했습니다.

### 🔥 어떻게 해결했나요 ?
Input 인터페이스의 type을 이렇게 수정했습니다.
`type: React.InputHTMLAttributes<HTMLInputElement>['type'];`

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 공통 Input을 사용하는 곳이 `HomePage`밖에 없어서 홈페이지의 input들이 잘 돌아가는지 확인했습니다. (정확히는 홈페이지 -> 리뷰 작성 완료까지 잘 돌아가는 걸 확인했습니다. 다른 곳에서는...안 쓰고 있겠죠?!)

### 📚 참고 자료, 할 말
