### PR TITLE
[FE] feat: 모바일 환경에서 홈 페이지 캐러셀 드래그 기능 구현

### DIFF
--- a/frontend/src/assets/nextArrow.svg
+++ b/frontend/src/assets/nextArrow.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12.6 12L8 7.4L9.4 6L15.4 12L9.4 18L8 16.6L12.6 12Z" fill="#1D1B20"/>
+</svg>

--- a/frontend/src/assets/prevArrow.svg
+++ b/frontend/src/assets/prevArrow.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14 18L8 12L14 6L15.4 7.4L10.8 12L15.4 16.6L14 18Z" fill="#1D1B20"/>
+</svg>

--- a/frontend/src/pages/HomePage/components/InfinityCarousel/index.tsx
+++ b/frontend/src/pages/HomePage/components/InfinityCarousel/index.tsx
@@ -53,7 +53,7 @@ const InfinityCarousel = ({ slideList }: InfinityCarouselProps) => {
   const handleSlideAnimation = ({ slide, withTransition, index, deltaX = 0 }: HandleSlideAnimationParams) => {
     const slideWidth = slide.clientWidth;
     slide.style.transition = withTransition ? `transform ${TRANSITION_DURATION}ms ease-in-out` : 'none';
-    slide.style.transform = `translate3d(${-slideWidth * index + deltaX}px, 0, 0)`;
+    slide.style.transform = `translate3d(${(-slideWidth * index + deltaX) * 0.1}rem, 0, 0)`;
   };
 
   const nextSlide = () => {

--- a/frontend/src/pages/HomePage/components/InfinityCarousel/index.tsx
+++ b/frontend/src/pages/HomePage/components/InfinityCarousel/index.tsx
@@ -1,5 +1,7 @@
 import { useRef, useState, useEffect } from 'react';
 
+import nextArrowIcon from '@/assets/nextArrow.svg';
+import prevArrowIcon from '@/assets/prevArrow.svg';
 import { breakpoints } from '@/styles/theme';
 
 import * as S from './styles';
@@ -161,8 +163,12 @@ const InfinityCarousel = ({ slideList }: InfinityCarouselProps) => {
           />
         ))}
       </S.IndicatorWrapper>
-      <S.PrevButton onClick={prevSlide}>{'<'}</S.PrevButton>
-      <S.NextButton onClick={nextSlide}>{'>'}</S.NextButton>
+      <S.PrevButton onClick={prevSlide}>
+        <img src={prevArrowIcon} alt="이전 화살표" />
+      </S.PrevButton>
+      <S.NextButton onClick={nextSlide}>
+        <img src={nextArrowIcon} alt="다음 화살표" />
+      </S.NextButton>
     </S.InfinityCarouselContainer>
   );
 };

--- a/frontend/src/pages/HomePage/components/InfinityCarousel/index.tsx
+++ b/frontend/src/pages/HomePage/components/InfinityCarousel/index.tsx
@@ -99,14 +99,14 @@ const InfinityCarousel = ({ slideList }: InfinityCarouselProps) => {
     return () => clearTimeout(timeout);
   }, [currentSlideIndex, clicked]);
 
