### PR TITLE
[FE] feat : 선택 질문에 대한 최소 조건 변경

### DIFF
--- a/frontend/src/pages/ReviewWritingPage/form/components/QnABox/index.tsx
+++ b/frontend/src/pages/ReviewWritingPage/form/components/QnABox/index.tsx
@@ -19,6 +19,8 @@ const QnABox = ({ question }: QnABoxProps) => {
     if (!optionGroup) return;
 
     const { minCount, maxCount } = optionGroup;
+    //선택 질문
+    if (!question.required) return `(${maxCount}개 이하)`;
 
     const isAllSelectAvailable = maxCount === optionGroup.options.length;
     if (!maxCount || isAllSelectAvailable) return `(최소 ${minCount}개 이상)`;

--- a/frontend/src/pages/ReviewWritingPage/form/components/QnABox/index.tsx
+++ b/frontend/src/pages/ReviewWritingPage/form/components/QnABox/index.tsx
@@ -40,9 +40,7 @@ const QnABox = ({ question }: QnABoxProps) => {
         <S.MultipleGuideline>{multipleLGuideline ?? ''}</S.MultipleGuideline>
       </S.QuestionTitle>
       {question.guideline && <S.QuestionGuideline>{question.guideline}</S.QuestionGuideline>}
-      {/*객관식*/}
       {question.questionType === 'CHECKBOX' && <MultipleChoiceAnswer question={question} />}
-      {/*서술형*/}
       {question.questionType === 'TEXT' && <TextAnswer question={question} />}
     </S.QnASection>
   );

--- a/frontend/src/pages/ReviewWritingPage/form/components/QnABox/index.tsx
+++ b/frontend/src/pages/ReviewWritingPage/form/components/QnABox/index.tsx
@@ -32,7 +32,11 @@ const QnABox = ({ question }: QnABoxProps) => {
     <S.QnASection>
       <S.QuestionTitle>
         {question.content}
-        {question.required ? <S.QuestionRequiredMark>*</S.QuestionRequiredMark> : <span> (선택) </span>}
+        {question.required ? (
+          <S.QuestionRequiredMark>*</S.QuestionRequiredMark>
+        ) : (
+          <S.NotRequiredQuestionText>(선택)</S.NotRequiredQuestionText>
+        )}
         <S.MultipleGuideline>{multipleLGuideline ?? ''}</S.MultipleGuideline>
       </S.QuestionTitle>
       {question.guideline && <S.QuestionGuideline>{question.guideline}</S.QuestionGuideline>}

--- a/frontend/src/pages/ReviewWritingPage/form/components/QnABox/style.ts
+++ b/frontend/src/pages/ReviewWritingPage/form/components/QnABox/style.ts
@@ -25,3 +25,7 @@ export const QuestionRequiredMark = styled.sup`
 export const MultipleGuideline = styled.span`
   margin-left: 0.5rem;
 `;
+
+export const NotRequiredQuestionText = styled.span`
+  margin-left: 0.5rem;
+`;

--- a/frontend/src/pages/ReviewWritingPage/form/hooks/answers/multipleChoice/useUpdateMultipleChoiceAnswer/index.ts
+++ b/frontend/src/pages/ReviewWritingPage/form/hooks/answers/multipleChoice/useUpdateMultipleChoiceAnswer/index.ts
@@ -19,25 +19,30 @@ const useUpdateMultipleChoiceAnswer = ({ question }: UseUpdateMultipleChoiceAnsw
     const { minCount, maxCount } = question.optionGroup;
     const { length } = newSelectedOptionList;
 
-    return length >= minCount && length <= maxCount;
+    const isMinSatisfied = length >= minCount;
+    const isMaxSatisfied = length <= maxCount;
+
+    // 선택 질문 - 최대 선택 이하
+    if (!question.required) {
+      return isMaxSatisfied;
+    }
+
+    //필수 질문 - 최소 선택 이상 최대 선택 이하
+    return isMinSatisfied && isMaxSatisfied;
   };
 
   const updateAnswerState = (newSelectedOptionList: number[]) => {
-    // 유효한 선택(=객관식 문항의 최소,최대 개수를 지켰을 경우)인지에 따라 answer 변경
+    // 유효한 선택인지에 따라 answer 변경
     const isValidatedAnswer = isValidatedChoice(newSelectedOptionList);
-    /**
-     * 선택 질문이면서 선택된 문항이 없는 경우
-     */
-    const isNotRequiredEmptyAnswer = !question.required && newSelectedOptionList.length === 0;
-    // 필수, 선택 질문 여부 상관없이 선택된 문항이 있다면 선택된 문항 개수가 유효할 경우에만 선택이 반영되고 그렇지 않으면 빈배열
+
     const newAnswer: ReviewWritingAnswer = {
       questionId: question.questionId,
-      selectedOptionIds: isNotRequiredEmptyAnswer ? [] : isValidatedAnswer ? newSelectedOptionList : [],
+      selectedOptionIds: isValidatedAnswer ? newSelectedOptionList : [],
       text: null,
     };
 
     updateAnswerMap(newAnswer);
-    updateAnswerValidationMap(newAnswer, isValidatedAnswer || isNotRequiredEmptyAnswer);
+    updateAnswerValidationMap(newAnswer, isValidatedAnswer);
   };
 
   return {

--- a/frontend/src/pages/ReviewWritingPage/form/hooks/answers/multipleChoice/useUpdateMultipleChoiceAnswer/test.tsx
+++ b/frontend/src/pages/ReviewWritingPage/form/hooks/answers/multipleChoice/useUpdateMultipleChoiceAnswer/test.tsx
@@ -171,8 +171,7 @@ describe('객관식 답변 테스트', () => {
     ];
 
     // 선택된 문항 옵션
-    const VALIDATED_OPTION_LIST = ['1', '1,2'];
-    const INVALIDATED_OPTION_LIST = ['', '1,2,3'];
+    const VALIDATED_OPTION_LIST = ['', '1', '1,2'];
 
     it('선택 질문의 객관식 답변에서 선택된 문항이 없다면, 답변이 유효하다.', async () => {
       const SELECTED_OPTION_LIST: number[] = [];
@@ -205,7 +204,7 @@ describe('객관식 답변 테스트', () => {
     });
 
     it.each(VALIDATED_OPTION_LIST)(
-      '선택 질문의 객관식 답변이라도, 선택 된 문항이 있다면 최소 선택 개수 이상 최대 선택 개수 이하로 선택해야 답변이 유효하다.(선택된 문항:%s)',
+      '선택 질문의 객관식 답변이라도, 선택 된 문항이 있다면 최대 선택 개수 이하로 선택해야 답변이 유효하다.(선택된 문항:%s)',
       async (optionList) => {
         const selectedOptionList = optionList.split(',').map((value) => Number(value));
 
@@ -235,36 +234,35 @@ describe('객관식 답변 테스트', () => {
       },
     );
 
-    it.each(INVALIDATED_OPTION_LIST)(
-      '선택 질문의 객관식 답변에서 선택된 문항이 있다면, 최소 선택 개수 미만이거나 최대 선택 개수의 요건을 충족하지 않다면 답변이 유효하지 않다.',
-      async (optionList) => {
-        const selectedOptionList = optionList === '' ? [] : optionList.split(',').map((value) => Number(value));
+    it('선택 질문의 객관식 답변에서 선택된 문항이 있다면, 최소 선택 개수 미만이거나 최대 선택 개수의 요건을 충족하지 않다면 답변이 유효하지 않다.', async () => {
+      const selectedOptionList = [1, 2, 3];
 
-        const { result } = renderUseMultipleChoiceHook({});
+      const { result } = renderUseMultipleChoiceHook({});
 
-        await waitFor(() => {
-          expect(result.current.cardSectionList.length).not.toBe(0);
-        });
+      await waitFor(() => {
+        expect(result.current.cardSectionList.length).not.toBe(0);
+      });
 
-        act(() => {
-          result.current.updateAnswerState(selectedOptionList);
-        });
+      act(() => {
+        result.current.updateAnswerState(selectedOptionList);
+      });
 
-        const { answerMap, answerValidationMap } = result.current;
+      const { answerMap, answerValidationMap } = result.current;
 
-        //해당 질문에 대한 answerMap 답변 확인
-        // 유효하지 않으면 빈배열
-        const updatedAnswer = answerMap?.get(MOCK_QUESTION.questionId);
-        expect(updatedAnswer).toEqual({
-          questionId: MOCK_QUESTION.questionId,
-          selectedOptionIds: [],
-          text: null,
-        });
+      //해당 질문에 대한 answerMap 답변 확인
+      // 유효하지 않으면 빈배열
+      const updatedAnswer = answerMap?.get(MOCK_QUESTION.questionId);
 
-        //해당 질문에 대한 answerValidationMap 답변 확인
-        const isValidated = answerValidationMap?.get(MOCK_QUESTION.questionId);
-        expect(isValidated).toBe(false);
-      },
-    );
+      expect(updatedAnswer).toEqual({
+        questionId: MOCK_QUESTION.questionId,
+        selectedOptionIds: [],
+        text: null,
+      });
+
+      //해당 질문에 대한 answerValidationMap 답변 확인
+      const isValidated = answerValidationMap?.get(MOCK_QUESTION.questionId);
+
+      expect(isValidated).toBe(false);
+    });
   });
 });

--- a/frontend/src/pages/ReviewWritingPage/form/hooks/answers/useTextAnswer/index.ts
+++ b/frontend/src/pages/ReviewWritingPage/form/hooks/answers/useTextAnswer/index.ts
@@ -11,11 +11,20 @@ export const TEXT_ANSWER_LENGTH = {
 };
 
 export const TEXT_ANSWER_ERROR_MESSAGE = {
+  empty: '공백만 입력할 수 없어요',
   min: `최소 ${TEXT_ANSWER_LENGTH.min}자 이상 작성해 주세요`,
   max: `최대 ${TEXT_ANSWER_LENGTH.max}자까지만 입력 가능해요`,
-  empty: '',
+  noError: '',
 };
 
+export const TEXT_ANSWER_ERROR_MESSAGE_KEY = {
+  empty: 'empty',
+  min: 'min',
+  max: 'max',
+  noError: 'noError',
+} as const;
+
+export type TextAnswerErrorMessageKey = keyof typeof TEXT_ANSWER_ERROR_MESSAGE_KEY;
 interface UseTextAnswerProps {
   question: ReviewWritingCardQuestion;
 }
@@ -26,10 +35,11 @@ const useTextAnswer = ({ question }: UseTextAnswerProps) => {
   const { updateAnswerMap, updateAnswerValidationMap } = useUpdateReviewerAnswer();
 
   const [text, setText] = useState('');
-  const [errorMessage, setErrorMessage] = useState(TEXT_ANSWER_ERROR_MESSAGE.empty);
+  const [errorMessage, setErrorMessage] = useState(TEXT_ANSWER_ERROR_MESSAGE.noError);
 
   const handleTextAnswerChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     const { value } = event.target;
+
     // NOTE: max 넘치는 글자는 max+ extra 만큼 자르는 이유
     // 1. 글자는 사용자가 입력한대로 보여줘야한다. (복붙해서 사용할때 이슈 있었음)
     // 2. 과도한 입력을 방지하기 위해 max를 넘어서는 일정 수준에서 글자를 자른다.
@@ -49,13 +59,15 @@ const useTextAnswer = ({ question }: UseTextAnswerProps) => {
   const validateTextLength = (text: string): TextAnswerErrorMessage => {
     const { min, max } = TEXT_ANSWER_LENGTH;
 
+    const isEmpty = text && text.trim() === '';
     const isOverMax = text.length > max;
     const isUnderMin = text.length < min;
 
-    if (isOverMax) return 'max';
-    if (isUnderMin) return 'min';
+    if (isEmpty) return TEXT_ANSWER_ERROR_MESSAGE_KEY.empty;
+    if (isOverMax) return TEXT_ANSWER_ERROR_MESSAGE_KEY.max;
+    if (isUnderMin) return TEXT_ANSWER_ERROR_MESSAGE_KEY.min;
 
-    return 'empty';
+    return TEXT_ANSWER_ERROR_MESSAGE_KEY.noError;
   };
 
   /**
@@ -65,7 +77,9 @@ const useTextAnswer = ({ question }: UseTextAnswerProps) => {
     const validationResult = validateTextLength(value);
     // 입력 중일때는 최소 글자 오류 메세지 보여주지 않음
     setErrorMessage(
-      validationResult === 'min' ? TEXT_ANSWER_ERROR_MESSAGE.empty : TEXT_ANSWER_ERROR_MESSAGE[validationResult],
+      validationResult === TEXT_ANSWER_ERROR_MESSAGE_KEY.min
+        ? TEXT_ANSWER_ERROR_MESSAGE.noError
+        : TEXT_ANSWER_ERROR_MESSAGE[validationResult],
     );
   };
 
@@ -85,7 +99,7 @@ const useTextAnswer = ({ question }: UseTextAnswerProps) => {
   const getNewAnswerAndValidation = (value: string) => {
     const validationResult = validateTextLength(value);
     //answer 업데이트
-    const isValidatedText = validationResult === 'empty';
+    const isValidatedText = validationResult === TEXT_ANSWER_ERROR_MESSAGE_KEY.noError;
     /**
      * 선택 질문이면서 답변이 없는 지 여부
      */
@@ -105,6 +119,7 @@ const useTextAnswer = ({ question }: UseTextAnswerProps) => {
 
   const handleTextAnswerBlur = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     const { value } = event.target;
+
     // 선택 질문, 작성한 답변이 없는 경우
     if (!question.required && value.length === 0) return;
     // 필수 질문 이거나 작성한 답변이 있는 선택 질문

--- a/frontend/src/pages/ReviewWritingPage/form/hooks/answers/useTextAnswer/index.ts
+++ b/frontend/src/pages/ReviewWritingPage/form/hooks/answers/useTextAnswer/index.ts
@@ -37,7 +37,7 @@ const useTextAnswer = ({ question }: UseTextAnswerProps) => {
     // 1. 글자는 사용자가 입력한대로 보여줘야한다. (복붙해서 사용할때 이슈 있었음)
     // 2. 과도한 입력을 방지하기 위해 max를 넘어서는 일정 수준에서 글자를 자른다.
     sliceTextAnswer(value);
-    handleErrorMessage(value);
+    handleErrorMessageOnChange(value);
     handleUpdateAnswerState(value);
   };
 
@@ -72,10 +72,14 @@ const useTextAnswer = ({ question }: UseTextAnswerProps) => {
   /**
     작성한 답변의 유효성 검사 여뷰에 따라 오류 메세지 관리
    */
-  const handleErrorMessage = (value: string) => {
+  const handleErrorMessageOnChange = (value: string) => {
     const validationResult = validateTextLength(value);
     // 입력 중일때는 최소 글자 오류 메세지 보여주지 않음
-    setErrorMessage(TEXT_ANSWER_ERROR_MESSAGE[validationResult]);
+
+    const isHideErrorMessage = validationResult !== 'max';
+    setErrorMessage(
+      isHideErrorMessage ? TEXT_ANSWER_ERROR_MESSAGE.noError : TEXT_ANSWER_ERROR_MESSAGE[validationResult],
+    );
   };
 
   /**

--- a/frontend/src/pages/ReviewWritingPage/form/hooks/answers/useTextAnswer/index.ts
+++ b/frontend/src/pages/ReviewWritingPage/form/hooks/answers/useTextAnswer/index.ts
@@ -48,13 +48,16 @@ const useTextAnswer = ({ question }: UseTextAnswerProps) => {
 
   const validateTextLength = (text: string): TextAnswerErrorMessage => {
     const { min, max } = TEXT_ANSWER_LENGTH;
+    const isNotMaxSatisfied = text.length > max;
+    const isNotMinSatisfied = text.length < min;
+    //선택 질문 유효성 조건 - 최대 글자 이하
+    if (!question.required) {
+      return isNotMaxSatisfied ? 'max' : 'empty';
+    }
 
-    const isOverMax = text.length > max;
-    // 선택 질문은 최대 글자 수 이하면 유효성 통과
-    const isUnderMin = text.length < min && question.required;
-
-    if (isOverMax) return 'max';
-    if (isUnderMin) return 'min';
+    // 필수 질문 유효성 조건 - 최소 글자 이상 최대 글자 이하
+    if (isNotMaxSatisfied) return 'max';
+    if (isNotMinSatisfied) return 'min';
 
     return 'empty';
   };

--- a/frontend/src/pages/ReviewWritingPage/form/hooks/answers/useTextAnswer/index.ts
+++ b/frontend/src/pages/ReviewWritingPage/form/hooks/answers/useTextAnswer/index.ts
@@ -50,7 +50,8 @@ const useTextAnswer = ({ question }: UseTextAnswerProps) => {
     const { min, max } = TEXT_ANSWER_LENGTH;
 
     const isOverMax = text.length > max;
-    const isUnderMin = text.length < min;
+    // 선택 질문은 최대 글자 수 이하면 유효성 통과
+    const isUnderMin = text.length < min && question.required;
 
     if (isOverMax) return 'max';
     if (isUnderMin) return 'min';
@@ -83,21 +84,13 @@ const useTextAnswer = ({ question }: UseTextAnswerProps) => {
    * 서술형에 작성한 답변에 따라, answerMap, answerValidationMap에 반영될 새로운 답과 답의 유효성 여부를 반환하는 함수
    */
   const getNewAnswerAndValidation = (value: string) => {
-    const validationResult = validateTextLength(value);
-    //answer 업데이트
-    const isValidatedText = validationResult === 'empty';
-    /**
-     * 선택 질문이면서 답변이 없는 지 여부
-     */
-    const isNotRequiredEmptyAnswer = !question.required && value === '';
-    const answerValidation = isValidatedText || isNotRequiredEmptyAnswer;
+    const answerValidation = validateTextLength(value) === 'empty';
 
     // 유효한 답변이여야 text에 value를 반영
     const newAnswer: ReviewWritingAnswer = {
       questionId: question.questionId,
       selectedOptionIds: null,
-      // 선택 질문이여도, 글자 개수가 유효성 여부 판단
-      text: isValidatedText ? value : '',
+      text: answerValidation ? value : '',
     };
 
     return { newAnswer, answerValidation };
@@ -105,10 +98,8 @@ const useTextAnswer = ({ question }: UseTextAnswerProps) => {
 
   const handleTextAnswerBlur = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     const { value } = event.target;
-    // 선택 질문, 작성한 답변이 없는 경우
-    if (!question.required && value.length === 0) return;
-    // 필수 질문 이거나 작성한 답변이 있는 선택 질문
     const validationResult = validateTextLength(value);
+
     setErrorMessage(TEXT_ANSWER_ERROR_MESSAGE[validationResult]);
   };
 

--- a/frontend/src/pages/ReviewWritingPage/form/hooks/answers/useTextAnswer/test.tsx
+++ b/frontend/src/pages/ReviewWritingPage/form/hooks/answers/useTextAnswer/test.tsx
@@ -15,7 +15,7 @@ import useUpdateDefaultAnswers from '../useUpdateDefaultAnswers';
 import useTextAnswer, { TEXT_ANSWER_ERROR_MESSAGE, TEXT_ANSWER_LENGTH } from '.';
 
 const MOCK_SECTION_LIST = [FEEDBACK_SECTION];
-const NOT_REQUIRED_MOCK_SECTION_LIST: ReviewWritingCardSection[] = [
+const NOT_REQUIRED_ANSWER_MOCK_SECTION_LIST: ReviewWritingCardSection[] = [
   { ...FEEDBACK_SECTION, questions: [{ ...FEEDBACK_SECTION.questions[0], required: false }] },
 ];
 
@@ -69,11 +69,13 @@ describe('서술형 답변 테스트', () => {
   const { min, max } = TEXT_ANSWER_LENGTH;
 
   const MOCK_TEXT = 'A'.repeat(max + 10);
-  const VALIDATE_CASE = [MOCK_TEXT.slice(0, min), MOCK_TEXT.slice(0, max)];
-  const INVALIDATE_CASE = [MOCK_TEXT.slice(0, min - 1), MOCK_TEXT.slice(0, max + 1)];
+  const COMMON_VALIDATE_CASE_LIST = [MOCK_TEXT.slice(0, min), MOCK_TEXT.slice(0, max)];
+  const NOT_REQUIRED_ANSWER_VALIDATE_CASE_LIST = ['', ...COMMON_VALIDATE_CASE_LIST];
+  const COMMON_INVALIDATE_CASE = MOCK_TEXT.slice(0, max + 1);
+  const REQUIRED_ANSWER_INVALIDATED_CASE_LIST = ['', MOCK_TEXT.slice(0, min - 1), COMMON_INVALIDATE_CASE];
 
   describe('필수 질문에 대한 서술형 답변 유효성 검사', () => {
-    it.each(VALIDATE_CASE)(
+    it.each(COMMON_VALIDATE_CASE_LIST)(
       '필수 질문에 대한 서술형의 경우, 답변 글자 수가 최소 글자 수 이상 최대 글자 수 이하 조건을 만족해야한다.(글자수 : %i.length)',
       async (text) => {
         const { result } = renderUseTextAnswerHook({});
@@ -94,7 +96,7 @@ describe('서술형 답변 테스트', () => {
       },
     );
 
-    it.each(INVALIDATE_CASE)(
+    it.each(REQUIRED_ANSWER_INVALIDATED_CASE_LIST)(
       '필수 질문에 대한 서술형의 경우, 답변 글자 수가 최소 글자 수 미만이거나 최대 글자 수를 초과하면 답변이 유효하지 않디.(글자수 : %i.length)',
       async (text) => {
         const { result } = renderUseTextAnswerHook({});
@@ -117,9 +119,9 @@ describe('서술형 답변 테스트', () => {
   });
 
   describe('선택 질문에 대한 서술형 답변 유효성 검사', () => {
-    it('선택 질문에 대한 서술형 답볌의 경우, 작성한 답변이 없거나 빈문자열이면 유효한 답변이다.', async () => {
+    it('선택 질문에 대한 서술형 답볌의 경우, 작성한 답변이 없으면 유효한 답변이다.', async () => {
       const { result } = renderUseTextAnswerHook({
-        reviewWritingFormSectionListData: NOT_REQUIRED_MOCK_SECTION_LIST,
+        reviewWritingFormSectionListData: NOT_REQUIRED_ANSWER_MOCK_SECTION_LIST,
       });
 
       //초기 셋팅 확인
@@ -128,16 +130,16 @@ describe('서술형 답변 테스트', () => {
       });
 
       expect(
-        result.current.answerValidationMap?.get(NOT_REQUIRED_MOCK_SECTION_LIST[0].questions[0].questionId),
+        result.current.answerValidationMap?.get(NOT_REQUIRED_ANSWER_MOCK_SECTION_LIST[0].questions[0].questionId),
       ).toBeTruthy();
     });
 
     describe('선택 질문에 대한 서술형 답변에 작성한 답변이 있는 경우의 유효성 검사', () => {
-      it.each(VALIDATE_CASE)(
-        '선택 질문이어도 작성한 답변이 있다면 답변 글자 수가 최소 글자 수 이상이면서 최대 글자 수 미만이면 답변이 유효하디.(글자수 : %i.length)',
+      it.each(NOT_REQUIRED_ANSWER_VALIDATE_CASE_LIST)(
+        '선택 질문이어도 작성한 답변이 있다면 답변 글자 수가 최대 글자 수 이하면 답변이 유효하디.(글자수 : %i.length)',
         async (text) => {
           const { result } = renderUseTextAnswerHook({
-            reviewWritingFormSectionListData: NOT_REQUIRED_MOCK_SECTION_LIST,
+            reviewWritingFormSectionListData: NOT_REQUIRED_ANSWER_MOCK_SECTION_LIST,
           });
 
           //초기 셋팅 확인
@@ -148,48 +150,41 @@ describe('서술형 답변 테스트', () => {
           expect(result.current.errorMessage).toEqual('');
 
           //change 이벤트 실행
-          if (text) {
-            act(() => {
-              const event = { target: { value: text } } as React.ChangeEvent<HTMLTextAreaElement>;
+          act(() => {
+            const event = { target: { value: text } } as React.ChangeEvent<HTMLTextAreaElement>;
 
-              result.current.handleTextAnswerChange(event);
-            });
-          }
+            result.current.handleTextAnswerChange(event);
+          });
 
           expect(
-            result.current.answerValidationMap?.get(NOT_REQUIRED_MOCK_SECTION_LIST[0].questions[0].questionId),
+            result.current.answerValidationMap?.get(NOT_REQUIRED_ANSWER_MOCK_SECTION_LIST[0].questions[0].questionId),
           ).toBeTruthy();
         },
       );
 
-      it.each(INVALIDATE_CASE)(
-        '선택 질문이어도 작성한 답변이 있다면 답변 글자 수가 최소 글자 수 미만이거나 최대 글자 수를 초과하면 답변이 유효하지 않디.(글자수 : %i.length)',
-        async (text) => {
-          const { result } = renderUseTextAnswerHook({
-            reviewWritingFormSectionListData: NOT_REQUIRED_MOCK_SECTION_LIST,
-          });
+      it('선택 질문이어도 작성한 답변의 글자 수가 최대 글자 수를 초과하면 답변이 유효하지 않디.(글자수 : %i.length)', async () => {
+        const { result } = renderUseTextAnswerHook({
+          reviewWritingFormSectionListData: NOT_REQUIRED_ANSWER_MOCK_SECTION_LIST,
+        });
 
-          //초기 셋팅 확인
-          await waitFor(() => {
-            expect(result.current.cardSectionList[0].questions[0].required).toBeFalsy();
-          });
+        //초기 셋팅 확인
+        await waitFor(() => {
+          expect(result.current.cardSectionList[0].questions[0].required).toBeFalsy();
+        });
 
-          expect(result.current.errorMessage).toEqual('');
+        expect(result.current.errorMessage).toEqual('');
 
-          //change 이벤트 실행
-          if (text) {
-            act(() => {
-              const event = { target: { value: text } } as React.ChangeEvent<HTMLTextAreaElement>;
+        //change 이벤트 실행
+        act(() => {
+          const event = { target: { value: COMMON_INVALIDATE_CASE } } as React.ChangeEvent<HTMLTextAreaElement>;
 
-              result.current.handleTextAnswerChange(event);
-            });
-          }
+          result.current.handleTextAnswerChange(event);
+        });
 
-          expect(
-            result.current.answerValidationMap?.get(NOT_REQUIRED_MOCK_SECTION_LIST[0].questions[0].questionId),
-          ).toBeFalsy();
-        },
-      );
+        expect(
+          result.current.answerValidationMap?.get(NOT_REQUIRED_ANSWER_MOCK_SECTION_LIST[0].questions[0].questionId),
+        ).toBeFalsy();
+      });
     });
   });
 
@@ -205,7 +200,7 @@ describe('서술형 답변 테스트', () => {
 
       // text값 넣기
       act(() => {
-        const event = { target: { value: INVALIDATE_CASE[1] } } as React.ChangeEvent<HTMLTextAreaElement>;
+        const event = { target: { value: COMMON_INVALIDATE_CASE } } as React.ChangeEvent<HTMLTextAreaElement>;
 
         result.current.handleTextAnswerChange(event);
       });
@@ -215,7 +210,7 @@ describe('서술형 답변 테스트', () => {
     });
 
     describe('포커스 해제 시(=onBlur) 메세지 테스트', () => {
-      it.each(['', ...INVALIDATE_CASE])(
+      it.each(REQUIRED_ANSWER_INVALIDATED_CASE_LIST)(
         '필수 질문일 경우, textArea에 포커스가 해제되면 오류 메세지를 띄운다.',
         async (text) => {
           const isUnderMin = text.length < min;
@@ -228,15 +223,6 @@ describe('서술형 답변 테스트', () => {
           });
 
           expect(result.current.errorMessage).toEqual('');
-
-          // text가 빈문자열이 아닐 경우에만 change 이벤트 실행
-          if (text) {
-            act(() => {
-              const event = { target: { value: text } } as React.ChangeEvent<HTMLTextAreaElement>;
-
-              result.current.handleTextAnswerChange(event);
-            });
-          }
 
           //onBlur
           act(() => {
@@ -251,39 +237,13 @@ describe('서술형 답변 테스트', () => {
       );
 
       describe('선택 질문', () => {
-        it('답변을 작성하지 않은 선택 질문에 대한 서술형 답변의경우, textArea에 포커스가 해제되어도 오류메세지를 띄우지 않는다', async () => {
-          const expectedErrorMessage = '';
-
-          const { result } = renderUseTextAnswerHook({
-            reviewWritingFormSectionListData: NOT_REQUIRED_MOCK_SECTION_LIST,
-          });
-
-          //초기 셋팅 확인
-          await waitFor(() => {
-            expect(result.current.cardSectionList[0].questions[0].required).toBeFalsy();
-          });
-
-          expect(result.current.errorMessage).toEqual('');
-
-          //onBlur
-          act(() => {
-            const event = { target: { value: '' } } as React.ChangeEvent<HTMLTextAreaElement>;
-
-            result.current.handleTextAnswerBlur(event);
-          });
-
-          // 오류 메세지 확인
-          expect(result.current.errorMessage).toEqual(expectedErrorMessage);
-        });
-
-        it.each(INVALIDATE_CASE)(
-          '선택 질문이어도 작성한 답변이 있고 답변이 유효하지 않다면, textArea에 포커스가 해제될때 오류 메세지를 띄운다.',
+        it.each(NOT_REQUIRED_ANSWER_VALIDATE_CASE_LIST)(
+          '선택 질문에 대한 유효한 서술형 답변인 경우(= 최소 글자 이하), textArea에 포커스가 해제되어도 오류메세지를 띄우지 않는다',
           async (text) => {
-            const isUnderMin = text.length < min;
-            const expectedErrorMessage = isUnderMin ? TEXT_ANSWER_ERROR_MESSAGE.min : TEXT_ANSWER_ERROR_MESSAGE.max;
+            const expectedErrorMessage = '';
 
             const { result } = renderUseTextAnswerHook({
-              reviewWritingFormSectionListData: NOT_REQUIRED_MOCK_SECTION_LIST,
+              reviewWritingFormSectionListData: NOT_REQUIRED_ANSWER_MOCK_SECTION_LIST,
             });
 
             //초기 셋팅 확인
@@ -292,15 +252,6 @@ describe('서술형 답변 테스트', () => {
             });
 
             expect(result.current.errorMessage).toEqual('');
-
-            // text가 빈문자열이 아닐 경우에만 change 이벤트 실행
-            if (text) {
-              act(() => {
-                const event = { target: { value: text } } as React.ChangeEvent<HTMLTextAreaElement>;
-
-                result.current.handleTextAnswerChange(event);
-              });
-            }
 
             //onBlur
             act(() => {
@@ -313,6 +264,31 @@ describe('서술형 답변 테스트', () => {
             expect(result.current.errorMessage).toEqual(expectedErrorMessage);
           },
         );
+
+        it('선택 질문이어도 작성한 답변이 있고 답변이 유효하지 않다면(= 최대 글자수를 초과), textArea에 포커스가 해제될때 오류 메세지를 띄운다.', async () => {
+          const expectedErrorMessage = TEXT_ANSWER_ERROR_MESSAGE.max;
+
+          const { result } = renderUseTextAnswerHook({
+            reviewWritingFormSectionListData: NOT_REQUIRED_ANSWER_MOCK_SECTION_LIST,
+          });
+
+          //초기 셋팅 확인
+          await waitFor(() => {
+            expect(result.current.cardSectionList[0].questions[0].required).toBeFalsy();
+          });
+
+          expect(result.current.errorMessage).toEqual('');
+
+          //onBlur
+          act(() => {
+            const event = { target: { value: COMMON_INVALIDATE_CASE } } as React.ChangeEvent<HTMLTextAreaElement>;
+
+            result.current.handleTextAnswerBlur(event);
+          });
+
+          // 오류 메세지 확인
+          expect(result.current.errorMessage).toEqual(expectedErrorMessage);
+        });
       });
     });
   });

--- a/frontend/src/pages/ReviewWritingPage/form/hooks/answers/useTextAnswer/test.tsx
+++ b/frontend/src/pages/ReviewWritingPage/form/hooks/answers/useTextAnswer/test.tsx
@@ -119,7 +119,7 @@ describe('서술형 답변 테스트', () => {
   });
 
   describe('선택 질문에 대한 서술형 답변 유효성 검사', () => {
-    it('선택 질문에 대한 서술형 답볌의 경우, 작성한 답변이 없으면 유효한 답변이다.', async () => {
+    it('선택 질문에 대한 서술형 답변의 경우, 작성한 답변이 없으면 유효한 답변이다.', async () => {
       const { result } = renderUseTextAnswerHook({
         reviewWritingFormSectionListData: NOT_REQUIRED_ANSWER_MOCK_SECTION_LIST,
       });


### PR DESCRIPTION


- resolves #561

---

### 🚀 어떤 기능을 구현했나요 ?
#### 선택인 객관식
- 최소 개수 조건을 적용하지 않게 훅을 변경했고, 훅에 대한 테스트 코드도 변경했어요.
- 최소 개수 안내 문구를 보여주지 않도록 변경했어요.

#### 선택인 주관식
최소 글자 개수 조건을 적용하지 않도록 훅을 변경했고, 훅에 대한 테스트 코드도 변경했어요.
최소 글자 개수 조건을 보여주지 않는다것은 올리가 담당해서, 이를 수정하지 않았어요.

### 🔥 어떻게 해결했나요 ?
- 유효성 검사를 진행하는 훅을 변경했고, 테스트를 돌려서 예상한대로 적용되는 지 확인했어요
- 테스트 통과 후, 목데이터를 바꿔서 실제 화면에서도 적용되는 것을 확인했어요.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 선택 질문인 주관식에서 최대 글자 수는 적용하기로 회의에서 결졍했지만, 선택 질문인 객관식의 최대 선택 개수는 정하지 않았어요.
객관식 질문에 최대 선택을 정한 이유가 리뷰어가 리뷰이의 찐 강점만 뽑도록 하고자 하는 의도가 있었기 때문에, 이를 생각해 선택 질문인 객관식은 최대 선택 개수 이하면 통과하도록 수정했어요. 

### 📚 참고 자료, 할 말
- 피그잼은...  개인 미션 끝내고 바꿀게요 ㅎㅎㅎ 