### PR TITLE
[FE] feat: 웹 페이지 탭 전환 시, 리액트 쿼리 api 요청 막기

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -52,6 +52,7 @@ const queryClient = new QueryClient({
     queries: {
       throwOnError: true,
       retry: retryFunction,
+      refetchOnWindowFocus: false,
     },
     mutations: {
       throwOnError: true,


### PR DESCRIPTION
- resolves #576 

---

### 🚀 어떤 기능을 구현했나요 ?
- 웹 페이지 탭 전환 시, 코드 수정 혹은 데이터에 변화가 없음에도 api 요청이 가고 있는 것을 발견했습니다. (아래 영상 참고)

https://github.com/user-attachments/assets/a5ddac5a-ba2b-4191-a455-1db40d89ad57


- 불필요한 api 요청을 방지하기 위해 리액트 쿼리 Refetching을 비활성화했습니다.


### 🔥 어떻게 해결했나요 ?

TanStack Query v5 문서에 아래와 같이 정의되어 있습니다.
```
Window Focus Refetching
사용자가 애플리케이션을 떠나서 돌아왔을 때 쿼리 데이터가 오래된 경우 TanStack Query는 백그라운드에서 자동으로 새로운 데이터를 요청합니다. refetchOnWindowFocus 옵션을 사용하여 전역적으로 또는 쿼리별로 이를 비활성화할 수 있습니다 .
```

불필요한 api 요청을 막기 위해 `QueryClient`의 설정에서 `refetchOnWindowFocus` 옵션을 `false`로 설정했습니다. `fasle`로 설정하면 새로고침을 하지 않는 이상 `refetch` 되지 않습니다.
```ts
const queryClient = new QueryClient({
  defaultOptions: {
    queries: {
      throwOnError: true,
      retry: retryFunction,
      refetchOnWindowFocus: false, // window에 focus 될 경우, refetch 비활성화
    },
    mutations: {
      throwOnError: true,
      retry: retryFunction,
    },
  },
});
```

### 결과
https://github.com/user-attachments/assets/caedc75f-d595-4399-8227-b42e34aa8b49



### 📝 어떤 부분에 집중해서 리뷰해야 할까요?

### 📚 참고 자료, 할 말
[TanStack Query v5](https://tanstack.com/query/latest/docs/framework/react/guides/window-focus-refetching)