### PR TITLE
[FE] fix: textarea에서 공백만 있는 입력인 경우 에러 메세지를 띄우고, 유효하지 않은 입력으로 간주

### DIFF
--- a/frontend/src/pages/ReviewWritingPage/form/hooks/answers/useTextAnswer/index.ts
+++ b/frontend/src/pages/ReviewWritingPage/form/hooks/answers/useTextAnswer/index.ts
@@ -11,11 +11,20 @@ export const TEXT_ANSWER_LENGTH = {
 };
 
 export const TEXT_ANSWER_ERROR_MESSAGE = {
+  empty: '공백만 입력할 수 없어요',
   min: `최소 ${TEXT_ANSWER_LENGTH.min}자 이상 작성해 주세요`,
   max: `최대 ${TEXT_ANSWER_LENGTH.max}자까지만 입력 가능해요`,
-  empty: '',
+  noError: '',
 };
 
+export const TEXT_ANSWER_ERROR_MESSAGE_KEY = {
+  empty: 'empty',
+  min: 'min',
+  max: 'max',
+  noError: 'noError',
+} as const;
+
+export type TextAnswerErrorMessageKey = keyof typeof TEXT_ANSWER_ERROR_MESSAGE_KEY;
 interface UseTextAnswerProps {
   question: ReviewWritingCardQuestion;
 }
@@ -26,10 +35,11 @@ const useTextAnswer = ({ question }: UseTextAnswerProps) => {
   const { updateAnswerMap, updateAnswerValidationMap } = useUpdateReviewerAnswer();
 
   const [text, setText] = useState('');
-  const [errorMessage, setErrorMessage] = useState(TEXT_ANSWER_ERROR_MESSAGE.empty);
+  const [errorMessage, setErrorMessage] = useState(TEXT_ANSWER_ERROR_MESSAGE.noError);
 
   const handleTextAnswerChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     const { value } = event.target;
+
     // NOTE: max 넘치는 글자는 max+ extra 만큼 자르는 이유
     // 1. 글자는 사용자가 입력한대로 보여줘야한다. (복붙해서 사용할때 이슈 있었음)
     // 2. 과도한 입력을 방지하기 위해 max를 넘어서는 일정 수준에서 글자를 자른다.
@@ -49,13 +59,15 @@ const useTextAnswer = ({ question }: UseTextAnswerProps) => {
   const validateTextLength = (text: string): TextAnswerErrorMessage => {
     const { min, max } = TEXT_ANSWER_LENGTH;
 
+    const isEmpty = text && text.trim() === '';
     const isOverMax = text.length > max;
     const isUnderMin = text.length < min;
 
-    if (isOverMax) return 'max';
-    if (isUnderMin) return 'min';
+    if (isEmpty) return TEXT_ANSWER_ERROR_MESSAGE_KEY.empty;
+    if (isOverMax) return TEXT_ANSWER_ERROR_MESSAGE_KEY.max;
+    if (isUnderMin) return TEXT_ANSWER_ERROR_MESSAGE_KEY.min;
 
-    return 'empty';
+    return TEXT_ANSWER_ERROR_MESSAGE_KEY.noError;
   };
 
   /**
@@ -65,7 +77,9 @@ const useTextAnswer = ({ question }: UseTextAnswerProps) => {
     const validationResult = validateTextLength(value);
     // 입력 중일때는 최소 글자 오류 메세지 보여주지 않음
     setErrorMessage(
-      validationResult === 'min' ? TEXT_ANSWER_ERROR_MESSAGE.empty : TEXT_ANSWER_ERROR_MESSAGE[validationResult],
+      validationResult === TEXT_ANSWER_ERROR_MESSAGE_KEY.min
+        ? TEXT_ANSWER_ERROR_MESSAGE.noError
+        : TEXT_ANSWER_ERROR_MESSAGE[validationResult],
     );
   };
 
@@ -85,7 +99,7 @@ const useTextAnswer = ({ question }: UseTextAnswerProps) => {
   const getNewAnswerAndValidation = (value: string) => {
     const validationResult = validateTextLength(value);
     //answer 업데이트
-    const isValidatedText = validationResult === 'empty';
+    const isValidatedText = validationResult === TEXT_ANSWER_ERROR_MESSAGE_KEY.noError;
     /**
      * 선택 질문이면서 답변이 없는 지 여부
      */
@@ -105,6 +119,7 @@ const useTextAnswer = ({ question }: UseTextAnswerProps) => {
 
   const handleTextAnswerBlur = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     const { value } = event.target;
+
     // 선택 질문, 작성한 답변이 없는 경우
     if (!question.required && value.length === 0) return;
     // 필수 질문 이거나 작성한 답변이 있는 선택 질문


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #558 

---

### 🚀 어떤 기능을 구현했나요 ?
- `textarea`에 공백만 포함된 경우 이를 유효하지 않은 입력으로 설정하는 기능을 구현했습니다.
- `textarea` 관련 에러 메세지에 대한 접근 문자열을 상수화했습니다.

### 🔥 어떻게 해결했나요 ?
- `trim()`을 유효성 검사에 추가해 현재 입력이 공백만 포함한 입력인지를 판단합니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
