### PR TITLE
[FE] refactor: 서술형 필수 질문에 최소/최대 문구 안내 추가

### DIFF
--- a/frontend/src/pages/ReviewWritingPage/constants/index.ts
+++ b/frontend/src/pages/ReviewWritingPage/constants/index.ts
@@ -1,1 +1,2 @@
 export * from './modal';
+export * from './textarea';

--- a/frontend/src/pages/ReviewWritingPage/constants/textarea.ts
+++ b/frontend/src/pages/ReviewWritingPage/constants/textarea.ts
@@ -1,0 +1,5 @@
+export const TEXT_ANSWER_LENGTH = {
+  min: 20,
+  max: 1000,
+  extra: 10,
+};

--- a/frontend/src/pages/ReviewWritingPage/form/components/QnABox/index.tsx
+++ b/frontend/src/pages/ReviewWritingPage/form/components/QnABox/index.tsx
@@ -1,3 +1,4 @@
+import { TEXT_ANSWER_LENGTH } from '@/pages/ReviewWritingPage/constants';
 import { MultipleChoiceAnswer, TextAnswer } from '@/pages/ReviewWritingPage/form/components';
 import { ReviewWritingCardQuestion } from '@/types';
 
@@ -15,12 +16,17 @@ const QnABox = ({ question }: QnABoxProps) => {
    * 객관식 문항의 최소,최대 개수에 대한 안내 문구
    */
   const multipleLGuideline = (() => {
-    const { optionGroup } = question;
-    if (!optionGroup) return;
+    const { optionGroup, questionType } = question;
 
+    if (question.required && questionType === 'TEXT') {
+      return `(최소 ${TEXT_ANSWER_LENGTH.min}자 ~ 최대 ${TEXT_ANSWER_LENGTH.max}자)`;
+    }
+
+    if (!optionGroup) return;
     const { minCount, maxCount } = optionGroup;
 
     const isAllSelectAvailable = maxCount === optionGroup.options.length;
+
     if (!maxCount || isAllSelectAvailable) return `(최소 ${minCount}개 이상)`;
 
     return `(${minCount}개 ~ ${maxCount}개)`;

--- a/frontend/src/pages/ReviewWritingPage/form/components/QnABox/index.tsx
+++ b/frontend/src/pages/ReviewWritingPage/form/components/QnABox/index.tsx
@@ -16,17 +16,17 @@ const QnABox = ({ question }: QnABoxProps) => {
    * 객관식 문항의 최소,최대 개수에 대한 안내 문구
    */
   const multipleLGuideline = (() => {
-    const { optionGroup, questionType } = question;
+    const { optionGroup } = question;
 
-    // NOTE: 객관식일 경우의 안내 문구 처리
-    if (questionType === 'TEXT') {
+    // NOTE: 주관식일 경우의 안내 문구 처리
+    if (!optionGroup) {
       const guideline = question.required
         ? `(최소 ${TEXT_ANSWER_LENGTH.min}자 ~ 최대 ${TEXT_ANSWER_LENGTH.max}자)`
         : `(최대 ${TEXT_ANSWER_LENGTH.max}자)`;
       return guideline;
     }
 
-    if (!optionGroup) return;
+    // NOTE: 객관식일 경우의 안내 문구 처리
     const { minCount, maxCount } = optionGroup;
 
     const isAllSelectAvailable = maxCount === optionGroup.options.length;

--- a/frontend/src/pages/ReviewWritingPage/form/components/QnABox/index.tsx
+++ b/frontend/src/pages/ReviewWritingPage/form/components/QnABox/index.tsx
@@ -18,8 +18,12 @@ const QnABox = ({ question }: QnABoxProps) => {
   const multipleLGuideline = (() => {
     const { optionGroup, questionType } = question;
 
-    if (question.required && questionType === 'TEXT') {
-      return `(최소 ${TEXT_ANSWER_LENGTH.min}자 ~ 최대 ${TEXT_ANSWER_LENGTH.max}자)`;
+    // NOTE: 객관식일 경우의 안내 문구 처리
+    if (questionType === 'TEXT') {
+      const guideline = question.required
+        ? `(최소 ${TEXT_ANSWER_LENGTH.min}자 ~ 최대 ${TEXT_ANSWER_LENGTH.max}자)`
+        : `(최대 ${TEXT_ANSWER_LENGTH.max}자)`;
+      return guideline;
     }
 
     if (!optionGroup) return;

--- a/frontend/src/pages/ReviewWritingPage/form/components/TextAnswer/index.tsx
+++ b/frontend/src/pages/ReviewWritingPage/form/components/TextAnswer/index.tsx
@@ -8,7 +8,7 @@ interface TextAnswerProps {
 }
 
 const TextAnswer = ({ question }: TextAnswerProps) => {
-  const { text, minLength, maxLength, errorMessage, handleTextAnswerBlur, handleTextAnswerChange } = useTextAnswer({
+  const { text, maxLength, errorMessage, handleTextAnswerBlur, handleTextAnswerChange } = useTextAnswer({
     question,
   });
 
@@ -22,7 +22,6 @@ const TextAnswer = ({ question }: TextAnswerProps) => {
         $isError={errorMessage !== ''}
         onChange={handleTextAnswerChange}
         onBlur={handleTextAnswerBlur}
-        placeholder={`최소 ${minLength}자 이상, 최대 ${maxLength}자까지 입력 가능해요`}
       />
       <S.TextareaInfoContainer>
         <S.ReviewTextareaError>{errorMessage}</S.ReviewTextareaError>

--- a/frontend/src/pages/ReviewWritingPage/form/hooks/answers/useTextAnswer/index.ts
+++ b/frontend/src/pages/ReviewWritingPage/form/hooks/answers/useTextAnswer/index.ts
@@ -1,14 +1,9 @@
 import { useState } from 'react';
 
+import { TEXT_ANSWER_LENGTH } from '@/pages/ReviewWritingPage/constants';
 import { ReviewWritingAnswer, ReviewWritingCardQuestion } from '@/types';
 
 import useUpdateReviewerAnswer from '../useUpdateReviewerAnswer';
-
-export const TEXT_ANSWER_LENGTH = {
-  min: 20,
-  max: 1000,
-  extra: 10,
-};
 
 export const TEXT_ANSWER_ERROR_MESSAGE = {
   min: `최소 ${TEXT_ANSWER_LENGTH.min}자 이상 작성해 주세요`,

--- a/frontend/src/pages/ReviewWritingPage/form/hooks/answers/useTextAnswer/test.tsx
+++ b/frontend/src/pages/ReviewWritingPage/form/hooks/answers/useTextAnswer/test.tsx
@@ -2,6 +2,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { RecoilRoot, RecoilState, useRecoilValue } from 'recoil';
 
 import { FEEDBACK_SECTION } from '@/mocks/mockData';
+import { TEXT_ANSWER_LENGTH } from '@/pages/ReviewWritingPage/constants';
 import {
   answerMapAtom,
   answerValidationMapAtom,
@@ -12,7 +13,7 @@ import { EssentialPropsWithChildren, ReviewWritingCardSection } from '@/types';
 
 import useUpdateDefaultAnswers from '../useUpdateDefaultAnswers';
 
-import useTextAnswer, { TEXT_ANSWER_ERROR_MESSAGE, TEXT_ANSWER_LENGTH } from '.';
+import useTextAnswer, { TEXT_ANSWER_ERROR_MESSAGE } from '.';
 
 const MOCK_SECTION_LIST = [FEEDBACK_SECTION];
 const NOT_REQUIRED_MOCK_SECTION_LIST: ReviewWritingCardSection[] = [


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #559 

---

### 🚀 어떤 기능을 구현했나요 ?
- 서술형 필수 질문에 최소/최대 문구 안내를 추가했습니다.
- 2곳 이상에서 사용하는 상수를 별도의 constant 폴더로 분리했습니다.

### 🔥 어떻게 해결했나요 ?
`!optionGroup` 이면 TEXT 타입(주관식)이긴 한데 

```ts
if (!optionGroup && ... question.required){
  return `(최소 ${TEXT_ANSWER_LENGTH.min}자 ~ 최대 ${TEXT_ANSWER_LENGTH.max}자)`;
}
```

이렇게 체크를 하는 것보다는 `questionType === 'TEXT'`처럼 명시적으로 질문 타입을 체크하는 게 나은 것 같아 `questionType`을 추가로 가져왔습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 이상한 곳 없는지 봐주세요~~

### 📚 참고 자료, 할 말
