### PR TITLE
[FE] feat : 요청 데이터 특징에 따라 useQuery staleTime 지정

### DIFF
--- a/frontend/src/hooks/review/useGetDetailedReview/index.ts
+++ b/frontend/src/hooks/review/useGetDetailedReview/index.ts
@@ -25,6 +25,7 @@ const useGetDetailedReview = ({ reviewId, groupAccessCode, reviewRequestCode }: 
   const result = useSuspenseQuery<DetailReviewData>({
     queryKey: [REVIEW_QUERY_KEY.detailedReview, reviewId],
     queryFn: () => fetchDetailedReview({ reviewId, groupAccessCode, reviewRequestCode }),
+    staleTime: 60 * 60 * 1000,
   });
 
   return result;

--- a/frontend/src/hooks/review/useGetReviewList/index.ts
+++ b/frontend/src/hooks/review/useGetReviewList/index.ts
@@ -7,6 +7,7 @@ const useGetReviewList = (groupAccessCode: string, reviewRequestCode: string) =>
   const { data, isLoading, error, isSuccess } = useSuspenseQuery({
     queryKey: [REVIEW_QUERY_KEY.reviews],
     queryFn: () => getReviewListApi(groupAccessCode, reviewRequestCode),
+    staleTime: 1 * 60 * 1000,
   });
 
   // NOTE: 무한스크롤 관련 코드 일단 주석 처리

--- a/frontend/src/hooks/reviewGroup/useGetReviewGroupData/index.ts
+++ b/frontend/src/hooks/reviewGroup/useGetReviewGroupData/index.ts
@@ -20,7 +20,7 @@ const useGetReviewGroupData = ({ reviewRequestCode }: UseGetReviewGroupDataProps
   const result = useSuspenseQuery<ReviewGroupData>({
     queryKey: [GROUP_QUERY_KEY.reviewGroupData, reviewRequestCode],
     queryFn: () => fetchReviewGroupData({ reviewRequestCode }),
-    staleTime: 1000 * 60 * 5,
+    staleTime: 60 * 60 * 1000,
   });
 
   return result;


### PR DESCRIPTION


- resolves #569

---

### 🚀 어떤 기능을 구현했나요 ?
아래 처럼 useQuery의 staleTime을 지정/변경했어요.

- 리뷰 목록 데이터 : 1분
- 리뷰 상세 데이터: 1시간
- 연결 페이지의 리뷰 데이터 :1시간

### 🔥 어떻게 해결했나요 ?
- 프론트 팀 회의에서 데이터의 가변성을 기준으로 staleTime을 지정한 후, 이를 반영했어요. 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
-

### 📚 참고 자료, 할 말
