### PR TITLE
[FE] fix: 캐러셀 왼쪽/오른쪽 버튼 연속 클릭 시, 슬라이드 멈추는 현상 해결

### DIFF
--- a/frontend/src/pages/HomePage/components/Carousel/index.tsx
+++ b/frontend/src/pages/HomePage/components/Carousel/index.tsx
@@ -83,7 +83,7 @@ const Carousel = ({ slideList }: CarouselProps) => {
     }, AUTO_SLIDE_INTERVAL);
 
     return () => clearTimeout(timeout);
-  }, [currentSlideIndex]);
+  }, [currentSlideIndex, clicked]);
 
   return (
     <S.CarouselContainer>

--- a/frontend/src/pages/HomePage/components/Carousel/index.tsx
+++ b/frontend/src/pages/HomePage/components/Carousel/index.tsx
@@ -42,14 +42,14 @@ const Carousel = ({ slideList }: CarouselProps) => {
     if (clicked) return;
     setClicked(true);
     scrollToSlide(currentSlideIndex + 1);
-    setTimeout(() => setClicked(false), TRANSITION_DURATION);
+    setTimeout(() => setClicked(false), TRANSITION_DURATION + 100);
   };
 
   const prevSlide = () => {
     if (clicked) return;
     setClicked(true);
     scrollToSlide(currentSlideIndex - 1);
-    setTimeout(() => setClicked(false), TRANSITION_DURATION);
+    setTimeout(() => setClicked(false), TRANSITION_DURATION + 100);
   };
 
   // NOTE: // 초기 슬라이드 위치 설정

--- a/frontend/src/pages/HomePage/components/Carousel/index.tsx
+++ b/frontend/src/pages/HomePage/components/Carousel/index.tsx
@@ -20,6 +20,7 @@ const Carousel = ({ slideList }: CarouselProps) => {
   // NOTE: 마지막 슬라이드를 복제해서 slideList의 맨 앞에 추가하므로 처음에 보여져야 하는 슬라이드는 1번 인덱스
   const [currentSlideIndex, setCurrentSlideIndex] = useState(REAL_START_INDEX);
   const [isTransitioning, setIsTransitioning] = useState(false);
+  const [clicked, setClicked] = useState(false);
   const slideRef = useRef<HTMLDivElement>(null);
 
   const slideLength = slideList.length;
@@ -38,11 +39,17 @@ const Carousel = ({ slideList }: CarouselProps) => {
   };
 
   const nextSlide = () => {
+    if (clicked) return;
+    setClicked(true);
     scrollToSlide(currentSlideIndex + 1);
+    setTimeout(() => setClicked(false), TRANSITION_DURATION);
   };
 
   const prevSlide = () => {
+    if (clicked) return;
+    setClicked(true);
     scrollToSlide(currentSlideIndex - 1);
+    setTimeout(() => setClicked(false), TRANSITION_DURATION);
   };
 
   // NOTE: // 초기 슬라이드 위치 설정


### PR DESCRIPTION
- resolves #553 

---

### 🚀 어떤 기능을 구현했나요 ?
슬라이드 넘어가는 버튼을 빠르게 연속 클릭하면 아래 영상처럼 슬라이드가 중간에 멈추는 문제가 있었습니다. 이 문제를 해결했습니다.

https://github.com/user-attachments/assets/eb1cc4fe-6273-4172-8123-bfaf4d7f3be5


### 🔥 어떻게 해결했나요 ?

현재 캐러셀 슬라이드 순서가 [1, 2, 3]에서 [3, 1, 2, 3, 1]으로 첫 슬라이드와 마지막 슬라이드 복제본을 양쪽 끝에 추가한 상태입니다.(마지막 슬라이드에서 첫 슬라이드로 자연스럽게 넘어가게 하기 위함)

문제는 여기서 슬라이드 전환을 자연스럽게 처리하기 위해 `setTimeout`을 사용했는데, 사용자가 `setTimeout`의 설정 시간보다 더 빠르게 버튼을 연속 클릭하면, 첫 슬라이드에서 잠깐 멈췄다가 다시 넘어가는 현상이 발생합니다.
```ts
  // NOTE: 맨 처음/맨 끝 슬라이드 전환용 useEffect
  useEffect(() => {
    if (isTransitioning) {
      if (currentSlideIndex === slideLength + 1) {
        // 마지막 슬라이드 처리
        setTimeout(() => {
          setIsTransitioning(false);
          scrollToSlide(REAL_START_INDEX, false);
        }, TRANSITION_DURATION); // NOTE: 애니메이션 트랜지션 시간과 동일하게 설정 (0.5초)
      } else if (currentSlideIndex === 0) {
        // 첫 번째 슬라이드 처리
        setTimeout(() => {
          setIsTransitioning(false);
          scrollToSlide(slideLength, false);
        }, TRANSITION_DURATION);
      }
    }
  }, [currentSlideIndex, slideLength, isTransitioning]);
```

`clicked` 상태를 추가해서 버튼이 연속으로 클릭될 때 트랜지션 코드가 실행되지 않도록 했습니다. 그리고 트랜지션이 끝난 이후에 `setTiemout`을 사용해서 `clicked` 상태를 `false`로 변경하는 방식으로 수정했습니다.


+0.01초를 한 이유는 트랜지션이 끝나고 바로 버튼을 클릭하면 타이밍에 따라 넘어가는 속도가 일정하지 않은 느낌?이 들어서 약간의 딜레이를 추가했습니다.
```ts
const nextSlide = () => {
    if (clicked) return;
    setClicked(true);
    scrollToSlide(currentSlideIndex + 1);
    setTimeout(() => setClicked(false), TRANSITION_DURATION + 100);
  };
```

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
- [많은 도움을 받은 "이종혁"님의 블로그](https://blog.dlwhd990.vercel.app/article/63cd127c96aadb2a2c267b5e) 

## To. 레디
안녕하세요~ 레디! 쑤쑤예요. 이 PR을 보실까...싶긴 한데..😅
4차 데모데이 때, 캐러셀 버튼 계속 클릭하면 중간에 멈춘다고 저에게 말해줬던 게 기억이 나네요. 덕분에 버그를 발견할 수 있었어요😉 알려줘서 정말 고맙네요^^^^^