### PR TITLE
[FE] design: 홈페이지 AlertModal 내 체크박스 선택 시, 버튼 색상을 primary 색상으로 변경

### DIFF
--- a/frontend/src/pages/HomePage/components/ReviewZoneURLModal/index.tsx
+++ b/frontend/src/pages/HomePage/components/ReviewZoneURLModal/index.tsx
@@ -24,7 +24,7 @@ const ReviewZoneURLModal = ({ reviewZoneURL, closeModal }: ReviewZoneURLModalPro
 
   return (
     <AlertModal
-      closeButton={{ content: '닫기', type: isChecked ? 'secondary' : 'disabled', handleClick: handleCloseButtonClick }}
+      closeButton={{ content: '닫기', type: isChecked ? 'primary' : 'disabled', handleClick: handleCloseButtonClick }}
       handleClose={null}
       isClosableOnBackground={false}
     >


### PR DESCRIPTION
- resolves #677 

---

### 🚀 어떤 기능을 구현했나요 ?
- 홈페이지 AlertModal에서 체크박스 선택 시, 버튼 색상을 primary 색상으로 변경했습니다.

### 🔥 어떻게 해결했나요 ?
- 홈페이지 AlertModal에서 체크박스를 선택했다는 건 이미 다른 곳에 링크를 저장해 두었다는 의미이므로, 버튼 클릭을 유도하는 primary 색상으로 변경했습니다.
<img width="348" alt="스크린샷 2024-09-24 오전 10 18 55" src="https://github.com/user-attachments/assets/e4148135-2a69-4078-a3cf-8d72d5145f68">

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
