### PR TITLE
[FE] refactor: Footer 반응형 경계값을 small(태블릿 세로 모드)로 수정

### DIFF
--- a/frontend/src/components/layouts/Footer/style.ts
+++ b/frontend/src/components/layouts/Footer/style.ts
@@ -21,7 +21,7 @@ export const Footer = styled.footer`
 
   background-color: ${({ theme }) => theme.colors.white};
 
-  ${media.small} {
+  ${media.xSmall} {
     font-size: 1.2rem;
 
     flex-direction: column;

--- a/frontend/src/components/layouts/Footer/style.ts
+++ b/frontend/src/components/layouts/Footer/style.ts
@@ -22,10 +22,9 @@ export const Footer = styled.footer`
   background-color: ${({ theme }) => theme.colors.white};
 
   ${media.xSmall} {
-    font-size: 1.2rem;
-
     flex-direction: column;
     gap: 0.2rem;
+    font-size: 1.2rem;
   }
 `;
 

--- a/frontend/src/components/layouts/Footer/style.ts
+++ b/frontend/src/components/layouts/Footer/style.ts
@@ -21,7 +21,7 @@ export const Footer = styled.footer`
 
   background-color: ${({ theme }) => theme.colors.white};
 
-  ${media.medium} {
+  ${media.small} {
     font-size: 1.2rem;
 
     flex-direction: column;


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #659 

---

### 🚀 어떤 기능을 구현했나요 ?
- 화면 너비가 작을 때 Footer가 겹치는/너무 가까워지는 문제가 있어 세로 2줄로 반응형을 추가했는데, 너비가 넉넉해진 상황(태블릿 가로 모드)에서도 2줄을 유지할 필요가 없어 수정했습니다.

### 🔥 어떻게 해결했나요 ?
- 간단하게 미디어쿼리를 수정했습니다. 
- ~~(`flex-direction` 변경 경계값 1024px -> 768px)~~
- (`flex-direction` 변경 경계값 1024px -> 425px)

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- ~~사실 저는 너비가 어느정도 있을 때는 디자인적으로 Footer 1줄-2줄의 큰 차이를 느끼지 못했습니다만, 단순히 시각적인 걸 넘어서 "태블릿 가로 모드 사이즈부터는 여유로운 너비로 본다"는 프론트 팀의 암묵적 합의를 생각했을 때 굳이 넉넉한 너비에서 너비가 작을 때를 고려한 `column`정렬을 적용할 필요가 없다고 생각해서 피드백 반영했습니다!~~
- 디자인 관점에서 최대한 한 줄 Footer를 적용하는 게 낫다는 의견이 많아 너비가 절대적으로 작은 모바일 환경(xSmall)부터 Footer 2줄을 적용했습니다.

### 📚 참고 자료, 할 말
- 반응형 할 때 대충 보이는 것만 생각하지 말고 너비의 의미도 의식하면서 작업해야겠다