### PR TITLE
[FE] feat: Error Fallback에 반응형 도입

### DIFF
--- a/frontend/src/components/error/ErrorSection/styles.ts
+++ b/frontend/src/components/error/ErrorSection/styles.ts
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
+import media from '@/utils/media';
+
 export const Layout = styled.div`
   position: fixed;
   top: 50%;
@@ -11,17 +13,41 @@ export const Layout = styled.div`
   gap: 3rem;
   align-items: center;
   justify-content: center;
+
+  text-align: center;
+
+  ${media.xxSmall} {
+    gap: 1.5rem;
+  }
 `;
 
 export const ErrorLogoWrapper = styled.div`
   & > img {
     width: 15rem;
     height: 15rem;
+
+    ${media.xSmall} {
+      width: 11rem;
+      height: 11rem;
+    }
+
+    ${media.xxSmall} {
+      width: 8rem;
+      height: 8rem;
+    }
   }
 `;
 
 export const ErrorMessage = styled.span`
   font-size: 2rem;
+
+  ${media.xSmall} {
+    font-size: 1.6rem;
+  }
+
+  ${media.xxSmall} {
+    font-size: 1.32rem;
+  }
 `;
 
 export const Container = styled.div`
@@ -30,10 +56,21 @@ export const Container = styled.div`
   align-items: center;
   justify-content: center;
 
+  ${media.xSmall} {
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
   & > button {
     width: 17rem;
     height: 5rem;
     font-size: 1.4rem;
+
+    ${media.xxSmall} {
+      width: 15rem;
+      height: 4rem;
+      font-size: 1.1rem;
+    }
   }
 `;
 

--- a/frontend/src/components/error/ErrorSection/styles.ts
+++ b/frontend/src/components/error/ErrorSection/styles.ts
@@ -39,8 +39,8 @@ export const ErrorLogoWrapper = styled.div`
 `;
 
 export const ErrorMessage = styled.span`
+  width: max-content;
   font-size: 2rem;
-
   ${media.xSmall} {
     font-size: 1.6rem;
   }


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #703 

---

### 🚀 어떤 기능을 구현했나요 ?
- Error Fallback에 반응형을 도입했습니다.

### 🔥 어떻게 해결했나요 ?
- `xSmall`일 때부터 버튼 정렬을 column으로 변경합니다.
- 그 외 작은 화면에서 자연스럽게 보이도록 이미지/폰트 크기 등을 조절했습니다.
![image](https://github.com/user-attachments/assets/3ad963fa-64bf-45e5-9cef-4a2b2526e426)


### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
- 로딩 바는 320에서도 잘 보여서 반응형 추가할 필요 없는 것 같습니다~