### PR TITLE
[FE] fix: media 유틸리티 함수 수정

### DIFF
--- a/frontend/src/components/layouts/Main/styles.ts
+++ b/frontend/src/components/layouts/Main/styles.ts
@@ -29,7 +29,7 @@ export const Contents = styled.div`
 
   box-sizing: border-box;
   width: 100%;
-  max-width: ${({ theme }) => theme.breakpoints.desktop};
+  max-width: ${({ theme }) => theme.breakpoint.medium}px;
   height: 100%;
   min-height: inherit;
 

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -16,10 +16,12 @@ export const componentHeight = {
   breadCrumb: '4.3rem',
 };
 
-export const breakpoints: ThemeProperty<string> = {
-  desktop: '102.4rem',
-  tablet: '72rem',
-  mobile: '57.6rem',
+export const breakpoint = {
+  xxSmall: 320,
+  xSmall: 425,
+  small: 768,
+  medium: 1024,
+  large: 1025,
 };
 // NOTE: 1rem = 10px
 export const fontSize: ThemeProperty<CSSProperties['fontSize']> = {
@@ -68,7 +70,7 @@ const theme: Theme = {
   fontWeight,
   zIndex,
   colors,
-  breakpoints,
+  breakpoint,
   sidebarWidth,
   borderRadius,
   formWidth,

--- a/frontend/src/types/emotion.ts
+++ b/frontend/src/types/emotion.ts
@@ -5,7 +5,7 @@ import {
   fontSize,
   fontWeight,
   zIndex,
-  breakpoints,
+  breakpoint,
   sidebarWidth,
   borderRadius,
   componentHeight,
@@ -16,7 +16,7 @@ export type Color = typeof colors;
 export type ZIndex = typeof zIndex;
 export type FontSize = typeof fontSize;
 export type FontWeight = typeof fontWeight;
-export type Breakpoints = typeof breakpoints;
+export type Breakpoint = typeof breakpoint;
 export type SidebarWidthStyle = typeof sidebarWidth;
 export type BorderRadius = typeof borderRadius;
 export type ComponentHeight = typeof componentHeight;
@@ -26,7 +26,7 @@ type ThemeType = {
   fontWeight: FontWeight;
   colors: Color;
   zIndex: ZIndex;
-  breakpoints: Breakpoints;
+  breakpoint: Breakpoint;
   sidebarWidth: SidebarWidthStyle;
   borderRadius: BorderRadius;
   formWidth: string;

--- a/frontend/src/utils/media.ts
+++ b/frontend/src/utils/media.ts
@@ -1,35 +1,17 @@
-import { css, SerializedStyles } from '@emotion/react';
-import { CSSObject } from '@emotion/styled';
+import theme from '@/styles/theme';
 
-export type Breakpoints = 'xxSmall' | 'xSmall' | 'small' | 'medium' | 'large';
+const { breakpoint } = theme;
 
-export const breakpoints: Record<Breakpoints, string> = {
-  xxSmall: '@media (max-width: 320px)',
-  xSmall: '@media (max-width: 425px)',
-  small: '@media (max-width: 768px)',
-  medium: '@media (max-width: 1024px)',
-  large: '@media (min-width: 1025px)',
-};
+export type Breakpoints = keyof typeof breakpoint;
+type Media = { [key in Breakpoints]: string };
 
-const media = Object.entries(breakpoints).reduce(
-  (acc, [key, value]) => {
-    acc[key as Breakpoints] = (
-      styles: CSSObject | TemplateStringsArray,
-      ...interpolations: Array<CSSObject | SerializedStyles>
-    ) => css`
-      ${value} {
-        ${css(styles, ...interpolations)}
-      }
-    `;
-    return acc;
-  },
-  {} as Record<
-    Breakpoints,
-    (
-      styles: CSSObject | TemplateStringsArray,
-      ...interpolations: Array<CSSObject | SerializedStyles>
-    ) => SerializedStyles
-  >,
-);
+const breakpointsKeyList = Object.keys(breakpoint) as Breakpoints[];
+
+const media = breakpointsKeyList.reduce((prev, key, index) => {
+  const mediaType = index === breakpointsKeyList.length - 1 ? 'min' : 'max';
+
+  prev[key] = `@media (${mediaType}-width: ${breakpoint[key]}px)`;
+  return prev;
+}, {} as Media);
 
 export default media;


### PR DESCRIPTION
- resolves #631 

---

### 🚀 어떤 기능을 구현했나요 ?
- 기존의 media 함수는 styled-components 방식에 특화되어 사용 가능했습니다.
- emotion에서는 styled-component 방식과 css helper 방식 모두를 사용 가능하기 때문에 호환성의 문제가 있었습니다.
- styled와 css의 argument 타입이 다르기 때문에 하나의 함수로 이 둘을 모두 처리하는 것은 불가능하고, 재사용 가능한 미디어 쿼리 조건문을 생성하는 함수로 수정했습니다.

### 🔥 어떻게 해결했나요 ?
```ts
large: "@media (min-width: 1025px)"
medium: "@media (max-width: 1024px)"
small: "@media (max-width: 768px)"
xSmall: "@media (max-width: 425px)"
xxSmall: "@media (max-width: 320px)"
```

위와 같은 문자열을 반환하도록 함수를 수정했습니다.
함수 수정 과정에서 `min-width`와 `max-width`를 모두 사용해 범위를 구체적으로 명시했지만, 일부 breakpoint를 사용하지 않을 경우 스타일 코드의 중복이 발생하기 때문에 min과 max 둘 중 하나만을 사용하도록 했습니다.

```ts
// styled에서 적용
${media.xxSmall} {
  background-color: ${({ theme }) => theme.colors.red};
}

// css에서 적용
${media.medium}{
  background-color: ${theme.colors.red};
}
```

위와 같이 media를 사용 가능합니다. styled, css에서 모두 기존처럼 theme 사용 가능합니다.
media를 사용할 때 대괄호 표기법과 점 표기법을 모두 사용 가능한데, 익숙한 방식인 점 표기법을 그대로 사용하면 될 것 같습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
- https://emotion.sh/docs/media-queries#reusable-media-queries
- 모두 동의한다면 이 PR을 먼저 머지한 뒤에, 각자 반응형 작업한 브랜치에 적용시키는 것이 좋을 듯합니다.