### PR TITLE
[BE] infra: 여러 운영 서버에 병렬적으로 배포될 수 있도록 변경

### DIFF
--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -52,7 +52,10 @@ jobs:
   deploy:
     name: Deploy via self-hosted runner
     needs: build
-    runs-on: [self-hosted, prod]
+    strategy:
+      matrix:
+        runner: [prod-a, prod-b]
+    runs-on: [self-hosted, "${{ matrix.runner }}"]
 
     steps:
       - name: Checkout to secret repository


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #693 

---

### 🚀 어떤 기능을 구현했나요 ?
- 현재 작성된 CD 스크립트는 하나의 운영 서버에만 배포되도록 설정되어 있습니다.
- 운영 서버 증설에 의해 여러 운영 서버에 배포 작업이 병렬적으로 수행되어야 합니다.

### 🔥 어떻게 해결했나요 ?
- matrix를 통해 runner label를 다중 설정 후 runs-on에 적용

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
- 빨리 합시다