### PR TITLE
[FE] feat : 폰트 preload 적용

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -16,12 +16,15 @@
   </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!--font-->
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link rel="stylesheet" type="text/css"
-    href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" />
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin="anonymous">
+  
   <link rel="preload" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,100..900;1,100..900&display=swap"
   as="style" />
+  <link rel="preload" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.8/dist/web/variable/pretendardvariable-dynamic-subset.css" />
+  <link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.8/dist/web/variable/pretendardvariable-dynamic-subset.css" />
   <title>REVIEW ME</title>
 </head>
 

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -18,10 +18,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,100..900;1,100..900&display=swap"
-    rel="stylesheet" />
   <link rel="stylesheet" type="text/css"
     href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" />
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+  as="style" />
   <title>REVIEW ME</title>
 </head>
 

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -23,8 +23,7 @@
   
   <link rel="preload" href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,100..900;1,100..900&display=swap"
   as="style" />
-  <link rel="preload" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.8/dist/web/variable/pretendardvariable-dynamic-subset.css" />
-  <link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.8/dist/web/variable/pretendardvariable-dynamic-subset.css" />
+  <link rel="preload" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.8/dist/web/variable/pretendardvariable-dynamic-subset.css" onload="this.onload=null;this.rel='stylesheet'" />
   <title>REVIEW ME</title>
 </head>
 

--- a/frontend/src/pages/ReviewWritingPage/progressBar/hooks/useStepList/test.tsx
+++ b/frontend/src/pages/ReviewWritingPage/progressBar/hooks/useStepList/test.tsx
@@ -179,10 +179,10 @@ describe('프로그레스 바 테스트', () => {
 
           return newMap;
         });
-      });
 
-      //두번째 카드 이동 불가
-      expect(result.current.stepList[1].isMovingAvailable).toBeFalsy();
+        //두번째 카드 이동 불가
+        expect(result.current.stepList[1].isMovingAvailable).toBeFalsy();
+      });
     });
   });
 });

--- a/frontend/src/styles/globalStyles.ts
+++ b/frontend/src/styles/globalStyles.ts
@@ -10,7 +10,7 @@ const globalStyles = css`
   }
 
   body {
-    font-family: 'Pretendard', 'Noto Sans', sans-serif;
+    font-family: 'Pretendard Variable', 'Noto Sans', sans-serif;
     margin: 0;
     padding: 0;
     box-sizing: border-box;

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -63,7 +63,7 @@ module.exports = (env, argv) => {
         favicon: './src/favicons/favicon.ico',
       }),
       new CleanWebpackPlugin(),
-      !isProduction && new BundleAnalyzerPlugin(),
+      isProduction && new BundleAnalyzerPlugin(),
       new Dotenv({
         systemvars: true,
         path: './.env',


### PR DESCRIPTION


- resolves #602

---

### 🚀 어떤 기능을 구현했나요 ?
- 구글 폰트에 preload를 적용해, 로딩 속도를 개선했어요.
- pretendard 폰트는 가변 다이나믹 서브셋(Variable Dynamic Subsetting)로 변경해 폰트 파일 크기르 줄이고 preload를 함께 적용해 로딩 속도를 개선했어요. 

#### pretendard 폰트에  가변 다이나믹 서브셋을 적용한 이유?
**기존 코드**
```html
 <link rel="stylesheet" type="text/css"
    href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" />
```
기존에 했던 코드로는 rel에 preload를 사용하면 css만 받고, css 안의 pretendard 글꼴을 받지 못했어요. 
pretendard 를 preload하는 방법을 찾다가 가변 다이나믹 서브셋을 사용하면 preload되고 폰트 파일 용량도 작아지는 진다는 것을 알게되었어요. 적용해보니, 로드 속도와 용량 측면에서 개선이 있다는 것을 확인했어요. 

### 🔥 어떻게 해결했나요 ?
#### waterfull 비교
- 아주 미세하게 로딩 속도가 빨라 빨라짐
**개선 전**
![image](https://github.com/user-attachments/assets/9d8b3c78-31c9-462b-aed9-854297f2ff14)

**개선 후**
![image](https://github.com/user-attachments/assets/5b8812d9-67bd-4f44-abb9-74b543146425)

#### pretendard
**개선 전**
![스크린샷 2024-09-12 143639](https://github.com/user-attachments/assets/16845a36-3dab-4a15-81ad-3f0267ba5fa7)
**개선 후**
![스크린샷 2024-09-12 152548](https://github.com/user-attachments/assets/2cb1f016-7f82-446e-a377-7a96395e3ac7)

- 폰트 총 리소스 용량 감소 : 2.4 MB ->209 kB
- 가변 다이나믹 서브셋으로 변경되면서 폰트 파일이 여러개로 나뉘었고, 개별 파일 용량과 총 용량이 줄어들었어요.
- 리뷰미 서비스에서 지원하는 브라우저 내에서 모두 가변 다이나믹 서브셋을 지원해요. 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
#### 가변 다이나믹 서브셋 vs 다이나믹 서브셋
다이나믹 서브셋: 웹 페이지에서 사용되는 글리프만 포함된 폰트 파일을 동적으로 생성하여 용량을 줄이는 방식.
가변 다이나믹 서브셋: 다이나믹 서브셋과 가변 폰트를 결합하여, 하나의 폰트 파일에 다양한 스타일(굵기, 너비 등)을 포함하면서 필요한 글리프만 동적으로 불러오는 방식. 
