### PR TITLE
[FE] fix : 리뷰 제출 페이지에서 리뷰 대상(프로젝트,리뷰이)사라지는 오류 해결

### DIFF
--- a/frontend/src/pages/ReviewWritingPage/form/components/CardForm/index.tsx
+++ b/frontend/src/pages/ReviewWritingPage/form/components/CardForm/index.tsx
@@ -64,16 +64,16 @@ const CardForm = () => {
   }, []);
 
   return (
-    <>
+    <S.CardFormContainer>
+      <S.RevieweeDescription>
+        <S.ProjectInfoContainer>
+          <S.ProjectName>{projectName}</S.ProjectName>
+          <p>
+            <S.RevieweeName>{revieweeName}</S.RevieweeName>을(를) 리뷰해주세요!
+          </p>
+        </S.ProjectInfoContainer>
+      </S.RevieweeDescription>
       <S.CardForm>
-        <S.RevieweeDescription>
-          <S.ProjectInfoContainer>
-            <S.ProjectName>{projectName}</S.ProjectName>
-            <p>
-              <S.RevieweeName>{revieweeName}</S.RevieweeName>을(를) 리뷰해주세요!
-            </p>
-          </S.ProjectInfoContainer>
-        </S.RevieweeDescription>
         <ProgressBar currentCardIndex={currentCardIndex} handleCurrentCardIndex={handleCurrentCardIndex} />
         <CardSlider
           currentCardIndex={currentCardIndex}
@@ -86,7 +86,7 @@ const CardForm = () => {
         closeModal={closeModal}
         handleNavigateConfirmButtonClick={handleNavigateConfirmButtonClick}
       />
-    </>
+    </S.CardFormContainer>
   );
 };
 

--- a/frontend/src/pages/ReviewWritingPage/form/components/CardForm/styles.ts
+++ b/frontend/src/pages/ReviewWritingPage/form/components/CardForm/styles.ts
@@ -2,10 +2,8 @@ import styled from '@emotion/styled';
 
 import media from '@/utils/media';
 
-export const CardForm = styled.form`
+export const CardFormContainer = styled.div`
   position: relative;
-
-  overflow: hidden;
 
   width: fit-content;
   min-width: ${({ theme }) => theme.formWidth};
@@ -20,9 +18,14 @@ export const CardForm = styled.form`
     margin-top: 2.4rem;
   }
 
-  ${media.xSmall} {
+  @media screen and (max-width: 500px) {
     width: 95vw;
   }
+`;
+export const CardForm = styled.form`
+  position: relative;
+  overflow: hidden;
+  width: 100%;
 `;
 
 export const RevieweeDescription = styled.div`
@@ -30,10 +33,6 @@ export const RevieweeDescription = styled.div`
   align-items: center;
   width: 100%;
   margin-bottom: 2rem;
-
-  ${media.small} {
-    padding-left: ${({ theme }) => theme.breadcrumbSize.paddingLeft};
-  }
 `;
 export const ProjectInfoContainer = styled.div`
   display: flex;

--- a/frontend/src/pages/ReviewWritingPage/layout/components/ReviewWritingCardLayout/style.ts
+++ b/frontend/src/pages/ReviewWritingPage/layout/components/ReviewWritingCardLayout/style.ts
@@ -7,6 +7,8 @@ export const ReviewWritingCardLayout = styled.div`
   display: flex;
   flex-direction: column;
 
+  margin: 0 0.1rem;
+
   border: 0.1rem solid ${({ theme }) => theme.colors.lightPurple};
   border-radius: ${({ theme }) => theme.borderRadius.basic};
 `;

--- a/frontend/src/pages/ReviewWritingPage/slider/components/CardSlider/style.ts
+++ b/frontend/src/pages/ReviewWritingPage/slider/components/CardSlider/style.ts
@@ -39,6 +39,8 @@ export const ButtonContainer = styled.div`
       max-width: calc(100% - (0.8rem * 2) / 3);
       padding-right: 0.4rem;
       padding-left: 0.4rem;
+
+      font-size: 1.2rem;
       text-align: center;
     }
   }

--- a/frontend/src/pages/ReviewWritingPage/slider/components/CardSlider/style.ts
+++ b/frontend/src/pages/ReviewWritingPage/slider/components/CardSlider/style.ts
@@ -12,9 +12,7 @@ export const ButtonContainer = styled.div`
   display: flex;
   gap: 2rem;
   justify-content: flex-end;
-
-  padding: 0 2rem;
-  padding-bottom: 2rem;
+  padding: 2rem 0 0 2rem;
   button {
     width: auto;
     min-width: 8rem;
@@ -24,6 +22,9 @@ export const ButtonContainer = styled.div`
   ${media.xSmall} {
     gap: 1.5rem;
     button {
+      max-width: calc(100% - (0.8rem * 2) / 3);
+      padding-right: 0.8rem;
+      padding-left: 0.8rem;
       font-size: ${({ theme }) => theme.fontSize.small};
     }
   }
@@ -32,10 +33,8 @@ export const ButtonContainer = styled.div`
     gap: 0.8rem;
 
     button {
-      max-width: calc(100% - (0.8rem * 2) / 3);
       padding-right: 0.4rem;
       padding-left: 0.4rem;
-
       font-size: 1.2rem;
       text-align: center;
     }

--- a/frontend/src/pages/ReviewWritingPage/slider/components/CardSlider/style.ts
+++ b/frontend/src/pages/ReviewWritingPage/slider/components/CardSlider/style.ts
@@ -5,6 +5,7 @@ import media from '@/utils/media';
 export const Slide = styled.div`
   flex: 0 0 100%;
   box-sizing: border-box;
+  width: 100%;
   height: fit-content;
 `;
 


### PR DESCRIPTION

- resolves #650

---

### 🚀 어떤 기능을 구현했나요 ?
- 리뷰 제출 페이지에서 cardForm의 overflow로 인해,리뷰 대상(프로젝트,리뷰이)사라지는 오류를 해결했어요.
- 추가로 모바일에서 반응형을 테스트하다가 오류 난 부분들도 수정했어요
  -  425px 이하 뷰포트에서 마지막 카드에서의 제출 전 확이 버튼의 글자가 일렬로 정렬되게 버튼 관련 속성을 변경했어요
  - 리뷰 작성폼에서 카드 index가 0을 넘어갈때, 카드 border가 사라지는 오류가 있었어요.  border 너비만큼 margin 양옆에 줘서 해결했어요. (오류 원인이 아마 캐러셀의 이동폭이 카드 너비와 완전히 일치하지 않아서, 소수점 차이들이 쌓여서 overflow에 의해 border가 사라진 것을 아닐까 추측하고 있어요)

### 🔥 어떻게 해결했나요 ?
- CardFormWrapper 스타일을 만들어서 카드 폼에 대한 width를 여기서 지정하도록 하고 리뷰 대상에 대한 정보를 CardForm 스타일 컴포넌트의 외부로 빼서 CardForm overflow로 인한 스타일 오류를 수정했어요. 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 개발 시 오류 없음을 확인했지만 사파리, 구글 크롬에서 오류가 없는지 확인해주세요.

### 📚 참고 자료, 할 말
