### PR TITLE
[FE] refactor: 페이지별로 JS 파일 분리

### DIFF
--- a/frontend/src/components/error/ErrorSuspenseContainer/index.tsx
+++ b/frontend/src/components/error/ErrorSuspenseContainer/index.tsx
@@ -1,11 +1,12 @@
 import { QueryErrorResetBoundary } from '@tanstack/react-query';
-import { Suspense } from 'react';
+import { lazy, Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
-import LoadingPage from '@/pages/LoadingPage';
 import { EssentialPropsWithChildren } from '@/types';
 
 import ErrorFallback from '../ErrorFallback';
+
+const LoadingPage = lazy(() => import('@/pages/LoadingPage'));
 
 const ErrorSuspenseContainer = ({ children }: EssentialPropsWithChildren) => {
   return (

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -79,10 +79,7 @@ const router = createBrowserRouter([
         path: 'user',
         element: <div>user</div>,
       },
-      {
-        path: `${ROUTE.reviewWriting}/:${ROUTE_PARAM.reviewRequestCode}`,
-        element: <ReviewWritingPage />,
-      },
+      { path: `${ROUTE.reviewWriting}/:${ROUTE_PARAM.reviewRequestCode}`, element: <ReviewWritingPage /> },
       { path: ROUTE.reviewWritingComplete, element: <ReviewWritingCompletePage /> },
       {
         path: ROUTE.reviewList,

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,21 +1,12 @@
 import { Global, ThemeProvider } from '@emotion/react';
 import * as Sentry from '@sentry/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import ReactDOM from 'react-dom/client';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { RecoilRoot } from 'recoil';
 
 import App from '@/App';
-import {
-  DetailedReviewPage,
-  ErrorPage,
-  HomePage,
-  ReviewListPage,
-  ReviewWritingCompletePage,
-  ReviewWritingPage,
-  ReviewZonePage,
-} from '@/pages';
 
 import { ErrorSuspenseContainer } from './components';
 import { API_ERROR_MESSAGE, ROUTE_PARAM } from './constants';
@@ -25,6 +16,16 @@ import theme from './styles/theme';
 
 const isProduction = process.env.NODE_ENV === 'production';
 const baseUrlPattern = new RegExp(`^${process.env.API_BASE_URL?.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')}`);
+
+const HomePage = lazy(() => import('@/pages/HomePage'));
+const DetailedReviewPage = lazy(() => import('@/pages/DetailedReviewPage'));
+const ErrorPage = lazy(() => import('@/pages/ErrorPage'));
+const ReviewListPage = lazy(() => import('@/pages/ReviewListPage'));
+const ReviewWritingCompletePage = lazy(() => import('@/pages/ReviewWritingCompletePage'));
+const ReviewWritingPage = lazy(() => import('@/pages/ReviewWritingPage'));
+const ReviewZonePage = lazy(() => import('@/pages/ReviewZonePage'));
+
+const LoadingPage = lazy(() => import('@/pages/LoadingPage'));
 
 Sentry.init({
   dsn: `${process.env.SENTRY_DSN}`,
@@ -63,7 +64,11 @@ const queryClient = new QueryClient({
 const router = createBrowserRouter([
   {
     path: ROUTE.home,
-    element: <App />,
+    element: (
+      <Suspense fallback={<LoadingPage />}>
+        <App />
+      </Suspense>
+    ),
     errorElement: <ErrorPage />,
     children: [
       {
@@ -74,7 +79,10 @@ const router = createBrowserRouter([
         path: 'user',
         element: <div>user</div>,
       },
-      { path: `${ROUTE.reviewWriting}/:${ROUTE_PARAM.reviewRequestCode}`, element: <ReviewWritingPage /> },
+      {
+        path: `${ROUTE.reviewWriting}/:${ROUTE_PARAM.reviewRequestCode}`,
+        element: <ReviewWritingPage />,
+      },
       { path: ROUTE.reviewWritingComplete, element: <ReviewWritingCompletePage /> },
       {
         path: ROUTE.reviewList,

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -12,7 +12,7 @@ module.exports = (env, argv) => {
     entry: './src/index.tsx',
     output: {
       path: path.join(__dirname, 'dist'),
-      filename: 'bundle.js',
+      filename: '[name].[contenthash].bundle.js',
       clean: true,
       publicPath: '/',
     },


### PR DESCRIPTION

- resolves #599 

---

### 🚀 어떤 기능을 구현했나요 ?
suspense와 lazy를 이용해서 페이지별로 JS 파일을 분리하고 동적으로 불러옵니다. 
 
### 🔥 어떻게 해결했나요 ?
처음엔 Outlet에 Suspense로 감싸는 방식으로 진행했지만 탑바에 있는 리뷰미 로고를 클릭 했을 때 홈으로 넘어가면 비동기 에러가 떴습니다. 
<img width="698" alt="스크린샷 2024-09-12 오후 4 53 06" src="https://github.com/user-attachments/assets/b7722a64-98df-44c4-9f75-e13ddfc9dce6">

홈 페이지는 Suspense로 감싸져 있는데 Suspense로 감싸져 있지 않은 탑바에서 홈 페이지로 이동할려고 하니 문제였습니다. 그래서 일단 Topbar, Footer 모두 Suspense로 감싸는 방식으로 진행했습니다. 

```tsx
const router = createBrowserRouter([
  {
    path: ROUTE.home,
    element: (
      <Suspense fallback={<LoadingPage />}>
        <App />
      </Suspense>
    ),
  // ....
]);
```

<img width="893" alt="스크린샷 2024-09-12 오후 5 05 43" src="https://github.com/user-attachments/assets/ef936d3b-61b0-4d8b-a5ea-778d7f6e6dac">

### Q. lazy를 걸게 된 계기는?
Suspense로 감싼 후, fallback에 컴포넌트(ex. LoadingPage) 를 넣었을 때, 동적으로 불러오지 못해서 <div> 태그로 단순하게 넣었더니 해결되었습니다. 그래서 단순 태그는 동기적으로 작동하지만 컴포넌트는 비동기적으로 불러오기 때문에 컴포넌트에 lazy를 추가했습니다.

### Q. Footer도 감싼 이유는?
Footer를 제외한 나머지 요소들을 Suspense로 감싸게 되면 첫 페이지에 들어갔을 때 Footer가 먼저 로드되어서 Layout Shift가 발생합니다.
<img width="375" alt="스크린샷 2024-09-12 오후 5 01 54" src="https://github.com/user-attachments/assets/d742a13e-b8c5-4ce5-9065-f4f04b93527b">


### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
- 