### PR TITLE
[BE] refactor: 패키지 `mapper`, `validator` 분리

### DIFF
--- a/backend/src/main/java/reviewme/review/service/ReviewDetailLookupService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewDetailLookupService.java
@@ -9,7 +9,7 @@ import reviewme.review.repository.ReviewRepository;
 import reviewme.review.service.dto.response.detail.ReviewDetailResponse;
 import reviewme.review.service.exception.ReviewGroupUnauthorizedException;
 import reviewme.review.service.exception.ReviewNotFoundByIdAndGroupException;
-import reviewme.review.service.module.ReviewDetailMapper;
+import reviewme.review.service.mapper.ReviewDetailMapper;
 import reviewme.reviewgroup.domain.ReviewGroup;
 import reviewme.reviewgroup.repository.ReviewGroupRepository;
 

--- a/backend/src/main/java/reviewme/review/service/ReviewListLookupService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewListLookupService.java
@@ -8,7 +8,7 @@ import reviewme.review.service.exception.ReviewGroupNotFoundByReviewRequestCodeE
 import reviewme.review.service.dto.response.list.ReceivedReviewsResponse;
 import reviewme.review.service.dto.response.list.ReviewListElementResponse;
 import reviewme.review.service.exception.ReviewGroupUnauthorizedException;
-import reviewme.review.service.module.ReviewListMapper;
+import reviewme.review.service.mapper.ReviewListMapper;
 import reviewme.reviewgroup.domain.ReviewGroup;
 import reviewme.reviewgroup.repository.ReviewGroupRepository;
 

--- a/backend/src/main/java/reviewme/review/service/ReviewPreviewGenerator.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewPreviewGenerator.java
@@ -1,4 +1,4 @@
-package reviewme.review.service.module;
+package reviewme.review.service;
 
 import java.util.List;
 import reviewme.review.domain.TextAnswer;

--- a/backend/src/main/java/reviewme/review/service/ReviewRegisterService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewRegisterService.java
@@ -6,8 +6,8 @@ import org.springframework.transaction.annotation.Transactional;
 import reviewme.review.domain.Review;
 import reviewme.review.repository.ReviewRepository;
 import reviewme.review.service.dto.request.ReviewRegisterRequest;
-import reviewme.review.service.module.ReviewMapper;
-import reviewme.review.service.module.ReviewValidator;
+import reviewme.review.service.mapper.ReviewMapper;
+import reviewme.review.service.validator.ReviewValidator;
 
 @Service
 @RequiredArgsConstructor

--- a/backend/src/main/java/reviewme/review/service/mapper/AnswerMapper.java
+++ b/backend/src/main/java/reviewme/review/service/mapper/AnswerMapper.java
@@ -1,4 +1,4 @@
-package reviewme.review.service.module;
+package reviewme.review.service.mapper;
 
 import org.springframework.stereotype.Component;
 import reviewme.review.domain.CheckboxAnswer;

--- a/backend/src/main/java/reviewme/review/service/mapper/ReviewDetailMapper.java
+++ b/backend/src/main/java/reviewme/review/service/mapper/ReviewDetailMapper.java
@@ -1,4 +1,4 @@
-package reviewme.review.service.module;
+package reviewme.review.service.mapper;
 
 import java.util.List;
 import java.util.Set;

--- a/backend/src/main/java/reviewme/review/service/mapper/ReviewListMapper.java
+++ b/backend/src/main/java/reviewme/review/service/mapper/ReviewListMapper.java
@@ -1,4 +1,4 @@
-package reviewme.review.service.module;
+package reviewme.review.service.mapper;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +10,7 @@ import reviewme.review.domain.Review;
 import reviewme.review.repository.ReviewRepository;
 import reviewme.review.service.dto.response.list.ReviewCategoryResponse;
 import reviewme.review.service.dto.response.list.ReviewListElementResponse;
+import reviewme.review.service.ReviewPreviewGenerator;
 import reviewme.reviewgroup.domain.ReviewGroup;
 
 @Component

--- a/backend/src/main/java/reviewme/review/service/mapper/ReviewListMapper.java
+++ b/backend/src/main/java/reviewme/review/service/mapper/ReviewListMapper.java
@@ -10,7 +10,6 @@ import reviewme.review.domain.Review;
 import reviewme.review.repository.ReviewRepository;
 import reviewme.review.service.dto.response.list.ReviewCategoryResponse;
 import reviewme.review.service.dto.response.list.ReviewListElementResponse;
-import reviewme.review.service.ReviewPreviewGenerator;
 import reviewme.reviewgroup.domain.ReviewGroup;
 
 @Component

--- a/backend/src/main/java/reviewme/review/service/mapper/ReviewMapper.java
+++ b/backend/src/main/java/reviewme/review/service/mapper/ReviewMapper.java
@@ -1,4 +1,4 @@
-package reviewme.review.service.module;
+package reviewme.review.service.mapper;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/backend/src/main/java/reviewme/review/service/mapper/ReviewPreviewGenerator.java
+++ b/backend/src/main/java/reviewme/review/service/mapper/ReviewPreviewGenerator.java
@@ -1,4 +1,4 @@
-package reviewme.review.service;
+package reviewme.review.service.mapper;
 
 import java.util.List;
 import reviewme.review.domain.TextAnswer;

