### PR TITLE
[BE] refactor: 필수 질문이 아닌 경우 최소 글자수 제한 제거

### DIFF
--- a/backend/src/main/java/reviewme/review/domain/exception/InvalidTextAnswerLengthException.java
+++ b/backend/src/main/java/reviewme/review/domain/exception/InvalidTextAnswerLengthException.java
@@ -13,8 +13,6 @@ public class InvalidTextAnswerLengthException extends BadRequestException {
     }
 
     public InvalidTextAnswerLengthException(long questionId, int answerLength, int maxLength) {
-        super("답변의 길이는 0자 이상 %d자 이하여야 해요.".formatted(maxLength));
-        log.warn("AnswerLength is out of bound - questionId: {}, answerLength: {}, minLength: 0, maxLength: {}",
-                questionId, answerLength, maxLength, this);
+        this(questionId, answerLength, 0, maxLength);
     }
 }

--- a/backend/src/main/java/reviewme/review/domain/exception/InvalidTextAnswerLengthException.java
+++ b/backend/src/main/java/reviewme/review/domain/exception/InvalidTextAnswerLengthException.java
@@ -6,9 +6,9 @@ import reviewme.global.exception.BadRequestException;
 @Slf4j
 public class InvalidTextAnswerLengthException extends BadRequestException {
 
-    public InvalidTextAnswerLengthException(int answerLength, int minLength, int maxLength) {
+    public InvalidTextAnswerLengthException(long questionId, int answerLength, int minLength, int maxLength) {
         super("답변의 길이는 %d자 이상 %d자 이하여야 해요.".formatted(minLength, maxLength));
-        log.warn("AnswerLength is out of bound - answerLength: {}, minLength: {}, maxLength: {}",
-                answerLength, minLength, maxLength, this);
+        log.warn("AnswerLength is out of bound - questionId: {}, answerLength: {}, minLength: {}, maxLength: {}",
+                questionId, answerLength, minLength, maxLength, this);
     }
 }

--- a/backend/src/main/java/reviewme/review/domain/exception/InvalidTextAnswerLengthException.java
+++ b/backend/src/main/java/reviewme/review/domain/exception/InvalidTextAnswerLengthException.java
@@ -11,4 +11,10 @@ public class InvalidTextAnswerLengthException extends BadRequestException {
         log.warn("AnswerLength is out of bound - questionId: {}, answerLength: {}, minLength: {}, maxLength: {}",
                 questionId, answerLength, minLength, maxLength, this);
     }
+
+    public InvalidTextAnswerLengthException(long questionId, int answerLength, int maxLength) {
+        super("답변의 길이는 0자 이상 %d자 이하여야 해요.".formatted(maxLength));
+        log.warn("AnswerLength is out of bound - questionId: {}, answerLength: {}, minLength: 0, maxLength: {}",
+                questionId, answerLength, maxLength, this);
+    }
 }

--- a/backend/src/main/java/reviewme/review/service/module/TextAnswerValidator.java
+++ b/backend/src/main/java/reviewme/review/service/module/TextAnswerValidator.java
@@ -33,7 +33,7 @@ public class TextAnswerValidator {
         }
 
         if (!question.isRequired() && answerLength > MAX_LENGTH) {
-            throw new InvalidTextAnswerLengthException(question.getId(), answerLength, ZERO_LENGTH, MAX_LENGTH);
+            throw new InvalidTextAnswerLengthException(question.getId(), answerLength, MAX_LENGTH);
         }
     }
 }

--- a/backend/src/main/java/reviewme/review/service/module/TextAnswerValidator.java
+++ b/backend/src/main/java/reviewme/review/service/module/TextAnswerValidator.java
@@ -2,6 +2,7 @@ package reviewme.review.service.module;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import reviewme.question.domain.Question;
 import reviewme.question.repository.QuestionRepository;
 import reviewme.review.domain.TextAnswer;
 import reviewme.review.domain.exception.InvalidTextAnswerLengthException;
