### PR TITLE
[FE] feat: Breadcrumb 컴포넌트에 반응형 추가

### DIFF
--- a/frontend/src/components/common/Breadcrumb/styles.ts
+++ b/frontend/src/components/common/Breadcrumb/styles.ts
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
+import media from '@/utils/media';
+
 export const BreadcrumbList = styled.ul`
   display: flex;
 
@@ -7,6 +9,11 @@ export const BreadcrumbList = styled.ul`
   padding: ${({ theme }) => theme.breadcrumbSize.paddingLeft} 0 0 2.5rem;
 
   font-size: 1.5rem;
+
+  ${media.xSmall} {
+    font-size: 1.4rem;
+  }
+
   list-style: none;
 `;
 
@@ -17,6 +24,10 @@ export const BreadcrumbItem = styled.li`
   &:not(:last-child)::after {
     content: '/';
     margin: 0 2rem;
+
+    ${media.xSmall} {
+      margin: 0 1rem;
+    }
   }
 
   &:last-child {


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #638 

---

### 🚀 어떤 기능을 구현했나요 ?
- 화면 크기가 작아질 때를 대비한 Breadcrumb 컴포넌트 반응형을 추가했습니다.

### 🔥 어떻게 해결했나요 ?
- 모바일 사이즈(xSmall)부터 경로 사이의 margin을 반으로 줄이고, 폰트 크기도 조금 줄였습니다.
  - 너비가 약 320px일 때의 Breadcrumb
  ![image](https://github.com/user-attachments/assets/b69029a2-71a1-4d66-88c6-cd5fd4502560)


### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
- 핫띵