### PR TITLE
[FE] design : body에 단어 단위로 줄 바꿈 되는 속성 추가 

### DIFF
--- a/frontend/src/pages/HomePage/components/ReviewZoneURLModal/styles.ts
+++ b/frontend/src/pages/HomePage/components/ReviewZoneURLModal/styles.ts
@@ -30,6 +30,7 @@ export const DataName = styled.span`
 export const Data = styled.span`
   flex: 2;
   color: ${({ theme }) => theme.colors.gray};
+  word-break: break-all;
 `;
 
 export const CheckContainer = styled.div`

--- a/frontend/src/pages/ReviewWritingPage/form/components/CardForm/styles.ts
+++ b/frontend/src/pages/ReviewWritingPage/form/components/CardForm/styles.ts
@@ -11,8 +11,6 @@ export const CardForm = styled.form`
   min-width: ${({ theme }) => theme.formWidth};
   max-width: 90rem;
 
-  word-break: keep-all;
-
   ${media.medium} {
     width: 80vw;
     min-width: initial;

--- a/frontend/src/pages/ReviewWritingPage/modals/components/AnswerListRecheckModal/styles.ts
+++ b/frontend/src/pages/ReviewWritingPage/modals/components/AnswerListRecheckModal/styles.ts
@@ -11,8 +11,6 @@ export const AnswerListContainer = styled.div`
 
   width: ${({ theme }) => theme.formWidth};
 
-  word-break: keep-all;
-
   ${media.medium} {
     width: ${({ theme }) => {
       const { maxWidth, padding } = theme.contentModalSize;

--- a/frontend/src/pages/ReviewWritingPage/modals/components/NavigateBlockerModal/style.ts
+++ b/frontend/src/pages/ReviewWritingPage/modals/components/NavigateBlockerModal/style.ts
@@ -8,8 +8,6 @@ export const ConfirmModalMessage = styled.div`
   gap: 0.8rem;
   align-items: start;
 
-  word-break: keep-all;
-
   p {
     width: max-content;
     margin: 0;

--- a/frontend/src/pages/ReviewWritingPage/modals/components/StrengthUnCheckModal/style.ts
+++ b/frontend/src/pages/ReviewWritingPage/modals/components/StrengthUnCheckModal/style.ts
@@ -6,10 +6,7 @@ export const Contents = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1rem;
-
   width: max-content;
-
-  word-break: keep-all;
 
   ${media.xSmall} {
     min-width: ${({ theme }) => {

--- a/frontend/src/styles/globalStyles.ts
+++ b/frontend/src/styles/globalStyles.ts
@@ -19,6 +19,7 @@ const globalStyles = (theme: Theme) => css`
 
     font-family: 'Pretendard Variable', 'Noto Sans', sans-serif;
     font-size: 1.6rem;
+    word-break: keep-all;
   }
 
   /* 스크롤바 설정 */


### PR DESCRIPTION


- resolves #634

---

### 🚀 어떤 기능을 구현했나요 ?
- 문장이 컨테이너의 너비를 넓을 경우 줄바꿈을 통일되게 적용하기 위해 body에 ```word-break: keep-all``` 을 적용했어요.
- ```word-break: keep-all``` 을 사용한 이유는 ux상 글자 단위가 아닌 단어 단위의 줄 바꿈이 가독성에 좋으며 한글이 지원 언어이며 한글에서도 단어 단위의 줄 바꿈이 가능한 속성을 사용했어요. 


### 🔥 어떻게 해결했나요 ?
- 위와 동일 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 리뷰 작성 페이지에서 적용되는 것을 확인했지만 혹시 모르니 줄 바꿈이 필요한 곳에서도 적용이 되는 지 확인해주세요 

### 📚 참고 자료, 할 말