@@ -11,26 +12,28 @@ import reviewme.review.service.exception.SubmittedQuestionNotFoundException;
 @RequiredArgsConstructor
 public class TextAnswerValidator {
 
+    private static final int ZERO_LENGTH = 0;
     private static final int MIN_LENGTH = 20;
     private static final int MAX_LENGTH = 1_000;
 
     private final QuestionRepository questionRepository;
 
     public void validate(TextAnswer textAnswer) {
-        validateExistQuestion(textAnswer);
-        validateLength(textAnswer);
+        Question question = questionRepository.findById(textAnswer.getQuestionId())
+                .orElseThrow(() -> new SubmittedQuestionNotFoundException(textAnswer.getQuestionId()));
+
+        validateLength(textAnswer, question);
     }
 
-    private void validateExistQuestion(TextAnswer textAnswer) {
-        if (!questionRepository.existsById(textAnswer.getQuestionId())) {
-            throw new SubmittedQuestionNotFoundException(textAnswer.getQuestionId());
-        }
-    }
-
-    private void validateLength(TextAnswer textAnswer) {
+    private void validateLength(TextAnswer textAnswer, Question question) {
         int answerLength = textAnswer.getContent().length();
-        if (answerLength < MIN_LENGTH || answerLength > MAX_LENGTH) {
-            throw new InvalidTextAnswerLengthException(answerLength, MIN_LENGTH, MAX_LENGTH);
+
+        if (question.isRequired() && (answerLength < MIN_LENGTH || answerLength > MAX_LENGTH)) {
+            throw new InvalidTextAnswerLengthException(question.getId(), answerLength, MIN_LENGTH, MAX_LENGTH);
+        }
+
+        if (!question.isRequired() && answerLength > MAX_LENGTH) {
+            throw new InvalidTextAnswerLengthException(question.getId(), answerLength, ZERO_LENGTH, MAX_LENGTH);
         }
     }
 }

--- a/backend/src/test/java/reviewme/review/service/module/TextAnswerValidatorTest.java
+++ b/backend/src/test/java/reviewme/review/service/module/TextAnswerValidatorTest.java
@@ -2,6 +2,7 @@ package reviewme.review.service.module;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static reviewme.fixture.QuestionFixture.서술형_옵션_질문;
 import static reviewme.fixture.QuestionFixture.서술형_필수_질문;
 
 import org.junit.jupiter.api.Test;
@@ -37,7 +38,7 @@ class TextAnswerValidatorTest {
 
     @ParameterizedTest
     @ValueSource(ints = {19, 10001})
-    void 답변_길이가_유효하지_않으면_예외가_발생한다(int length) {
+    void 필수_질문의_답변_길이가_유효하지_않으면_예외가_발생한다(int length) {
         // given
         String content = "답".repeat(length);
         Question savedQuestion = questionRepository.save(서술형_필수_질문());
@@ -46,5 +47,28 @@ class TextAnswerValidatorTest {
         // when, then
         assertThatThrownBy(() -> textAnswerValidator.validate(textAnswer))
                 .isInstanceOf(InvalidTextAnswerLengthException.class);
+    }
+
+    @Test
+    void 선택_질문의_답변_길이가_유효하지_않으면_예외가_발생한다() {
+        // given
+        String content = "답".repeat(10001);
+        Question savedQuestion = questionRepository.save(서술형_옵션_질문());
+        TextAnswer textAnswer = new TextAnswer(savedQuestion.getId(), content);
+
+        // when, then
+        assertThatThrownBy(() -> textAnswerValidator.validate(textAnswer))
+                .isInstanceOf(InvalidTextAnswerLengthException.class);
+    }
+
+    @Test
+    void 선택_질문은_최소_글자수_제한을_받지_않는다() {
+        // given
+        String content = "답".repeat(1);
+        Question savedQuestion = questionRepository.save(서술형_옵션_질문());
+        TextAnswer textAnswer = new TextAnswer(savedQuestion.getId(), content);
+
+        // when, then
+        assertThatCode(() -> textAnswerValidator.validate(textAnswer)).doesNotThrowAnyException();
     }
 }


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #453 

---

### 🚀 어떤 기능을 구현했나요 ?
- 서술형 필수 질문이 아닌 경우 최소 글자수 제한을 받지 않도록 변경했습니다.

### 🔥 어떻게 해결했나요 ?
- textAnswerValidator에서 textAnswer 글자수 검증 시, 질문의 필수여부에 따라 분기처리 했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
