### PR TITLE
[BE] infra: 운영 환경 DB를 RDS로 마이그레이션 및 Replication 적용

### DIFF
--- a/backend/src/main/java/reviewme/config/DataSourceType.java
+++ b/backend/src/main/java/reviewme/config/DataSourceType.java
@@ -1,0 +1,7 @@
+package reviewme.config;
+
+public enum DataSourceType {
+    READ,
+    WRITE,
+    ;
+}

--- a/backend/src/main/java/reviewme/config/ReplicationDatasourceConfig.java
+++ b/backend/src/main/java/reviewme/config/ReplicationDatasourceConfig.java
@@ -16,6 +16,7 @@ import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
 @Profile("prod")
 @Configuration
 public class ReplicationDatasourceConfig {
+
     @Bean(name = "writeDataSource")
     @ConfigurationProperties(prefix = "spring.datasource.write.hikari")
     public DataSource writeDataSource() {

--- a/backend/src/main/java/reviewme/config/ReplicationDatasourceConfig.java
+++ b/backend/src/main/java/reviewme/config/ReplicationDatasourceConfig.java
@@ -1,0 +1,49 @@
+package reviewme.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+
+@Configuration
+public class ReplicationDatasourceConfig {
+    @Bean(name = "writeDataSource")
+    @ConfigurationProperties(prefix = "spring.datasource.write.hikari")
+    public DataSource writeDataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    @Bean(name = "readDataSource")
+    @ConfigurationProperties(prefix = "spring.datasource.read.hikari")
+    public DataSource readDataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    @Bean
+    DataSource routingDataSource(
+            @Qualifier("writeDataSource") DataSource writeDataSource,
+            @Qualifier("readDataSource") DataSource readDataSource) {
+        AbstractRoutingDataSource routingDataSource = new ReplicationRoutingDataSource();
+        Map<Object, Object> dataSourceMap = new HashMap<>();
+        dataSourceMap.put("write", writeDataSource);
+        dataSourceMap.put("read", readDataSource);
+
+        routingDataSource.setTargetDataSources(dataSourceMap);
+        routingDataSource.setDefaultTargetDataSource(writeDataSource);
+
+        return routingDataSource;
+    }
+
+    @Primary
+    @Bean
+    public DataSource dataSource(@Qualifier("routingDataSource") DataSource routingDataSource) {
+        return new LazyConnectionDataSourceProxy(routingDataSource);
+    }
+}

--- a/backend/src/main/java/reviewme/config/ReplicationDatasourceConfig.java
+++ b/backend/src/main/java/reviewme/config/ReplicationDatasourceConfig.java
@@ -9,9 +9,11 @@ import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
 import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
 
+@Profile("prod")
 @Configuration
 public class ReplicationDatasourceConfig {
     @Bean(name = "writeDataSource")

--- a/backend/src/main/java/reviewme/config/ReplicationRoutingDataSource.java
+++ b/backend/src/main/java/reviewme/config/ReplicationRoutingDataSource.java
@@ -4,6 +4,7 @@ import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 public class ReplicationRoutingDataSource extends AbstractRoutingDataSource {
+
     @Override
     protected Object determineCurrentLookupKey() {
         boolean isReadOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();

--- a/backend/src/main/java/reviewme/config/ReplicationRoutingDataSource.java
+++ b/backend/src/main/java/reviewme/config/ReplicationRoutingDataSource.java
@@ -9,8 +9,8 @@ public class ReplicationRoutingDataSource extends AbstractRoutingDataSource {
     protected Object determineCurrentLookupKey() {
         boolean readOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
         if (readOnly) {
-            return "read";
+            return DataSourceType.READ;
         }
-        return "write";
+        return DataSourceType.WRITE;
     }
 }

--- a/backend/src/main/java/reviewme/config/ReplicationRoutingDataSource.java
+++ b/backend/src/main/java/reviewme/config/ReplicationRoutingDataSource.java
@@ -1,0 +1,15 @@
+package reviewme.config;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public class ReplicationRoutingDataSource extends AbstractRoutingDataSource {
+    @Override
+    protected Object determineCurrentLookupKey() {
+        boolean isReadOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
+        if (isReadOnly) {
+            return "read";
+        }
+        return "write";
+    }
+}

--- a/backend/src/main/java/reviewme/config/ReplicationRoutingDataSource.java
+++ b/backend/src/main/java/reviewme/config/ReplicationRoutingDataSource.java
@@ -7,8 +7,8 @@ public class ReplicationRoutingDataSource extends AbstractRoutingDataSource {
 
     @Override
     protected Object determineCurrentLookupKey() {
-        boolean isReadOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
-        if (isReadOnly) {
+        boolean readOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
+        if (readOnly) {
             return "read";
         }
         return "write";

--- a/backend/src/main/java/reviewme/review/service/ReviewDetailLookupService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewDetailLookupService.java
@@ -23,6 +23,7 @@ public class ReviewDetailLookupService {
 
     private final ReviewDetailMapper reviewDetailMapper;
 
+    @Transactional(readOnly = true)
     public ReviewDetailResponse getReviewDetail(long reviewId, String reviewRequestCode, String groupAccessCode) {
         ReviewGroup reviewGroup =  reviewGroupRepository.findByReviewRequestCode(reviewRequestCode)
                 .orElseThrow(() -> new ReviewGroupNotFoundByReviewRequestCodeException(reviewRequestCode));

--- a/backend/src/main/java/reviewme/reviewgroup/service/ReviewGroupLookupService.java
+++ b/backend/src/main/java/reviewme/reviewgroup/service/ReviewGroupLookupService.java
@@ -2,6 +2,7 @@ package reviewme.reviewgroup.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import reviewme.review.service.exception.ReviewGroupNotFoundByReviewRequestCodeException;
 import reviewme.reviewgroup.domain.ReviewGroup;
 import reviewme.reviewgroup.repository.ReviewGroupRepository;
@@ -13,6 +14,7 @@ public class ReviewGroupLookupService {
 
     private final ReviewGroupRepository reviewGroupRepository;
 
+    @Transactional(readOnly = true)
     public ReviewGroupResponse getReviewGroupSummary(String reviewRequestCode) {
         ReviewGroup reviewGroup = reviewGroupRepository.findByReviewRequestCode(reviewRequestCode)
                 .orElseThrow(() -> new ReviewGroupNotFoundByReviewRequestCodeException(reviewRequestCode));

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -19,3 +19,4 @@ spring:
     show-sql: true
     hibernate:
       ddl-auto: update
+    open-in-view: false

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -11,6 +11,8 @@ spring:
     show-sql: true
     hibernate:
       ddl-auto: update
+  flyway:
+    enabled: false
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #671 
- resolves #664 

---

### 🚀 어떤 기능을 구현했나요 ?
- 운영 환경의 DB를 RDS 클러스터로 변경하고 DB Replication을 적용했습니다.

### 🔥 어떻게 해결했나요 ?
- application-prod.yml에 dataSource의 url을 리더 인스턴스, 라이터 인스턴스의 엔드포인트로 분리하여 적용하였습니다.
- application-prod.yml에 정의된 데이터베이스 접속정보를 읽어서 write용 dataSource, read용 dataSource를 생성 후 spring에서 라우팅 해주도록 설정하였습니다.
- replication 관련하여 오류를 방지하기 위해 osiv를 해제해주었습니다. (local, dev, prod 모두 적용)

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- config 파일에서 상수화가 필요한 부분이 보입니다만... 일단 올렸습니다ㅎ

### 할 말
참고로 이 pr이 develop에 머지가 되도 작동하는지 바로 확인할 수는 없습니다😂
왜냐하면 아래 두가지가 모두 일어나야 read, write db 접근을 확인할 수 있기 때문이에요.
1. 해당 pr의 변경사항을 relaese 브랜치로 반영 
2. application-prod.yml의 secret 레포의 release 브랜치로 반영

### 📚 참고 자료
- rds 마이그레이션 과정 정리
https://longing-mastodon-de7.notion.site/RDS-10e90f1fe2db80f1a344c0618763a5b5?pvs=4
- replication 과정 정리
https://longing-mastodon-de7.notion.site/DB-Replication-10e90f1fe2db80b4b53decdbf8a7916a?pvs=4