### PR TITLE
[FE] fix: 리뷰 제출 확인 모달 border, border-radius 복원

### DIFF
--- a/frontend/src/pages/ReviewWritingPage/form/components/ReviewWritingCard/index.tsx
+++ b/frontend/src/pages/ReviewWritingPage/form/components/ReviewWritingCard/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { ReviewWritingCardLayout } from '@/pages/ReviewWritingPage/layout/components';
-import { ReviewWritingCardSection } from '@/types';
+import { EssentialPropsWithChildren, ReviewWritingCardSection } from '@/types';
 
 import QnABox from '../QnABox';
 
@@ -9,12 +9,16 @@ interface ReviewWritingCardProps {
   cardSection: ReviewWritingCardSection;
 }
 
-const ReviewWritingCard = ({ cardSection }: ReviewWritingCardProps) => {
+const ReviewWritingCard = ({
+  cardSection,
+  children: sliderController,
+}: EssentialPropsWithChildren<ReviewWritingCardProps>) => {
   return (
     <ReviewWritingCardLayout cardSection={cardSection}>
       {cardSection.questions.map((question) => (
         <QnABox key={question.questionId} question={question} />
       ))}
+      {sliderController}
     </ReviewWritingCardLayout>
   );
 };

--- a/frontend/src/pages/ReviewWritingPage/layout/components/ReviewWritingCardLayout/style.ts
+++ b/frontend/src/pages/ReviewWritingPage/layout/components/ReviewWritingCardLayout/style.ts
@@ -3,8 +3,12 @@ import styled from '@emotion/styled';
 import media from '@/utils/media';
 
 export const ReviewWritingCardLayout = styled.div`
+  overflow-x: hidden;
   display: flex;
   flex-direction: column;
+
+  border: 0.1rem solid ${({ theme }) => theme.colors.lightPurple};
+  border-radius: ${({ theme }) => theme.borderRadius.basic};
 `;
 
 export const Header = styled.div`

--- a/frontend/src/pages/ReviewWritingPage/slider/components/CardSlider/index.tsx
+++ b/frontend/src/pages/ReviewWritingPage/slider/components/CardSlider/index.tsx
@@ -41,35 +41,36 @@ const CardSlider = ({ currentCardIndex, handleCurrentCardIndex, handleOpenModal 
     <Carousel ref={wrapperRef} cardIndex={currentCardIndex} height={slideHeight}>
       {cardSectionList?.map((section, index) => (
         <S.Slide data-testid={section.sectionName} id={makeId(index)} key={section.sectionId}>
-          <ReviewWritingCard cardSection={section} />
-          <S.ButtonContainer>
-            {isAblePrevStep(index) && (
-              <CardSliderController.PrevButton
-                data-testid={`${section.sectionId}-prevButton`}
-                handleCurrentCardIndex={handleCurrentCardIndex}
-              />
-            )}
-            {isLastCard() ? (
-              <>
-                <CardSliderController.RecheckButton
-                  data-testid={`${section.sectionId}-recheckButton`}
-                  isAbleNextStep={isAbleNextStep}
-                  handleRecheckButtonClick={handleRecheckButtonClick}
+          <ReviewWritingCard cardSection={section}>
+            <S.ButtonContainer>
+              {isAblePrevStep(index) && (
+                <CardSliderController.PrevButton
+                  data-testid={`${section.sectionId}-prevButton`}
+                  handleCurrentCardIndex={handleCurrentCardIndex}
                 />
-                <CardSliderController.ConfirmModalOpenButton
-                  data-testid={`${section.sectionId}-submitButton`}
+              )}
+              {isLastCard() ? (
+                <>
+                  <CardSliderController.RecheckButton
+                    data-testid={`${section.sectionId}-recheckButton`}
+                    isAbleNextStep={isAbleNextStep}
+                    handleRecheckButtonClick={handleRecheckButtonClick}
+                  />
+                  <CardSliderController.ConfirmModalOpenButton
+                    data-testid={`${section.sectionId}-submitButton`}
+                    isAbleNextStep={isAbleNextStep}
+                    handleSubmitConfirmModalOpenButtonClick={handleSubmitConfirmModalOpenButtonClick}
+                  />
+                </>
+              ) : (
+                <CardSliderController.NextButton
+                  data-testid={`${section.sectionId}-nextButton`}
                   isAbleNextStep={isAbleNextStep}
-                  handleSubmitConfirmModalOpenButtonClick={handleSubmitConfirmModalOpenButtonClick}
+                  handleCurrentCardIndex={handleNextClick}
                 />
-              </>
-            ) : (
-              <CardSliderController.NextButton
-                data-testid={`${section.sectionId}-nextButton`}
-                isAbleNextStep={isAbleNextStep}
-                handleCurrentCardIndex={handleNextClick}
-              />
-            )}
-          </S.ButtonContainer>
+              )}
+            </S.ButtonContainer>
+          </ReviewWritingCard>
         </S.Slide>
       ))}
     </Carousel>

--- a/frontend/src/pages/ReviewWritingPage/slider/components/CardSlider/style.ts
+++ b/frontend/src/pages/ReviewWritingPage/slider/components/CardSlider/style.ts
@@ -4,12 +4,8 @@ import media from '@/utils/media';
 
 export const Slide = styled.div`
   flex: 0 0 100%;
-
   box-sizing: border-box;
   height: fit-content;
-
-  border: 0.1rem solid ${({ theme }) => theme.colors.lightPurple};
-  border-radius: ${({ theme }) => theme.borderRadius.basic};
 `;
 
 export const ButtonContainer = styled.div`


### PR DESCRIPTION

- resolves #646

---

### 🚀 어떤 기능을 구현했나요 ?
리뷰 작성폼과 리뷰 제출 확인 모달에서 border가 필요해요.
그러나 리뷰 제출 확인 모달과 달리, 리뷰 작성폼의 경우 Slider안에 ReviewCard, 슬라이더를 콘트롤하는 버튼들이 담겨 있고 이를 다 감싸서 border를  적용해야해요. 

border를 주는 ui용 컴포넌트를 만들려 했지만, 이미 ReviewWritingCardLayout이 존재해서 border를 위한 또 다른 컴포넌트를 사용해야한다는 번거로움이 있을 거라 생각했어요.

그래서 border를 ReviewWritingCardLayout 에서 적용하고, ReviewWritingCard가 슬라이더 컨트롤러 버튼들을 children을 받게 변경했어요. 

![스크린샷 2024-09-20 154911](https://github.com/user-attachments/assets/0a9e3a6e-69c1-4fbb-b2ea-776e29022a69)

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 짧은 시간에 버그를 잡은거라, 더 좋은 방안이 있다면 말씀해주세요! 

### 📚 참고 자료, 할 말
