### PR TITLE
[FE] fix: 객관식 문항의 최소, 최대 선택 개수가 같은 경우 문구 추가

### DIFF
--- a/frontend/src/pages/ReviewWritingPage/form/components/QnABox/index.tsx
+++ b/frontend/src/pages/ReviewWritingPage/form/components/QnABox/index.tsx
@@ -22,6 +22,7 @@ const QnABox = ({ question }: QnABoxProps) => {
 
     const isAllSelectAvailable = maxCount === optionGroup.options.length;
     if (!maxCount || isAllSelectAvailable) return `(최소 ${minCount}개 이상)`;
+    if (minCount === maxCount) return `(${maxCount}개)`;
 
     return `(${minCount}개 ~ ${maxCount}개)`;
   })();


### PR DESCRIPTION
- resolves #562 

---

### 🚀 어떤 기능을 구현했나요 ?
- 객관식 문항의 최소, 최대 선택 개수가 같은 경우, '1개 ~ 1개`의 형식이 아닌 '1개' 형식의 문구를 추가했습니다.

### 🔥 어떻게 해결했나요 ?
- 최소, 최대가 같은 경우를 추가했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
