### PR TITLE
[BE] test: 리뷰 목록 조회, 리뷰 상세 조회 테스트에 픽스처를 적용

### DIFF
--- a/backend/src/test/java/reviewme/review/service/ReviewDetailLookupServiceTest.java
+++ b/backend/src/test/java/reviewme/review/service/ReviewDetailLookupServiceTest.java
@@ -160,7 +160,7 @@ class ReviewDetailLookupServiceTest {
     class 필수가_아닌_답변에_응답하지_않았을_때 {
 
         @Test
-        void 섹션에_그_질문만_있다면_섹션_자체를_반환하지_않는다() {
+        void 섹션에_필수가_아닌_질문만_있다면_섹션_자체를_반환하지_않는다() {
             // given - 리뷰 그룹 저장
             String reviewRequestCode = "sancho";
             String groupAccessCode = "kirby";

--- a/backend/src/test/java/reviewme/review/service/ReviewServiceTest.java
+++ b/backend/src/test/java/reviewme/review/service/ReviewServiceTest.java
@@ -69,11 +69,13 @@ class ReviewServiceTest {
     @Test
     void 그룹_액세스_코드가_일치하지_않는_경우_예외가_발생한다() {
         // given
-        ReviewGroup reviewGroup = reviewGroupRepository.save(리뷰_그룹());
+        String reviewRequestCode = "Jamsil";
+        String groupAccessCode = "Seolleung";
+        ReviewGroup reviewGroup = reviewGroupRepository.save(리뷰_그룹(reviewRequestCode, groupAccessCode));
 
         // when, then
         assertThatThrownBy(() -> reviewService.findReceivedReviews(
-                reviewGroup.getReviewRequestCode(), "wrong" + reviewGroup.getGroupAccessCode()
+                reviewRequestCode, "wrong" + groupAccessCode
         )).isInstanceOf(ReviewGroupUnauthorizedException.class);
     }
 

--- a/backend/src/test/java/reviewme/review/service/ReviewServiceTest.java
+++ b/backend/src/test/java/reviewme/review/service/ReviewServiceTest.java
@@ -2,28 +2,33 @@ package reviewme.review.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static reviewme.fixture.OptionGroupFixture.선택지_그룹;
+import static reviewme.fixture.OptionItemFixture.선택지;
+import static reviewme.fixture.QuestionFixture.선택형_필수_질문;
+import static reviewme.fixture.ReviewGroupFixture.리뷰_그룹;
+import static reviewme.fixture.SectionFixture.항상_보이는_섹션;
+import static reviewme.fixture.TemplateFixture.템플릿;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import reviewme.question.domain.OptionGroup;
 import reviewme.question.domain.OptionItem;
-import reviewme.question.domain.OptionType;
 import reviewme.question.domain.Question;
-import reviewme.question.domain.QuestionType;
 import reviewme.question.repository.OptionGroupRepository;
 import reviewme.question.repository.OptionItemRepository;
 import reviewme.question.repository.QuestionRepository;
 import reviewme.review.domain.CheckboxAnswer;
 import reviewme.review.domain.Review;
+import reviewme.review.domain.TextAnswer;
 import reviewme.review.domain.exception.ReviewGroupNotFoundByReviewRequestCodeException;
-import reviewme.review.repository.CheckboxAnswerRepository;
 import reviewme.review.repository.ReviewRepository;
 import reviewme.review.service.dto.response.list.ReceivedReviewsResponse;
 import reviewme.review.service.exception.ReviewGroupUnauthorizedException;
 import reviewme.reviewgroup.domain.ReviewGroup;
 import reviewme.reviewgroup.repository.ReviewGroupRepository;
 import reviewme.support.ServiceTest;
+import reviewme.template.domain.Section;
 import reviewme.template.domain.Template;
 import reviewme.template.repository.SectionRepository;
 import reviewme.template.repository.TemplateRepository;
@@ -32,31 +37,28 @@ import reviewme.template.repository.TemplateRepository;
 class ReviewServiceTest {
 
     @Autowired
-    ReviewService reviewService;
+    private ReviewService reviewService;
 
     @Autowired
-    QuestionRepository questionRepository;
+    private QuestionRepository questionRepository;
 
     @Autowired
-    ReviewGroupRepository reviewGroupRepository;
+    private ReviewGroupRepository reviewGroupRepository;
 
     @Autowired
-    OptionItemRepository optionItemRepository;
+    private OptionItemRepository optionItemRepository;
 
     @Autowired
-    OptionGroupRepository optionGroupRepository;
+    private OptionGroupRepository optionGroupRepository;
 
     @Autowired
-    SectionRepository sectionRepository;
+    private SectionRepository sectionRepository;
 
     @Autowired
-    TemplateRepository templateRepository;
+    private TemplateRepository templateRepository;
 
     @Autowired
-    CheckboxAnswerRepository checkboxAnswerRepository;
-
-    @Autowired
-    ReviewRepository reviewRepository;
+    private ReviewRepository reviewRepository;
 
     @Test
     void 리뷰_요청_코드가_존재하지_않는_경우_예외가_발생한다() {
@@ -67,38 +69,36 @@ class ReviewServiceTest {
     @Test
     void 그룹_액세스_코드가_일치하지_않는_경우_예외가_발생한다() {
         // given
-        String reviewRequestCode = "code";
-        String groupAccessCode = "1234";
-        reviewGroupRepository.save(new ReviewGroup("커비", "리뷰미", reviewRequestCode, groupAccessCode));
+        ReviewGroup reviewGroup = reviewGroupRepository.save(리뷰_그룹());
 
         // when, then
-        assertThatThrownBy(() -> reviewService.findReceivedReviews(reviewRequestCode, "5678"))
-                .isInstanceOf(ReviewGroupUnauthorizedException.class);
+        assertThatThrownBy(() -> reviewService.findReceivedReviews(
+                reviewGroup.getReviewRequestCode(), "wrong" + reviewGroup.getGroupAccessCode()
+        )).isInstanceOf(ReviewGroupUnauthorizedException.class);
     }
 
     @Test
-    void 확인_코드에_해당하는_그룹이_존재하면_리뷰_리스트를_반환한다() {
-        // given
+    void 확인_코드에_해당하는_그룹이_존재하면_내가_받은_리뷰_목록을_반환한다() {
+        // given - 리뷰 그룹 저장
         String reviewRequestCode = "reviewRequestCode";
         String groupAccessCode = "groupAccessCode";
-        Question question = questionRepository.save(
-                new Question(true, QuestionType.CHECKBOX, "프로젝트 기간 동안, 팀원의 강점이 드러났던 순간을 선택해주세요. (1~2개)", null, 1)
-        );
-        OptionGroup categoryOptionGroup = optionGroupRepository.save(new OptionGroup(question.getId(), 1, 2));
-        OptionItem categoryOption1 = new OptionItem("커뮤니케이션 능력 ", categoryOptionGroup.getId(), 1, OptionType.CATEGORY);
-        OptionItem categoryOption2 = new OptionItem("시간 관리 능력", categoryOptionGroup.getId(), 2, OptionType.CATEGORY);
-        optionItemRepository.saveAll(List.of(categoryOption1, categoryOption2));
+        ReviewGroup reviewGroup = reviewGroupRepository.save(리뷰_그룹(reviewRequestCode, groupAccessCode));
 
-        Template template = templateRepository.save(new Template(List.of()));
+        // given - 질문 저장
+        Question question = questionRepository.save(선택형_필수_질문());
+        OptionGroup optionGroup = optionGroupRepository.save(선택지_그룹(question.getId()));
+        OptionItem categoryOption = optionItemRepository.save(선택지(optionGroup.getId(), 1));
 
-        ReviewGroup reviewGroup = reviewGroupRepository.save(
-                new ReviewGroup("커비", "리뷰미", reviewRequestCode, groupAccessCode)
-        );
-        CheckboxAnswer categoryAnswer1 = new CheckboxAnswer(question.getId(), List.of(categoryOption1.getId()));
-        CheckboxAnswer categoryAnswer2 = new CheckboxAnswer(question.getId(), List.of(categoryOption2.getId()));
-        Review review1 = new Review(template.getId(), reviewGroup.getId(), List.of(), List.of(categoryAnswer1));
-        Review review = new Review(template.getId(), reviewGroup.getId(), List.of(), List.of(categoryAnswer2));
-        reviewRepository.saveAll(List.of(review1, review));
+        // given - 섹션, 템플릿 저장
+        Section section = sectionRepository.save(항상_보이는_섹션(List.of(question.getId())));
+        Template template = templateRepository.save(템플릿(List.of(section.getId())));
+
+        // given - 리뷰 답변 저장
+        CheckboxAnswer categoryAnswer = new CheckboxAnswer(question.getId(), List.of(categoryOption.getId()));
+        Review review1 = new Review(template.getId(), reviewGroup.getId(), List.of(), List.of(categoryAnswer));
+        TextAnswer textAnswer = new TextAnswer(question.getId(), "텍스트형 응답");
+        Review review2 = new Review(template.getId(), reviewGroup.getId(), List.of(textAnswer), List.of());
+        reviewRepository.saveAll(List.of(review1, review2));
 
         // when
         ReceivedReviewsResponse response = reviewService.findReceivedReviews(reviewRequestCode, groupAccessCode);


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #554 

---

### 🚀 어떤 기능을 구현했나요 ?
- 리뷰 목록 조회, 리뷰 상세 조회 테스트에 픽스쳐를 적용했습니다.

### 🔥 어떻게 해결했나요 ?
- 픽스쳐를 적용했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
가장 중요한 포인트 "Fixture 에 static 적용"한 것입니다.

**이유 1 : 가독성을 높이기 위해서** 
여러분들도 잘 알고 계시겠지만, static 을 사용하면, 생성자로 객체를 새로 만들거나
autowired 주입을 받지 않더라도 {객체}.{함수이름}() 으로 사용 가능합니다. 또한 여기서 {객체} 부분은 static import 를 한다면 생략 가능합니다. fixture 의 경우, '한글 이름'만으로도 fixture 임이 충분히 드러납니다. 따라서 어떤 클래스의 함수인지를 드러낼 필요가 없다는 생각이 들었습니다.

**이유 2 : fixture 는 어느곳에서도 호출할 수 있어야 한다.**
static 을 사용하는 것의 부작용은, '어디서든 호출 가능하다'는 것입니다. 하지만 fixture 는 테스트코드의 어떤 영역에 제한되지 않습니다. 테스트의 어느 패키지, 클래스에 종속적이지 않으므로, static 을 사용해도 된다는 생각이 들었습니다.

### 📚 참고 자료, 할 말