--- a/backend/src/main/java/reviewme/review/service/validator/CheckBoxAnswerValidator.java
+++ b/backend/src/main/java/reviewme/review/service/validator/CheckBoxAnswerValidator.java
@@ -1,4 +1,4 @@
-package reviewme.review.service.module;
+package reviewme.review.service.validator;
 
 import java.util.HashSet;
 import java.util.List;

--- a/backend/src/main/java/reviewme/review/service/validator/ReviewValidator.java
+++ b/backend/src/main/java/reviewme/review/service/validator/ReviewValidator.java
@@ -1,4 +1,4 @@
-package reviewme.review.service.module;
+package reviewme.review.service.validator;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/backend/src/main/java/reviewme/review/service/validator/TextAnswerValidator.java
+++ b/backend/src/main/java/reviewme/review/service/validator/TextAnswerValidator.java
@@ -1,4 +1,4 @@
-package reviewme.review.service.module;
+package reviewme.review.service.validator;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;

--- a/backend/src/main/java/reviewme/template/service/TemplateService.java
+++ b/backend/src/main/java/reviewme/template/service/TemplateService.java
@@ -7,7 +7,7 @@ import reviewme.review.service.exception.ReviewGroupNotFoundByReviewRequestCodeE
 import reviewme.reviewgroup.domain.ReviewGroup;
 import reviewme.reviewgroup.repository.ReviewGroupRepository;
 import reviewme.template.service.dto.response.TemplateResponse;
-import reviewme.template.service.module.TemplateMapper;
+import reviewme.template.service.mapper.TemplateMapper;
 
 @Service
 @RequiredArgsConstructor

--- a/backend/src/main/java/reviewme/template/service/mapper/TemplateMapper.java
+++ b/backend/src/main/java/reviewme/template/service/mapper/TemplateMapper.java
@@ -1,4 +1,4 @@
-package reviewme.template.service.module;
+package reviewme.template.service.mapper;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/test/java/reviewme/review/service/ReviewPreviewGeneratorTest.java
+++ b/backend/src/test/java/reviewme/review/service/ReviewPreviewGeneratorTest.java
@@ -1,4 +1,4 @@
-package reviewme.review.service.module;
+package reviewme.review.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/backend/src/test/java/reviewme/review/service/ReviewPreviewGeneratorTest.java
+++ b/backend/src/test/java/reviewme/review/service/ReviewPreviewGeneratorTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import reviewme.review.domain.TextAnswer;
+import reviewme.review.service.mapper.ReviewPreviewGenerator;
 
 class ReviewPreviewGeneratorTest {
 

--- a/backend/src/test/java/reviewme/review/service/mapper/AnswerMapperTest.java
+++ b/backend/src/test/java/reviewme/review/service/mapper/AnswerMapperTest.java
@@ -1,4 +1,4 @@
-package reviewme.review.service.module;
+package reviewme.review.service.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/backend/src/test/java/reviewme/review/service/mapper/ReviewMapperTest.java
+++ b/backend/src/test/java/reviewme/review/service/mapper/ReviewMapperTest.java
@@ -1,4 +1,4 @@
-package reviewme.review.service.module;
+package reviewme.review.service.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/backend/src/test/java/reviewme/review/service/validator/CheckBoxAnswerValidatorTest.java
+++ b/backend/src/test/java/reviewme/review/service/validator/CheckBoxAnswerValidatorTest.java
@@ -1,4 +1,4 @@
-package reviewme.review.service.module;
+package reviewme.review.service.validator;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static reviewme.fixture.OptionGroupFixture.선택지_그룹;

--- a/backend/src/test/java/reviewme/review/service/validator/ReviewValidatorTest.java
+++ b/backend/src/test/java/reviewme/review/service/validator/ReviewValidatorTest.java
@@ -1,4 +1,4 @@
-package reviewme.review.service.module;
+package reviewme.review.service.validator;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/backend/src/test/java/reviewme/review/service/validator/TextAnswerValidatorTest.java
+++ b/backend/src/test/java/reviewme/review/service/validator/TextAnswerValidatorTest.java
@@ -1,4 +1,4 @@
-package reviewme.review.service.module;
+package reviewme.review.service.validator;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/backend/src/test/java/reviewme/template/service/mapper/TemplateMapperTest.java
+++ b/backend/src/test/java/reviewme/template/service/mapper/TemplateMapperTest.java
@@ -1,4 +1,4 @@
-package reviewme.template.service;
+package reviewme.template.service.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -30,7 +30,6 @@ import reviewme.template.repository.TemplateRepository;
 import reviewme.template.service.dto.response.QuestionResponse;
 import reviewme.template.service.dto.response.SectionResponse;
 import reviewme.template.service.dto.response.TemplateResponse;
-import reviewme.template.service.module.TemplateMapper;
 
 @ServiceTest
 class TemplateMapperTest {


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #597 

---

### 🚀 어떤 기능을 구현했나요 ?
- `module` 패키지는 너무 광범위한 의미를 가져 폴더명만으로 뜻을 추론하기 어렵습니다. 보다 구체적인 네이밍을 통해 패키지를 분리합니다.

### 🔥 어떻게 해결했나요 ?
- 코드와 테스트를 옮겼습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 다 옮겼겠죠 ??