### PR TITLE
[FE] chore: BrotliPlugin을 prod 모드에서만 실행할 수 있도록 변경

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -59,14 +59,18 @@ module.exports = (env, argv) => {
         systemvars: true,
         path: './.env',
       }),
-      new BrotliPlugin({
-        asset: '[path].br[query]', // .br 확장자 설정
-        test: /\.(js|jsx|ts|tsx|css|html|svg|ico)$/, // 압축할 파일 유형
-        threshold: 8196, // 8KB 이상의 파일만 압축
-        minRatio: 0.8, // 압축 후 80% 이하로 줄어든 파일만 압축
-        quality: 11, // 최대 압축률 (0~11 사이, 기본값: 11)
-        deleteOriginalAssets: false, // 원본 파일을 삭제하지 않음
-      }),
+      ...(isProduction
+        ? [
+            new BrotliPlugin({
+              asset: '[path].br[query]', // .br 확장자 설정
+              test: /\.(js|jsx|ts|tsx|css|html|svg|ico)$/, // 압축할 파일 유형
+              threshold: 8196, // 8KB 이상의 파일만 압축
+              minRatio: 0.8, // 압축 후 80% 이하로 줄어든 파일만 압축
+              quality: 11, // 최대 압축률 (0~11 사이, 기본값: 11)
+              deleteOriginalAssets: false, // 원본 파일을 삭제하지 않음
+            }),
+          ]
+        : []),
       //new BundleAnalyzerPlugin(),
       sentryWebpackPlugin({
         authToken: process.env.SENTRY_AUTH_TOKEN,


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #700 

---

### 🚀 어떤 기능을 구현했나요 ?
- 제목이 곧 내용. BrotliPlugin이 dev 환경에서도 실행되니 코드 수정하고 컴파일 하는 시간이 조금 증가해서 소소한 불편함이 있었습니다.
- 그래서 prod 환경에서만 압축을 실행하도록 변경했습니다.

### 🔥 어떻게 해결했나요 ?
- 간단한 웹팩 코드 수정

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
- 리뷰미 이슈 700번대 돌파!