### PR TITLE
[FE] refactor: scrollToTop을 유틸함수로 분리

### DIFF
--- a/frontend/src/components/common/TopButton/index.tsx
+++ b/frontend/src/components/common/TopButton/index.tsx
@@ -1,10 +1,11 @@
 import UpperArrowIcon from '@/assets/upperArrow.svg';
 import useTopButton from '@/hooks/useTopButton';
+import { scrollToTop } from '@/utils';
 
 import * as S from './style';
 
 const TopButton = () => {
-  const { showTopButton, scrollToTop } = useTopButton();
+  const { showTopButton } = useTopButton();
 
   if (!showTopButton) return null;
 

--- a/frontend/src/hooks/useTopButton.ts
+++ b/frontend/src/hooks/useTopButton.ts
@@ -2,12 +2,7 @@ import { useState, useEffect } from 'react';
 
 const TOP_BUTTON_DISPLAY_THRESHOLD = 500;
 
-interface UseTopButtonResult {
-  showTopButton: boolean;
-  scrollToTop: () => void;
-}
-
-const useTopButton = (): UseTopButtonResult => {
+const useTopButton = () => {
   const [showTopButton, setShowTopButton] = useState(false);
 
   const handleShowTopButton = () => {
@@ -26,14 +21,7 @@ const useTopButton = (): UseTopButtonResult => {
     };
   }, []);
 
-  const scrollToTop = () => {
-    window.scrollTo({
-      top: 0,
-      behavior: 'smooth',
-    });
-  };
-
-  return { showTopButton, scrollToTop };
+  return { showTopButton };
 };
 
 export default useTopButton;

--- a/frontend/src/pages/HomePage/components/URLGeneratorForm/index.tsx
+++ b/frontend/src/pages/HomePage/components/URLGeneratorForm/index.tsx
@@ -5,14 +5,13 @@ import { Button } from '@/components';
 import { ROUTE } from '@/constants/route';
 import { useModals } from '@/hooks';
 import { isValidPasswordInput, isValidReviewGroupDataInput } from '@/pages/HomePage/utils/validateInput';
-import { debounce } from '@/utils/debounce';
+import { debounce } from '@/utils';
 
 import usePostDataForReviewRequestCode from '../../hooks/usePostDataForReviewRequestCode';
 import { FormLayout, ReviewZoneURLModal } from '../index';
 import { ProjectNameField, RevieweeNameField, PasswordField } from '../Inputs';
 
 import * as S from './styles';
-
 
 const DEBOUNCE_TIME = 300;
 

--- a/frontend/src/pages/ReviewWritingPage/form/hooks/useCurrentCardIndex.ts
+++ b/frontend/src/pages/ReviewWritingPage/form/hooks/useCurrentCardIndex.ts
@@ -1,5 +1,7 @@
 import { useLayoutEffect, useState } from 'react';
 
+import { scrollToTop } from '@/utils';
+
 import { Direction } from '../../types';
 
 const STEP = {
@@ -19,7 +21,7 @@ const useCurrentCardIndex = () => {
   };
 
   useLayoutEffect(() => {
-    window.scrollTo({ top: 0 });
+    scrollToTop();
   }, [currentCardIndex]);
 
   return {

--- a/frontend/src/utils/debounce.ts
+++ b/frontend/src/utils/debounce.ts
@@ -21,7 +21,7 @@
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-export function debounce<T extends (...args: any[]) => void>(func: T, wait: number): T {
+const debounce = <T extends (...args: any[]) => void>(func: T, wait: number): T => {
   let timeoutId: ReturnType<typeof setTimeout> | null;
 
   return function (this: any, ...args: any[]) {
@@ -31,4 +31,6 @@ export function debounce<T extends (...args: any[]) => void>(func: T, wait: numb
       func.apply(this, args);
     }, wait);
   } as T;
-}
+};
+
+export default debounce;

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,2 +1,4 @@
 export * from './date';
 export * from './isExistentElement';
+export * from './scroll';
+export * from './media';

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,4 +1,4 @@
 export * from './date';
 export * from './isExistentElement';
-export * from './scroll';
+export { default as scrollToTop } from './scrollToTop';
 export * from './media';

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './date';
 export * from './isExistentElement';
 export { default as scrollToTop } from './scrollToTop';
+export { default as debounce } from './debounce';
 export * from './media';

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,5 +1,5 @@
 export * from './date';
-export * from './isExistentElement';
+export { default as isExistentElement } from './isExistentElement';
 export { default as scrollToTop } from './scrollToTop';
 export { default as debounce } from './debounce';
 export * from './media';

--- a/frontend/src/utils/isExistentElement.ts
+++ b/frontend/src/utils/isExistentElement.ts
@@ -1,6 +1,6 @@
 type NullableElement = Element | HTMLElement | null | undefined;
 
-export const isExistentElement = (element: NullableElement, elementName: string): boolean => {
+const isExistentElement = (element: NullableElement, elementName: string): boolean => {
   const isExistentElement = element !== null && element !== undefined;
   const isHTMLElementOrElement = element instanceof HTMLElement || element instanceof Element;
 
@@ -16,3 +16,5 @@ export const isExistentElement = (element: NullableElement, elementName: string)
 
   return true;
 };
+
+export default isExistentElement;

--- a/frontend/src/utils/scroll.ts
+++ b/frontend/src/utils/scroll.ts
@@ -1,0 +1,6 @@
+export const scrollToTop = () => {
+  window.scrollTo({
+    top: 0,
+    behavior: 'smooth',
+  });
+};

--- a/frontend/src/utils/scrollToTop.ts
+++ b/frontend/src/utils/scrollToTop.ts
@@ -1,6 +1,8 @@
-export const scrollToTop = () => {
+const scrollToTop = () => {
   window.scrollTo({
     top: 0,
     behavior: 'smooth',
   });
 };
+
+export default scrollToTop;


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #636

---

### 🚀 어떤 기능을 구현했나요 ?
-  스크롤을 top=0으로 변경하는 코드가 반복되어서, 이미 구현 된 scrollToTop을 유틸함수로 분리했어요.

### 🔥 어떻게 해결했나요 ?
- scrollToTop을 유틸함수로 분리하고, 해당 기능이 필요한 곳에서 srcollToTop을 적용하는 방법으로 리팩토링했어요.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 리팩토링을 진행하면서, utills/index.tsx에서 유틸 파일을 export해서 ```import {필요한_유틸함수}  from '@/utils'``` 로 import 할 수 있게 했어요.


### 📚 참고 자료, 할 말
