### PR TITLE
[FE] fix: 무한 스크롤에서 lastReviewId 값이 null일 때와 아닐 때의 엔드포인트 링크 분리

### DIFF
--- a/frontend/src/apis/endpoints.ts
+++ b/frontend/src/apis/endpoints.ts
@@ -58,8 +58,12 @@ const endPoint = {
   gettingDetailedReview: (reviewId: number) => `${DETAILED_REVIEW_API_URL}/${reviewId}`,
   gettingDataToWriteReview: (reviewRequestCode: string) =>
     `${REVIEW_WRITING_API_URL}/${REVIEW_WRITING_API_PARAMS.queryString.write}?${REVIEW_WRITING_API_PARAMS.queryString.reviewRequestCode}=${reviewRequestCode}`,
-  gettingReviewList: (lastReviewId: number | null, size: number) =>
-    `${REVIEW_LIST_API_URL}?lastReviewId=${lastReviewId}&size=${size}`,
+  gettingReviewList: (lastReviewId: number | null, size: number) => {
+    if (lastReviewId) {
+      return `${REVIEW_LIST_API_URL}?lastReviewId=${lastReviewId}&size=${size}`;
+    }
+    return `${REVIEW_LIST_API_URL}?size=${size}`;
+  },
   postingDataForReviewRequestCode: `${serverUrl}/${VERSION2}/groups`,
   checkingPassword: `${serverUrl}/${VERSION2}/${REVIEW_PASSWORD_API_PARAMS.resource}/${REVIEW_PASSWORD_API_PARAMS.queryString.check}`,
   gettingReviewGroupData: (reviewRequestCode: string) =>


### PR DESCRIPTION

- resolves #713 

---

### 🚀 어떤 기능을 구현했나요 ?
- 무한 스크롤 과정에서 lastReviewId 값이 null일 때와 아닐 때의 엔드포인트 링크를 분리했습니다.

### 🔥 어떻게 해결했나요 ?
기존에는 리뷰 목록 페이지에서 첫 api 요청 시, lastReviewId에 null 값을 보내고 있었습니다. 그런데 여기서 null을 보내게 되면 백엔드에서 문자열 "null"로 인식하고, 이를 숫자로 변환하려다 오류가 발생하는 상황이 발생했습니다. 이를 해결하기 위해, lastReviewId가 null일 때는 size만 포함된 URL을 반환하고, lastReviewId가 존재할 경우 해당 값을 포함한 URL을 생성하는 방식으로 변경했습니다. 즉, lastReviewId가 null이거나 아닐 때 각각 다른 엔드포인트 링크를 사용하도록 분리했습니다.

```tsx
const endPoint = {
  // ...
  gettingReviewList: (lastReviewId: number | null, size: number) => {
    if (lastReviewId) {
      return `${REVIEW_LIST_API_URL}?lastReviewId=${lastReviewId}&size=${size}`;
    }
    return `${REVIEW_LIST_API_URL}?size=${size}`;
  },
  //...
};
```

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
완벽할 줄 알았던 무한 스크롤.... 오류가 발생했군요.