### PR TITLE
[BE] refactor: 문자열 치환을 프론트엔드에서 진행하도록 수정

### DIFF
--- a/backend/src/main/java/reviewme/DatabaseInitializer.java
+++ b/backend/src/main/java/reviewme/DatabaseInitializer.java
@@ -23,7 +23,7 @@ import reviewme.template.repository.TemplateRepository;
 @RequiredArgsConstructor
 public class DatabaseInitializer {
 
-    private static final String CATEGORY_HEADER = "이제, 선택한 순간들을 바탕으로 {revieweeName}에 대한 리뷰를 작성해볼게요.";
+    private static final String CATEGORY_HEADER = "이제, 선택한 순간들을 바탕으로 ${revieweeName}에 대한 리뷰를 작성해볼게요.";
     private static final String CATEGORY_TEXT_QUESTION = "위에서 선택한 사항과 관련된 경험을 구체적으로 적어 주세요.";
     private static final int KEYWORD_CHECKBOX_MIN_COUNT = 1;
     private static final int KEYWORD_CHECKBOX_MAX_COUNT = 2;
@@ -43,18 +43,18 @@ public class DatabaseInitializer {
         }
 
         // 카테고리 선택 섹션
-        long categoryQuestionId = questionRepository.save(new Question(true, QuestionType.CHECKBOX, "프로젝트 기간 동안, {revieweeName}의 강점이 드러났던 순간을 선택해주세요.", null, 1)).getId();
-        long categorySectionId = sectionRepository.save(new Section(VisibleType.ALWAYS, List.of(categoryQuestionId), null, "강점 발견", "{revieweeName}와 함께 한 기억을 떠올려볼게요.", 1)).getId();
+        long categoryQuestionId = questionRepository.save(new Question(true, QuestionType.CHECKBOX, "프로젝트 기간 동안, ${revieweeName}의 강점이 드러났던 순간을 선택해주세요.", null, 1)).getId();
+        long categorySectionId = sectionRepository.save(new Section(VisibleType.ALWAYS, List.of(categoryQuestionId), null, "강점 발견", "${revieweeName/와:과} 함께 한 기억을 떠올려볼게요.", 1)).getId();
         long categoryOptionGroupId = optionGroupRepository.save(new OptionGroup(categoryQuestionId, KEYWORD_CHECKBOX_MIN_COUNT, KEYWORD_CHECKBOX_MAX_COUNT)).getId();
-        long communicationOptionId = optionItemRepository.save(new OptionItem("🗣️커뮤니케이션, 협업 능력  (예: 팀원간의 원활한 정보 공유, 명확한 의사소통)", categoryOptionGroupId, 1, OptionType.CATEGORY)).getId();
-        long problemSolvingOptionId = optionItemRepository.save(new OptionItem("💡문제 해결 능력  (예: 프로젝트 중 만난 버그/오류를 분석하고 이를 해결하는 능력)",categoryOptionGroupId,2, OptionType.CATEGORY )).getId();
+        long communicationOptionId = optionItemRepository.save(new OptionItem("🗣️커뮤니케이션, 협업 능력 (예: 팀원간의 원활한 정보 공유, 명확한 의사소통)", categoryOptionGroupId, 1, OptionType.CATEGORY)).getId();
+        long problemSolvingOptionId = optionItemRepository.save(new OptionItem("💡문제 해결 능력 (예: 프로젝트 중 만난 버그/오류를 분석하고 이를 해결하는 능력)",categoryOptionGroupId,2, OptionType.CATEGORY )).getId();
         long timeManagingOptionId = optionItemRepository.save(new OptionItem("⏰시간 관리 능력 (예: 일정과 마감 기한 준수, 업무의 우선 순위 분배)",categoryOptionGroupId,3, OptionType.CATEGORY )).getId();
         long technicalOptionId = optionItemRepository.save(new OptionItem("💻기술적 역량, 전문 지식 (예: 요구 사항을 이해하고 이를 구현하는 능력)",categoryOptionGroupId,4, OptionType.CATEGORY )).getId();
         long growthOptionId = optionItemRepository.save(new OptionItem("🌱성장 마인드셋 (예: 새로운 분야나 잘 모르는 분야에 도전하는 마음, 꾸준한 노력으로 프로젝트 이전보다 성장하는 모습)",categoryOptionGroupId,5, OptionType.CATEGORY )).getId();
 
         // 커뮤니케이션 능력 섹션
         long checkBoxCommunicationQuestionId = questionRepository.save(new Question(true, QuestionType.CHECKBOX, "커뮤니케이션, 협업 능력에서 어떤 부분이 인상 깊었는지 선택해주세요.", null, 1)).getId();
-        long textCommunicationQuestionId = questionRepository.save(new Question(true, QuestionType.TEXT, CATEGORY_TEXT_QUESTION, "상황을 자세하게 기록할수록 {revieweeName}에게 도움이 돼요. {revieweeName} 덕분에 팀이 원활한 소통을 이뤘거나, 함께 일하면서 배울 점이 있었는지 떠올려 보세요.", 2)).getId();
+        long textCommunicationQuestionId = questionRepository.save(new Question(true, QuestionType.TEXT, CATEGORY_TEXT_QUESTION, "상황을 자세하게 기록할수록 ${revieweeName}에게 도움이 돼요. ${revieweeName} 덕분에 팀이 원활한 소통을 이뤘거나, 함께 일하면서 배울 점이 있었는지 떠올려 보세요.", 2)).getId();
         long communicationSectionId = sectionRepository.save(new Section(VisibleType.CONDITIONAL, List.of(checkBoxCommunicationQuestionId, textCommunicationQuestionId), communicationOptionId, "커뮤니케이션 능력", CATEGORY_HEADER, 2)).getId();
         long communicationOptionGroupId = optionGroupRepository.save(new OptionGroup(checkBoxCommunicationQuestionId, KEYWORD_CHECKBOX_MIN_COUNT, KEYWORD_CHECKBOX_MAX_COUNT)).getId();
         optionItemRepository.save(new OptionItem("반대 의견을 내더라도 듣는 사람이 기분 나쁘지 않게 이야기해요.",communicationOptionGroupId,1, OptionType.KEYWORD ));
@@ -67,7 +67,7 @@ public class DatabaseInitializer {
 
         // 문제해결 능력 섹션
         long checkBoxProblemSolvingQuestionId = questionRepository.save(new Question(true, QuestionType.CHECKBOX, "문제해결 능력에서 어느 부분이 인상 깊었는지 선택해주세요.", null, 1)).getId();
-        long textProblemSolvingQuestionId = questionRepository.save(new Question(true, QuestionType.TEXT, CATEGORY_TEXT_QUESTION, "상황을 자세하게 기록할수록 {revieweeName}에게 도움이 돼요.  어떤 문제 상황이 발생했고, {revieweeName}이/가 어떻게 해결했는지 그 과정을 떠올려 보세요.", 2)).getId();
+        long textProblemSolvingQuestionId = questionRepository.save(new Question(true, QuestionType.TEXT, CATEGORY_TEXT_QUESTION, "상황을 자세하게 기록할수록 ${revieweeName}에게 도움이 돼요.  어떤 문제 상황이 발생했고, ${revieweeName/가:이} 어떻게 해결했는지 그 과정을 떠올려 보세요.", 2)).getId();
         long problemSolvingSectionId = sectionRepository.save(new Section(VisibleType.CONDITIONAL, List.of(checkBoxProblemSolvingQuestionId, textProblemSolvingQuestionId), problemSolvingOptionId, "문제해결 능력", CATEGORY_HEADER, 3)).getId();
         long problemSolvingOptionGroupId = optionGroupRepository.save(new OptionGroup(checkBoxProblemSolvingQuestionId, KEYWORD_CHECKBOX_MIN_COUNT, KEYWORD_CHECKBOX_MAX_COUNT)).getId();
         optionItemRepository.save(new OptionItem("큰 문제를 작은 단위로 쪼개서 단계별로 해결해나가요.",problemSolvingOptionGroupId,1, OptionType.KEYWORD ));
@@ -81,7 +81,7 @@ public class DatabaseInitializer {
 
         // 시간 관리 능력 섹션
         long checkBoxTimeManagingQuestionId = questionRepository.save(new Question(true, QuestionType.CHECKBOX, "시간 관리 능력에서 어느 부분이 인상 깊었는지 선택해주세요.", null, 1)).getId();
-        long textTimeManagingQuestionId = questionRepository.save(new Question(true, QuestionType.TEXT, CATEGORY_TEXT_QUESTION, "상황을 자세하게 기록할수록 {revieweeName}에게 도움이 돼요. {revieweeName} 덕분에 팀이 효율적으로 시간관리를 할 수 있었는지 떠올려 보세요.", 2)).getId();
+        long textTimeManagingQuestionId = questionRepository.save(new Question(true, QuestionType.TEXT, CATEGORY_TEXT_QUESTION, "상황을 자세하게 기록할수록 ${revieweeName}에게 도움이 돼요. ${revieweeName} 덕분에 팀이 효율적으로 시간관리를 할 수 있었는지 떠올려 보세요.", 2)).getId();
         long timeManagingSectionId = sectionRepository.save(new Section(VisibleType.CONDITIONAL, List.of(checkBoxTimeManagingQuestionId, textTimeManagingQuestionId), timeManagingOptionId, "시간관리 능력", CATEGORY_HEADER, 4)).getId();
         long timeManagingOptionGroupId = optionGroupRepository.save(new OptionGroup(checkBoxTimeManagingQuestionId, KEYWORD_CHECKBOX_MIN_COUNT, KEYWORD_CHECKBOX_MAX_COUNT)).getId();
         optionItemRepository.save(new OptionItem("프로젝트의 일정과 주요 마일스톤을 설정하여 체계적으로 일정을 관리해요.",timeManagingOptionGroupId,1, OptionType.KEYWORD ));
@@ -92,7 +92,7 @@ public class DatabaseInitializer {
 
         // 기술 역량 섹션
         long checkBoxTechnicalQuestionId = questionRepository.save(new Question(true, QuestionType.CHECKBOX, "기술 역량, 전문 지식에서 어떤 부분이 인상 깊었는지 선택해주세요.", null, 1)).getId();
-        long textTechnicalQuestionId = questionRepository.save(new Question(true, QuestionType.TEXT, CATEGORY_TEXT_QUESTION, "상황을 자세하게 기록할수록 {revieweeName}에게 도움이 돼요. {revieweeName} 덕분에 기술적 역량, 전문 지식적으로 도움을 받은 경험을 떠올려 보세요.", 2)).getId();
+        long textTechnicalQuestionId = questionRepository.save(new Question(true, QuestionType.TEXT, CATEGORY_TEXT_QUESTION, "상황을 자세하게 기록할수록 ${revieweeName}에게 도움이 돼요. ${revieweeName} 덕분에 기술적 역량, 전문 지식적으로 도움을 받은 경험을 떠올려 보세요.", 2)).getId();
         long technicalSectionId = sectionRepository.save(new Section(VisibleType.CONDITIONAL, List.of(checkBoxTechnicalQuestionId, textTechnicalQuestionId), technicalOptionId, "기술 역량", CATEGORY_HEADER, 5)).getId();
         long technicalOptionGroupId = optionGroupRepository.save(new OptionGroup(checkBoxTechnicalQuestionId, KEYWORD_CHECKBOX_MIN_COUNT, KEYWORD_CHECKBOX_MAX_COUNT)).getId();
         optionItemRepository.save(new OptionItem("관련 언어 / 라이브러리 / 프레임워크 지식이 풍부해요.",technicalOptionGroupId,1, OptionType.KEYWORD ));
@@ -110,7 +110,7 @@ public class DatabaseInitializer {
 
         // 성장 마인드셋 섹션
         long checkBoxGrowthQuestionId = questionRepository.save(new Question(true, QuestionType.CHECKBOX, "성장 마인드셋에서 어떤 부분이 인상 깊었는지 선택해주세요.", null, 1)).getId();
-        long textGrowthQuestionId = questionRepository.save(new Question(true, QuestionType.TEXT, CATEGORY_TEXT_QUESTION, "상황을 자세하게 기록할수록 {revieweeName}에게 도움이 돼요. 인상깊었던 {revieweeName}의 성장 마인드셋을 떠올려 보세요.", 2)).getId();
+        long textGrowthQuestionId = questionRepository.save(new Question(true, QuestionType.TEXT, CATEGORY_TEXT_QUESTION, "상황을 자세하게 기록할수록 ${revieweeName}에게 도움이 돼요. 인상깊었던 ${revieweeName}의 성장 마인드셋을 떠올려 보세요.", 2)).getId();
         long growthSectionId = sectionRepository.save(new Section(VisibleType.CONDITIONAL, List.of(checkBoxGrowthQuestionId, textGrowthQuestionId), growthOptionId, "성장 마인드셋", CATEGORY_HEADER, 6)).getId();
         long growthOptionGroupId = optionGroupRepository.save(new OptionGroup(checkBoxGrowthQuestionId, KEYWORD_CHECKBOX_MIN_COUNT, KEYWORD_CHECKBOX_MAX_COUNT)).getId();
         optionItemRepository.save(new OptionItem("어떤 상황에도 긍정적인 태도로 임해요.",growthOptionGroupId,1, OptionType.KEYWORD ));
@@ -125,11 +125,11 @@ public class DatabaseInitializer {
         optionItemRepository.save(new OptionItem("새로운 아이디어를 시도하고, 기존의 틀을 깨는 것을 두려워하지 않아요.",growthOptionGroupId,10, OptionType.KEYWORD ));
 
         // 성장 목표 설정 섹션
-        long textGrowthGoalQuestionId = questionRepository.save(new Question(true, QuestionType.TEXT, "앞으로의 성장을 위해서 {revieweeName}이/가 어떤 목표를 설정하면 좋을까요?", "어떤 점을 보완하면 좋을지와 함께 '이렇게 해보면 어떨까?'하는 간단한 솔루션을 제안해봐요.", 1)).getId();
-        long textGrowthGoalSectionId = sectionRepository.save(new Section(VisibleType.ALWAYS, List.of(textGrowthGoalQuestionId), null, "보완할 점", "{revieweeName}의 성장을 도와주세요!", 7)).getId();
+        long textGrowthGoalQuestionId = questionRepository.save(new Question(true, QuestionType.TEXT, "앞으로의 성장을 위해서 ${revieweeName/가:이} 어떤 목표를 설정하면 좋을까요?", "어떤 점을 보완하면 좋을지와 함께 '이렇게 해보면 어떨까?'하는 간단한 솔루션을 제안해봐요.", 1)).getId();
+        long textGrowthGoalSectionId = sectionRepository.save(new Section(VisibleType.ALWAYS, List.of(textGrowthGoalQuestionId), null, "보완할 점", "${revieweeName}의 성장을 도와주세요!", 7)).getId();
 
         // 응원의 말 섹션
-        long textCheerUpQuestionId = questionRepository.save(new Question(false, QuestionType.TEXT, "{revieweeName}에게 전하고 싶은 다른 리뷰가 있거나 응원의 말이 있다면 적어주세요.", null, 1)).getId();
+        long textCheerUpQuestionId = questionRepository.save(new Question(false, QuestionType.TEXT, "${revieweeName}에게 전하고 싶은 다른 리뷰가 있거나 응원의 말이 있다면 적어주세요.", null, 1)).getId();
         long cheerUpSectionId = sectionRepository.save(new Section(VisibleType.ALWAYS, List.of(textCheerUpQuestionId), null, "추가 리뷰/응원", "리뷰를 더 하고 싶은 리뷰어를 위한 추가 리뷰!", 8)).getId();
 
         templateRepository.save(new Template(List.of(

--- a/backend/src/main/java/reviewme/DatabaseInitializer.java
+++ b/backend/src/main/java/reviewme/DatabaseInitializer.java
@@ -36,7 +36,7 @@ public class DatabaseInitializer {
 
     @PostConstruct
     @Transactional
-    void setup() {
+    public void setup() {
         // 템플릿이 이미 존재하면 종료
         if (!templateRepository.findAll().isEmpty()) {
             return;
@@ -46,11 +46,11 @@ public class DatabaseInitializer {
         long categoryQuestionId = questionRepository.save(new Question(true, QuestionType.CHECKBOX, "프로젝트 기간 동안, {revieweeName}의 강점이 드러났던 순간을 선택해주세요.", null, 1)).getId();
         long categorySectionId = sectionRepository.save(new Section(VisibleType.ALWAYS, List.of(categoryQuestionId), null, "강점 발견", "{revieweeName}와 함께 한 기억을 떠올려볼게요.", 1)).getId();
         long categoryOptionGroupId = optionGroupRepository.save(new OptionGroup(categoryQuestionId, KEYWORD_CHECKBOX_MIN_COUNT, KEYWORD_CHECKBOX_MAX_COUNT)).getId();
-        long communicationOptionId = optionItemRepository.save(new OptionItem("🗣️커뮤니케이션, 협업 능력  (ex: 팀원간의 원활한 정보 공유, 명확한 의사소통)", categoryOptionGroupId, 1, OptionType.CATEGORY)).getId();
-        long problemSolvingOptionId = optionItemRepository.save(new OptionItem("💡문제 해결 능력  (ex: 프로젝트 중 만난 버그/오류를 분석하고 이를 해결하는 능력)",categoryOptionGroupId,2, OptionType.CATEGORY )).getId();
-        long timeManagingOptionId = optionItemRepository.save(new OptionItem("⏰시간 관리 능력 (ex: 일정과 마감 기한 준수, 업무의 우선 순위 분배)",categoryOptionGroupId,3, OptionType.CATEGORY )).getId();
-        long technicalOptionId = optionItemRepository.save(new OptionItem("💻기술적 역량, 전문 지식 (ex: 요구 사항을 이해하고 이를 구현하는 능력)",categoryOptionGroupId,4, OptionType.CATEGORY )).getId();
-        long growthOptionId = optionItemRepository.save(new OptionItem("🌱성장 마인드셋 (ex: 새로운 분야나 잘 모르는 분야에 도전하는 마음, 꾸준한 노력으로 프로젝트 이전보다 성장하는 모습)",categoryOptionGroupId,5, OptionType.CATEGORY )).getId();
+        long communicationOptionId = optionItemRepository.save(new OptionItem("🗣️커뮤니케이션, 협업 능력  (예: 팀원간의 원활한 정보 공유, 명확한 의사소통)", categoryOptionGroupId, 1, OptionType.CATEGORY)).getId();
+        long problemSolvingOptionId = optionItemRepository.save(new OptionItem("💡문제 해결 능력  (예: 프로젝트 중 만난 버그/오류를 분석하고 이를 해결하는 능력)",categoryOptionGroupId,2, OptionType.CATEGORY )).getId();
+        long timeManagingOptionId = optionItemRepository.save(new OptionItem("⏰시간 관리 능력 (예: 일정과 마감 기한 준수, 업무의 우선 순위 분배)",categoryOptionGroupId,3, OptionType.CATEGORY )).getId();
+        long technicalOptionId = optionItemRepository.save(new OptionItem("💻기술적 역량, 전문 지식 (예: 요구 사항을 이해하고 이를 구현하는 능력)",categoryOptionGroupId,4, OptionType.CATEGORY )).getId();
+        long growthOptionId = optionItemRepository.save(new OptionItem("🌱성장 마인드셋 (예: 새로운 분야나 잘 모르는 분야에 도전하는 마음, 꾸준한 노력으로 프로젝트 이전보다 성장하는 모습)",categoryOptionGroupId,5, OptionType.CATEGORY )).getId();
 
         // 커뮤니케이션 능력 섹션
         long checkBoxCommunicationQuestionId = questionRepository.save(new Question(true, QuestionType.CHECKBOX, "커뮤니케이션, 협업 능력에서 어떤 부분이 인상 깊었는지 선택해주세요.", null, 1)).getId();

--- a/backend/src/main/java/reviewme/question/domain/Question.java
+++ b/backend/src/main/java/reviewme/question/domain/Question.java
@@ -55,15 +55,4 @@ public class Question {
     public boolean hasGuideline() {
         return guideline != null && !guideline.isEmpty();
     }
-
-    public String convertContent(String target, String replacement) {
-        return content.replace(target, replacement);
-    }
-
-    public String convertGuideLine(String target, String replacement) {
-        if (guideline == null) {
-            return null;
-        }
-        return guideline.replace(target, replacement);
-    }
 }

--- a/backend/src/main/java/reviewme/review/service/mapper/ReviewDetailMapper.java
+++ b/backend/src/main/java/reviewme/review/service/mapper/ReviewDetailMapper.java
@@ -49,7 +49,7 @@ public class ReviewDetailMapper {
                 .collect(Collectors.groupingBy(OptionItem::getOptionGroupId));
 
         List<SectionAnswerResponse> sectionResponses = sections.stream()
-                .map(section -> mapToSectionResponse(review, reviewGroup, section, questions,
+                .map(section -> mapToSectionResponse(review, section, questions,
                         optionGroupsByQuestion, optionItemsByOptionGroup))
                 .filter(sectionResponse -> !sectionResponse.questions().isEmpty())
                 .toList();
@@ -63,35 +63,34 @@ public class ReviewDetailMapper {
         );
     }
 
-    private SectionAnswerResponse mapToSectionResponse(Review review, ReviewGroup reviewGroup, Section section,
+    private SectionAnswerResponse mapToSectionResponse(Review review, Section section,
                                                        List<Question> questions,
                                                        Map<Long, OptionGroup> optionGroupsByQuestion,
                                                        Map<Long, List<OptionItem>> optionItemsByOptionGroup) {
         List<QuestionAnswerResponse> questionResponses = questions.stream()
                 .filter(question -> review.hasAnsweredQuestion(question.getId()))
-                .map(question -> mapToQuestionResponse(review, reviewGroup, question,
-                        optionGroupsByQuestion, optionItemsByOptionGroup))
-                .toList();
+                .map(question -> mapToQuestionResponse(
+                        review, question, optionGroupsByQuestion, optionItemsByOptionGroup)
+                ).toList();
 
         return new SectionAnswerResponse(
                 section.getId(),
-                reviewGroup.getReviewee(),
+                section.getHeader(),
                 questionResponses
         );
     }
 
-    private QuestionAnswerResponse mapToQuestionResponse(Review review, ReviewGroup reviewGroup, Question question,
+    private QuestionAnswerResponse mapToQuestionResponse(Review review, Question question,
                                                          Map<Long, OptionGroup> optionGroupsByQuestion,
                                                          Map<Long, List<OptionItem>> optionItemsByOptionGroup) {
         if (question.isSelectable()) {
-            return mapToCheckboxQuestionResponse(review, reviewGroup, question,
-                    optionGroupsByQuestion, optionItemsByOptionGroup);
+            return mapToCheckboxQuestionResponse(review, question, optionGroupsByQuestion, optionItemsByOptionGroup);
         } else {
-            return mapToTextQuestionResponse(review, reviewGroup, question);
+            return mapToTextQuestionResponse(review, question);
         }
     }
 
-    private QuestionAnswerResponse mapToCheckboxQuestionResponse(Review review, ReviewGroup reviewGroup,
+    private QuestionAnswerResponse mapToCheckboxQuestionResponse(Review review,
                                                                  Question question,
                                                                  Map<Long, OptionGroup> optionGroupsByQuestion,
                                                                  Map<Long, List<OptionItem>> optionItemsByOptionGroup) {
@@ -118,13 +117,13 @@ public class ReviewDetailMapper {
                 question.getId(),
                 question.isRequired(),
                 question.getQuestionType(),
-                reviewGroup.getReviewee(),
+                question.getContent(),
                 optionGroupAnswerResponse,
                 null
         );
     }
 
-    private QuestionAnswerResponse mapToTextQuestionResponse(Review review, ReviewGroup reviewGroup,
+    private QuestionAnswerResponse mapToTextQuestionResponse(Review review,
                                                              Question question) {
         List<TextAnswer> textAnswers = review.getTextAnswers();
         TextAnswer textAnswer = textAnswers.stream()
@@ -136,7 +135,7 @@ public class ReviewDetailMapper {
                 question.getId(),
                 question.isRequired(),
                 question.getQuestionType(),
-                reviewGroup.getReviewee(),
+                question.getContent(),
                 null,
                 textAnswer.getContent()
         );

--- a/backend/src/main/java/reviewme/review/service/mapper/ReviewDetailMapper.java
+++ b/backend/src/main/java/reviewme/review/service/mapper/ReviewDetailMapper.java
@@ -15,8 +15,6 @@ import reviewme.question.repository.OptionItemRepository;
 import reviewme.question.repository.QuestionRepository;
 import reviewme.review.domain.Review;
 import reviewme.review.domain.TextAnswer;
-import reviewme.review.domain.TextAnswers;
-import reviewme.review.service.exception.OptionGroupNotFoundByQuestionIdException;
 import reviewme.review.service.dto.response.detail.OptionGroupAnswerResponse;
 import reviewme.review.service.dto.response.detail.OptionItemAnswerResponse;
 import reviewme.review.service.dto.response.detail.QuestionAnswerResponse;
@@ -29,8 +27,6 @@ import reviewme.template.repository.SectionRepository;
 @Component
 @RequiredArgsConstructor
 public class ReviewDetailMapper {
-
-    public static final String REVIEWEE_NAME_PLACEHOLDER = "{revieweeName}";
 
     private final SectionRepository sectionRepository;
     private final QuestionRepository questionRepository;
@@ -79,7 +75,7 @@ public class ReviewDetailMapper {
 
         return new SectionAnswerResponse(
                 section.getId(),
-                section.convertHeader(REVIEWEE_NAME_PLACEHOLDER, reviewGroup.getReviewee()),
+                reviewGroup.getReviewee(),
                 questionResponses
         );
     }
@@ -122,7 +118,7 @@ public class ReviewDetailMapper {
                 question.getId(),
                 question.isRequired(),
                 question.getQuestionType(),
-                question.convertContent(REVIEWEE_NAME_PLACEHOLDER, reviewGroup.getReviewee()),
+                reviewGroup.getReviewee(),
                 optionGroupAnswerResponse,
                 null
         );
@@ -140,7 +136,7 @@ public class ReviewDetailMapper {
                 question.getId(),
                 question.isRequired(),
                 question.getQuestionType(),
-                question.convertContent(REVIEWEE_NAME_PLACEHOLDER, reviewGroup.getReviewee()),
+                reviewGroup.getReviewee(),
                 null,
                 textAnswer.getContent()
         );

--- a/backend/src/main/java/reviewme/template/domain/Section.java
+++ b/backend/src/main/java/reviewme/template/domain/Section.java
@@ -65,8 +65,4 @@ public class Section {
     public boolean isVisibleBySelectedOptionIds(Collection<Long> selectedOptionIds) {
         return visibleType == VisibleType.ALWAYS || selectedOptionIds.contains(onSelectedOptionId);
     }
-
-    public String convertHeader(String target, String replacement) {
-        return header.replace(target, replacement);
-    }
 }

--- a/backend/src/main/java/reviewme/template/service/mapper/TemplateMapper.java
+++ b/backend/src/main/java/reviewme/template/service/mapper/TemplateMapper.java
@@ -72,7 +72,7 @@ public class TemplateMapper {
                 section.getSectionName(),
                 section.getVisibleType().name(),
                 section.getOnSelectedOptionId(),
-                section.convertHeader(REVIEWEE_NAME_PLACEHOLDER, reviewGroup.getReviewee()),
+                reviewGroup.getReviewee(),
                 questionResponses
         );
     }
@@ -89,11 +89,11 @@ public class TemplateMapper {
         return new QuestionResponse(
                 question.getId(),
                 question.isRequired(),
-                question.convertContent(REVIEWEE_NAME_PLACEHOLDER, reviewGroup.getReviewee()),
+                reviewGroup.getReviewee(),
                 question.getQuestionType().name(),
                 optionGroupResponse,
                 question.hasGuideline(),
-                question.convertGuideLine(REVIEWEE_NAME_PLACEHOLDER, reviewGroup.getReviewee())
+                reviewGroup.getReviewee()
         );
     }
 

--- a/backend/src/main/java/reviewme/template/service/mapper/TemplateMapper.java
+++ b/backend/src/main/java/reviewme/template/service/mapper/TemplateMapper.java
@@ -46,7 +46,7 @@ public class TemplateMapper {
 
         List<SectionResponse> sectionResponses = template.getSectionIds()
                 .stream()
-                .map(templateSection -> mapToSectionResponse(templateSection, reviewGroup))
+                .map(this::mapToSectionResponse)
                 .toList();
 
         return new TemplateResponse(
@@ -57,14 +57,14 @@ public class TemplateMapper {
         );
     }
 
-    private SectionResponse mapToSectionResponse(TemplateSection templateSection, ReviewGroup reviewGroup) {
+    private SectionResponse mapToSectionResponse(TemplateSection templateSection) {
         Section section = sectionRepository.findById(templateSection.getSectionId())
                 .orElseThrow(() -> new SectionInTemplateNotFoundException(
                         templateSection.getTemplateId(), templateSection.getSectionId())
                 );
         List<QuestionResponse> questionResponses = section.getQuestionIds()
                 .stream()
-                .map(sectionQuestion -> mapToQuestionResponse(sectionQuestion, reviewGroup))
+                .map(this::mapToQuestionResponse)
                 .toList();
 
         return new SectionResponse(
@@ -72,12 +72,12 @@ public class TemplateMapper {
                 section.getSectionName(),
                 section.getVisibleType().name(),
                 section.getOnSelectedOptionId(),
-                reviewGroup.getReviewee(),
+                section.getHeader(),
                 questionResponses
         );
     }
 
-    private QuestionResponse mapToQuestionResponse(SectionQuestion sectionQuestion, ReviewGroup reviewGroup) {
+    private QuestionResponse mapToQuestionResponse(SectionQuestion sectionQuestion) {
         Question question = questionRepository.findById(sectionQuestion.getQuestionId())
                 .orElseThrow(() -> new QuestionInSectionNotFoundException(
                         sectionQuestion.getSectionId(), sectionQuestion.getQuestionId())
@@ -89,11 +89,11 @@ public class TemplateMapper {
         return new QuestionResponse(
                 question.getId(),
                 question.isRequired(),
-                reviewGroup.getReviewee(),
+                question.getContent(),
                 question.getQuestionType().name(),
                 optionGroupResponse,
                 question.hasGuideline(),
-                reviewGroup.getReviewee()
+                question.getGuideline()
         );
     }
 


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- related #667 

---

### 🚀 어떤 기능을 구현했나요 ?
- 백엔드에서의 문자열 치환을 삭제했습니다.
- 앞으로 `${변수명/받침있는조사:받침없는조사}`형태로 내면 됩니다.
- 조사 필요없으면 `${변수명}`으로 하면 됩니다.

- 일단 데브서버의 DB는 수정해뒀습니다.