### PR TITLE
[FE] feat: 반응형 유틸리티 함수 구현

### DIFF
--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -15,11 +15,6 @@ export const componentHeight = {
   topbar: '7rem',
   breadCrumb: '43rem',
 };
-export const breakpoints: ThemeProperty<string> = {
-  desktop: '102.4rem',
-  tablet: '72rem',
-  mobile: '57.6rem',
-};
 // NOTE: 1rem = 10px
 export const fontSize: ThemeProperty<CSSProperties['fontSize']> = {
   small: '1.4rem',

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -15,6 +15,12 @@ export const componentHeight = {
   topbar: '7rem',
   breadCrumb: '43rem',
 };
+
+export const breakpoints: ThemeProperty<string> = {
+  desktop: '102.4rem',
+  tablet: '72rem',
+  mobile: '57.6rem',
+};
 // NOTE: 1rem = 10px
 export const fontSize: ThemeProperty<CSSProperties['fontSize']> = {
   small: '1.4rem',

--- a/frontend/src/utils/media.ts
+++ b/frontend/src/utils/media.ts
@@ -1,0 +1,33 @@
+import { css, SerializedStyles } from '@emotion/react';
+import { CSSObject } from '@emotion/styled';
+
+export type Breakpoints = 'mobile' | 'tablet' | 'desktop';
+
+export const breakpoints: Record<Breakpoints, string> = {
+  mobile: '@media (max-width: 768px)',
+  tablet: '@media (max-width: 1024px)',
+  desktop: '@media (min-width: 1025px)',
+};
+
+const media = Object.entries(breakpoints).reduce(
+  (acc, [key, value]) => {
+    acc[key as Breakpoints] = (
+      styles: CSSObject | TemplateStringsArray,
+      ...interpolations: Array<CSSObject | SerializedStyles>
+    ) => css`
+      ${value} {
+        ${css(styles, ...interpolations)}
+      }
+    `;
+    return acc;
+  },
+  {} as Record<
+    Breakpoints,
+    (
+      styles: CSSObject | TemplateStringsArray,
+      ...interpolations: Array<CSSObject | SerializedStyles>
+    ) => SerializedStyles
+  >,
+);
+
+export default media;

--- a/frontend/src/utils/media.ts
+++ b/frontend/src/utils/media.ts
@@ -1,12 +1,14 @@
 import { css, SerializedStyles } from '@emotion/react';
 import { CSSObject } from '@emotion/styled';
 
-export type Breakpoints = 'mobile' | 'tablet' | 'desktop';
+export type Breakpoints = 'xxSmall' | 'xSmall' | 'small' | 'medium' | 'large';
 
 export const breakpoints: Record<Breakpoints, string> = {
-  mobile: '@media (max-width: 768px)',
-  tablet: '@media (max-width: 1024px)',
-  desktop: '@media (min-width: 1025px)',
+  xxSmall: '@media (max-width: 320px)',
+  xSmall: '@media (max-width: 425px)',
+  small: '@media (max-width: 768px)',
+  medium: '@media (max-width: 1024px)',
+  large: '@media (min-width: 1025px)',
 };
 
 const media = Object.entries(breakpoints).reduce(


### PR DESCRIPTION
- resolves #607 

---

### 🚀 어떤 기능을 구현했나요 ?
- emotion 환경에서 media query를 간편하게 적용할 수 있는 반응형 유틸리티 함수를 구현했습니다.

### 🔥 어떻게 해결했나요 ?
- 각 breakpoint마다 스타일을 media query 내에 삽입하게 됩니다. 템플릿 리터럴을 사용했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
- media query 내부에서 사용하는 `rem`이나 `em` 단위는 브라우저의 기본 폰트 크기를 기준으로 하기 때문에, rem으로 breakpoint를 설정하게 되면 10을 곱한 값이 아닌 16을 곱한 값으로 변환되어 의도와 다르게 동작합니다.
- 따라서 media query에서는 px 단위를 사용하고, 이외의 스타일에서는 모두 rem을 사용하면 되겠습니다.

### 사용 예시
- 이슈에 올린 것과 동일합니다.

```tsx
import styled from '@emotion/styled';

import media from '@/utils/media';

export const HomePage = styled.div`
  display: flex;
  width: 100vw;
  min-height: inherit;

  ${media.desktop`
    background-color: red;
  `}

  ${media.tablet`
    background-color: blue;
  `}

  ${media.mobile`
    background-color: green;
  `}
`;
```

- 제대로 동작하는 것을 Home에서 확인했습니다.

### 의논하고 싶은 점
https://medium.com/@duchanjo/styled-components%EB%A1%9C-%EB%B0%98%EC%9D%91%ED%98%95-%EC%9E%91%EC%97%85%ED%95%98%EA%B8%B0-32a41d3966eb

위 블로그를 참고했는데, `mobile`, `tablet`, `desktop` 과 같이 이름 붙이는 것보다 `small`, `medium`, `large`와 같은 명시적인 이름을 사용하는 게 좋다는 부분이 있어요. 다들 어떻게 생각하는지, 어떤 네이밍을 사용할지 이야기 나눠보면 좋겠어요.