### PR TITLE
[FE] fix: 이전 버튼이 눌리지 않는 현상 수정

### DIFF
--- a/frontend/src/pages/ReviewWritingPage/slider/components/CardSlider/index.tsx
+++ b/frontend/src/pages/ReviewWritingPage/slider/components/CardSlider/index.tsx
@@ -46,7 +46,6 @@ const CardSlider = ({ currentCardIndex, handleCurrentCardIndex, handleOpenModal 
             {isAblePrevStep(index) && (
               <CardSliderController.PrevButton
                 data-testid={`${section.sectionId}-prevButton`}
-                currentCardIndex={currentCardIndex}
                 handleCurrentCardIndex={handleCurrentCardIndex}
               />
             )}

--- a/frontend/src/pages/ReviewWritingPage/slider/components/CardSliderController/index.tsx
+++ b/frontend/src/pages/ReviewWritingPage/slider/components/CardSliderController/index.tsx
@@ -11,7 +11,7 @@ const PrevButton = ({ currentCardIndex, handleCurrentCardIndex, ...rest }: PrevB
 
   return (
     <Button
-      disabled={!currentCardIndex}
+      disabled={currentCardIndex === 0}
       styleType={styledType}
       type={'button'}
       onClick={() => handleCurrentCardIndex('prev')}

--- a/frontend/src/pages/ReviewWritingPage/slider/components/CardSliderController/index.tsx
+++ b/frontend/src/pages/ReviewWritingPage/slider/components/CardSliderController/index.tsx
@@ -11,7 +11,7 @@ const PrevButton = ({ currentCardIndex, handleCurrentCardIndex, ...rest }: PrevB
 
   return (
     <Button
-      disabled={!!currentCardIndex}
+      disabled={!currentCardIndex}
       styleType={styledType}
       type={'button'}
       onClick={() => handleCurrentCardIndex('prev')}

--- a/frontend/src/pages/ReviewWritingPage/slider/components/CardSliderController/index.tsx
+++ b/frontend/src/pages/ReviewWritingPage/slider/components/CardSliderController/index.tsx
@@ -2,21 +2,12 @@ import { Button } from '@/components';
 import { ButtonStyleType } from '@/types';
 
 interface PrevButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
-  currentCardIndex: number;
   handleCurrentCardIndex: (direction: 'prev' | 'next') => void;
 }
 
-const PrevButton = ({ currentCardIndex, handleCurrentCardIndex, ...rest }: PrevButtonProps) => {
-  const styledType: ButtonStyleType = currentCardIndex ? 'secondary' : 'disabled';
-
+const PrevButton = ({ handleCurrentCardIndex, ...rest }: PrevButtonProps) => {
   return (
-    <Button
-      disabled={currentCardIndex === 0}
-      styleType={styledType}
-      type={'button'}
-      onClick={() => handleCurrentCardIndex('prev')}
-      {...rest}
-    >
+    <Button styleType={'secondary'} type={'button'} onClick={() => handleCurrentCardIndex('prev')} {...rest}>
       이전
     </Button>
   );


### PR DESCRIPTION
- resolves #579 

---

### 🚀 어떤 기능을 구현했나요 ?
- 이전 버튼이 눌리지 않는 현상을 수정했습니다.

### 🔥 어떻게 해결했나요 ?
- 이전 버튼은 첫 번째 카드를 제외한 나머지에서 모두 활성화되고, 첫 번째 인덱스인지는 다른 컴포넌트에서 판단하고 있기 때문에 currentCardIndex를 받을 필요가 없습니다.
- 불필요한 props를 제거하고, styleType은 secondary로 고정했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
