### PR TITLE
[FE] chore: 서술형 답변에 최대 max의 2배 길이 문자열을 붙여 넣어도 문자열이 잘리지 않도록 수정

### DIFF
--- a/frontend/src/pages/ReviewWritingPage/constants/textarea.ts
+++ b/frontend/src/pages/ReviewWritingPage/constants/textarea.ts
@@ -1,5 +1,4 @@
 export const TEXT_ANSWER_LENGTH = {
   min: 20,
   max: 1000,
-  extra: 10,
 };

--- a/frontend/src/pages/ReviewWritingPage/form/hooks/answers/useTextAnswer/index.ts
+++ b/frontend/src/pages/ReviewWritingPage/form/hooks/answers/useTextAnswer/index.ts
@@ -28,18 +28,16 @@ const useTextAnswer = ({ question }: UseTextAnswerProps) => {
   const handleTextAnswerChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     const { value } = event.target;
 
-    // NOTE: max 넘치는 글자는 max+ extra 만큼 자르는 이유
-    // 1. 글자는 사용자가 입력한대로 보여줘야한다. (복붙해서 사용할때 이슈 있었음)
-    // 2. 과도한 입력을 방지하기 위해 max를 넘어서는 일정 수준에서 글자를 자른다.
     sliceTextAnswer(value);
     handleErrorMessageOnChange(value);
     handleUpdateAnswerState(value);
   };
 
   const sliceTextAnswer = (value: string) => {
-    const { max, extra } = TEXT_ANSWER_LENGTH;
+    const { max } = TEXT_ANSWER_LENGTH;
 
-    setText(value.slice(0, max + extra));
+    // 최대 max의 2배 길이 문자열까지 붙여넣어도 문자열이 잘리지 않도록 설정
+    setText(value.slice(0, max * 2));
   };
 
   type TextAnswerErrorMessage = keyof typeof TEXT_ANSWER_ERROR_MESSAGE;


### PR DESCRIPTION
- resolves #575 

---

### 🚀 어떤 기능을 구현했나요 ?
- 사용자가 서술형 답변으로 문자열을 붙여넣기 할 때, 1000자가 넘는 경우 문자열이 잘려 보이는 문제가 있었습니다.
- 서술형 답변에 최대 max의 2배 길이 문자열을 붙여 넣어도 문자열이 잘리지 않도록 수정했습니다.

### 🔥 어떻게 해결했나요 ?
- 기존에 `extra: 10`만큼 추가적으로 문자열을 받았던 것에서, max * 2 길이까지는 문자열이 잘리지 않도록 수정했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
![image](https://github.com/user-attachments/assets/d51c9c9b-1d01-4cbd-b93c-e9ec3ed36cad)