-  const handleTouchStart = (e: React.MouseEvent | React.TouchEvent) => {
+  const handleTouchStart = (e: React.TouchEvent) => {
     if (window.innerWidth <= breakpoints.xSmall) {
       setIsDragging(true);
       setStartX(getClientX(e));
     }
   };
 
-  const handleTouchMove = (e: React.MouseEvent | React.TouchEvent) => {
+  const handleTouchMove = (e: React.TouchEvent) => {
     if (!isDragging || !slideRef.current) return;
     const currentX = getClientX(e);
     const dragDistance = currentX - startX;
@@ -136,7 +136,7 @@ const InfinityCarousel = ({ slideList }: InfinityCarouselProps) => {
     setDeltaX(0);
   };
 
-  const getClientX = (e: React.MouseEvent | React.TouchEvent) => ('touches' in e ? e.touches[0].clientX : e.clientX);
+  const getClientX = (e: React.TouchEvent) => e.touches[0].clientX;
 
   return (
     <S.InfinityCarouselContainer>

--- a/frontend/src/pages/HomePage/components/InfinityCarousel/index.tsx
+++ b/frontend/src/pages/HomePage/components/InfinityCarousel/index.tsx
@@ -166,10 +166,10 @@ const InfinityCarousel = ({ slideList }: InfinityCarouselProps) => {
         ))}
       </S.IndicatorWrapper>
       <S.PrevButton onClick={prevSlide}>
-        <img src={prevArrowIcon} alt="이전 화살표" />
+        <img src={prevArrowIcon} alt="캐러셀 이전 화살표" />
       </S.PrevButton>
       <S.NextButton onClick={nextSlide}>
-        <img src={nextArrowIcon} alt="다음 화살표" />
+        <img src={nextArrowIcon} alt="캐러셀 다음 화살표" />
       </S.NextButton>
     </S.InfinityCarouselContainer>
   );

--- a/frontend/src/pages/HomePage/components/InfinityCarousel/index.tsx
+++ b/frontend/src/pages/HomePage/components/InfinityCarousel/index.tsx
@@ -28,6 +28,7 @@ const AUTO_SLIDE_INTERVAL = 6000; // 자동 슬라이드 시간
 const DRAG_THRESHOLD = 0.3; // 슬라이드 넘기기 위한 최소 드래그 거리 비율 (슬라이드 너비의 30%)
 
 const InfinityCarousel = ({ slideList }: InfinityCarouselProps) => {
+  // 마지막 슬라이드를 복제해서 slideList의 맨 앞에 추가하므로 처음에 보여져야 하는 슬라이드는 1번 인덱스
   const [currentSlideIndex, setCurrentSlideIndex] = useState(REAL_START_INDEX);
   const [isTransitioning, setIsTransitioning] = useState(false);
   const [clicked, setClicked] = useState(false);
@@ -38,6 +39,7 @@ const InfinityCarousel = ({ slideList }: InfinityCarouselProps) => {
   const slideRef = useRef<HTMLDivElement>(null);
 
   const slideLength = slideList.length;
+  // 첫 슬라이드와 마지막 슬라이드의 복제본을 각각 맨 뒤, 맨 처음에 추가
   const clonedSlideList = [slideList[slideLength - 1], ...slideList, slideList[0]];
 
   const scrollToSlide = (index: number, withTransition = true) => {
@@ -73,14 +75,14 @@ const InfinityCarousel = ({ slideList }: InfinityCarouselProps) => {
     scrollToSlide(REAL_START_INDEX, false);
   }, []);
 
-  // 슬라이드 경계 처리
+  // 맨 처음/맨 끝 슬라이드 전환용 useEffect
   useEffect(() => {
     if (isTransitioning) {
       if (currentSlideIndex === slideLength + 1) {
         setTimeout(() => {
           setIsTransitioning(false);
           scrollToSlide(REAL_START_INDEX, false);
-        }, TRANSITION_DURATION);
+        }, TRANSITION_DURATION); // 애니메이션 트랜지션 시간과 동일하게 설정 (0.5초)
       } else if (currentSlideIndex === 0) {
         setTimeout(() => {
           setIsTransitioning(false);

--- a/frontend/src/pages/HomePage/components/InfinityCarousel/index.tsx
+++ b/frontend/src/pages/HomePage/components/InfinityCarousel/index.tsx
@@ -1,5 +1,7 @@
 import { useRef, useState, useEffect } from 'react';
 
+import { breakpoints } from '@/styles/theme';
+
 import * as S from './styles';
 
 export interface Slide {
@@ -11,40 +13,43 @@ interface InfinityCarouselProps {
   slideList: Slide[];
 }
 
-const REAL_START_INDEX = 1;
+interface HandleSlideAnimationParams {
+  slide: HTMLDivElement;
+  withTransition: boolean;
+  index: number;
+  deltaX?: number;
+}
 
-const TRANSITION_DURATION = 500; // NOTE: 트랜지션(애니메이션) 시간
-const AUTO_SLIDE_INTERVAL = 6000; // NOTE: 자동 슬라이드 시간
+const REAL_START_INDEX = 1;
+const TRANSITION_DURATION = 500; // 트랜지션 시간
+const AUTO_SLIDE_INTERVAL = 6000; // 자동 슬라이드 시간
+const DRAG_THRESHOLD = 0.3; // 슬라이드 넘기기 위한 최소 드래그 거리 비율 (슬라이드 너비의 30%)
 
 const InfinityCarousel = ({ slideList }: InfinityCarouselProps) => {
-  // NOTE: 마지막 슬라이드를 복제해서 slideList의 맨 앞에 추가하므로 처음에 보여져야 하는 슬라이드는 1번 인덱스
   const [currentSlideIndex, setCurrentSlideIndex] = useState(REAL_START_INDEX);
   const [isTransitioning, setIsTransitioning] = useState(false);
   const [clicked, setClicked] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+  const [startX, setStartX] = useState(0); // 드래그를 시작한 시점의 X 좌표
+  const [deltaX, setDeltaX] = useState(0); // 현재 드래그 중인 위치와 시작 위치 사이의 차이
+
   const slideRef = useRef<HTMLDivElement>(null);
 
   const slideLength = slideList.length;
-  // NOTE: 첫 슬라이드와 마지막 슬라이드의 복제본을 각각 맨 뒤, 맨 처음에 추가
   const clonedSlideList = [slideList[slideLength - 1], ...slideList, slideList[0]];
 
   const scrollToSlide = (index: number, withTransition = true) => {
     if (slideRef.current) {
       setIsTransitioning(true);
-      window.requestAnimationFrame(() => handleSlideAnimation({ slide: slideRef.current!, withTransition, index }));
+      handleSlideAnimation({ slide: slideRef.current, withTransition, index });
     }
     setCurrentSlideIndex(index);
   };
 
-  interface HandleSlideAnimationParams {
-    slide: HTMLDivElement;
-    withTransition: boolean;
-    index: number;
-  }
-
-  const handleSlideAnimation = ({ slide, withTransition, index }: HandleSlideAnimationParams) => {
+  const handleSlideAnimation = ({ slide, withTransition, index, deltaX = 0 }: HandleSlideAnimationParams) => {
     const slideWidth = slide.clientWidth;
     slide.style.transition = withTransition ? `transform ${TRANSITION_DURATION}ms ease-in-out` : 'none';
-    slide.style.transform = `translate3d(-${slideWidth * index * 0.1}rem, 0, 0)`;
+    slide.style.transform = `translate3d(${-slideWidth * index + deltaX}px, 0, 0)`;
   };
 
   const nextSlide = () => {
@@ -61,22 +66,20 @@ const InfinityCarousel = ({ slideList }: InfinityCarouselProps) => {
     setTimeout(() => setClicked(false), TRANSITION_DURATION + 100);
   };
 
-  // NOTE: // 초기 슬라이드 위치 설정
+  // 초기 슬라이드 위치 설정
   useEffect(() => {
     scrollToSlide(REAL_START_INDEX, false);
   }, []);
 
-  // NOTE: 맨 처음/맨 끝 슬라이드 전환용 useEffect
+  // 슬라이드 경계 처리
   useEffect(() => {
     if (isTransitioning) {
       if (currentSlideIndex === slideLength + 1) {
-        // 마지막 슬라이드 처리
         setTimeout(() => {
           setIsTransitioning(false);
           scrollToSlide(REAL_START_INDEX, false);
-        }, TRANSITION_DURATION); // NOTE: 애니메이션 트랜지션 시간과 동일하게 설정 (0.5초)
+        }, TRANSITION_DURATION);
       } else if (currentSlideIndex === 0) {
-        // 첫 번째 슬라이드 처리
         setTimeout(() => {
           setIsTransitioning(false);
           scrollToSlide(slideLength, false);
@@ -85,7 +88,7 @@ const InfinityCarousel = ({ slideList }: InfinityCarouselProps) => {
     }
   }, [currentSlideIndex, slideLength, isTransitioning]);
 
-  // NOTE: 슬라이드 자동 이동용
+  // 자동 슬라이드 이동
   useEffect(() => {
     const timeout = setTimeout(() => {
       nextSlide();
@@ -94,9 +97,53 @@ const InfinityCarousel = ({ slideList }: InfinityCarouselProps) => {
     return () => clearTimeout(timeout);
   }, [currentSlideIndex, clicked]);
 
+  const handleTouchStart = (e: React.MouseEvent | React.TouchEvent) => {
+    if (window.innerWidth <= breakpoints.xSmall) {
+      setIsDragging(true);
+      setStartX(getClientX(e));
+    }
+  };
+
+  const handleTouchMove = (e: React.MouseEvent | React.TouchEvent) => {
+    if (!isDragging || !slideRef.current) return;
+    const currentX = getClientX(e);
+    const dragDistance = currentX - startX;
+
+    setDeltaX(dragDistance);
+    handleSlideAnimation({
+      slide: slideRef.current,
+      withTransition: false,
+      index: currentSlideIndex,
+      deltaX: dragDistance,
+    });
+  };
+
+  const handleTouchUp = () => {
+    setIsDragging(false);
+
+    if (!slideRef.current) return;
+    const slideWidth = slideRef.current.clientWidth;
+
+    // 드래그된 거리가 슬라이드 너비의 30%를 넘으면 슬라이드 넘김
+    if (Math.abs(deltaX) > slideWidth * DRAG_THRESHOLD) {
+      deltaX > 0 ? prevSlide() : nextSlide();
+    } else {
+      scrollToSlide(currentSlideIndex);
+    }
+
+    setDeltaX(0);
+  };
+
+  const getClientX = (e: React.MouseEvent | React.TouchEvent) => ('touches' in e ? e.touches[0].clientX : e.clientX);
+
   return (
     <S.InfinityCarouselContainer>
-      <S.SlideList ref={slideRef}>
+      <S.SlideList
+        ref={slideRef}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchUp}
+      >
         {clonedSlideList.map((slide, index) => (
           <S.SlideItem key={index}>
             <S.SlideContent>


### PR DESCRIPTION

- resolves #643 

---

### 🚀 어떤 기능을 구현했나요 ?
- 모바일 환경(max-width: 425px)에서 홈 페이지 캐러셀을 드래그하면 이전 및 다음 슬라이드로 넘어가는 기능을 구현했습니다.
- 기존의 이전 및 다음 버튼은 키보드에 내장된 `<, >` 를 활용했으나, 화살표 이미지를 추가해서 적용했습니다.

### 🔥 어떻게 해결했나요 ?

캐러셀 드래그 시, 현재 슬라이드 너비의 30%가 넘어가면 다음 슬라이드로 넘어가게 구현했습니다. 드래그 시작, 드래그 중, 드래그 종료 3단계로 나눴습니다.

#### 1. 드래그 시작
- 드래그 시작 위치의 x 좌표를 startX에 저장합니다.
```ts
  const handleTouchStart = (e: React.TouchEvent) => {
    if (window.innerWidth <= breakpoints.xSmall) {
      setIsDragging(true);
      setStartX(getClientX(e));
    }
  };
```

#### 2. 드래그 중
- 현재 x 좌표(currentX)를 계산해서 deltaX에 드래그 거리(시작 지점과 현재 지점의 차이)를 저장합니다.
```ts
  const handleTouchMove = (e: React.TouchEvent) => {
    if (!isDragging || !slideRef.current) return;
    const currentX = getClientX(e);
    const dragDistance = currentX - startX;

    setDeltaX(dragDistance);
    handleSlideAnimation({
      slide: slideRef.current,
      withTransition: false,
      index: currentSlideIndex,
      deltaX: dragDistance,
    });
  };
```


#### 3. 드래그 종료
- deltaX(드래그를 시작한 지점의 x 좌표와 드래그를 끝낸 지점. 즉, 터치를 뗀 지점의 x 좌표 간의 차이를 계산한 값)가 양수이면 이전 슬라이드로 이동하고, 음수이면 다음 슬라이드로 넘어갑니다.

```ts
  const handleTouchUp = () => {
    setIsDragging(false);

    if (!slideRef.current) return;
    const slideWidth = slideRef.current.clientWidth;

    // 드래그된 거리가 슬라이드 너비의 30%를 넘으면 슬라이드 넘김
    if (Math.abs(deltaX) > slideWidth * DRAG_THRESHOLD) {
      deltaX > 0 ? prevSlide() : nextSlide();
    } else {
      scrollToSlide(currentSlideIndex);
    }

    setDeltaX(0);
  };
```

https://github.com/user-attachments/assets/faf5e65f-5e95-4e28-b487-af80d942a42f



캐러셀의 이전 및 다음 버튼 `<, >` 을 기존에는 그냥 키보드에 있는 걸 사용했는데 이미지를 활용하는 것으로 변경했습니다. 
- 이전 화살표(prevArrow), 다음 화살표(nextArrow) 이미지를 추가했습니다. ⇒ 여기서 프로그레스 바에서 사용 중인 `NavigateNextIcon`을 재사용하지 않은 이유는 이미 연한 그레이 색상이 적용되어 있어서, 캐러셀 화살표는 검정색이니까 동일한 디자인이더라도 색상이 달라서 별도의 이미지를 추가했습니다




### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- ~~모바일 환경에서 제대로 드래그가 되는지..?~~
모바일에서 localhost 접속하는 방법을 인터넷에 검색해서 접속해 보니까 다행히도 드래그가 잘 되네요..

### 📚 참고 자료, 할 말

올리가 삼성 인터넷에서 홈 페이지 리뷰 폼이 꽉 차보이는 이슈가 있다고 해서 갤럭시 노트 20 뷰포트 크기를 찾아보니 아래와 같다고 합니다. 개발자 도구 모바일 모드에서 보면 리뷰 폼이 꽉 차 보이지 않는데 왜 삼성 인터넷에서는 꽉 차게 보이는 걸까요...🥹
```
Samsung Galaxy Note 20
width: 412 / height: 915

출처 : https://mu08.tistory.com/33
```

### 제안
홈 페이지 AlertModal에서 체크 선택을 하면 버튼 타입이 secondary로 변경되는데 primary로 변경하는건 어떨까요? 체크 선택했다는 건 링크를 미리 다른 곳에 복사해 놓았다는 의미니까 버튼 클릭을 유도하는 색상인 primary 도 괜찮다고 생각합니다…🥹
<img width="742" alt="스크린샷 2024-09-21 오후 7 14 44" src="https://github.com/user-attachments/assets/020fddf5-69d4-45ab-9cc5-6d0ce136f898">


#### 참고 자료
- https://duklook.tistory.com/576
- [https://velog.io/@bepyan/Drag-Carousel-뽀개기](https://velog.io/@bepyan/Drag-Carousel-%EB%BD%80%EA%B0%9C%EA%B8%B0)


+홈 페이지 코드가 엄청 길어져서... 추후에 리팩하겠습니다👍
