### PR TITLE
[FE] refactor: TopButton 반응형 도입, Layout에서 TopButton 제거

### DIFF
--- a/frontend/src/components/common/TopButton/style.ts
+++ b/frontend/src/components/common/TopButton/style.ts
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
+import media from '@/utils/media';
+
 export const TopButton = styled.button`
   position: fixed;
   right: 5rem;
@@ -18,9 +20,36 @@ export const TopButton = styled.button`
   filter: drop-shadow(0 0 0.2rem ${({ theme }) => theme.colors.primary});
   border: 0.2rem solid ${({ theme }) => theme.colors.primary};
   border-radius: 100%;
+
+  ${media.medium} {
+    right: 7.5rem;
+  }
+
+  ${media.small} {
+    right: 1.5rem;
+    bottom: 5%;
+    width: 4.5rem;
+    height: 4.5rem;
+  }
+
+  ${media.xSmall} {
+    right: 1rem;
+    width: 3.8rem;
+    height: 3.8rem;
+  }
 `;
 
 export const ArrowImage = styled.img`
   width: 3rem;
   height: 3rem;
+
+  ${media.small} {
+    width: 2.7rem;
+    height: 2.7rem;
+  }
+
+  ${media.xSmall} {
+    width: 2.5rem;
+    height: 2.5rem;
+  }
 `;

--- a/frontend/src/components/layouts/Main/styles.ts
+++ b/frontend/src/components/layouts/Main/styles.ts
@@ -13,6 +13,8 @@ const calculateMinHeight = ({ $isShowBreadCrumb, ...theme }: MainContainerProps 
 };
 
 export const MainContainer = styled.div<MainContainerProps>`
+  z-index: ${({ theme }) => theme.zIndex.main};
+
   display: flex;
   align-items: center;
   justify-content: center;

--- a/frontend/src/components/layouts/PageLayout/index.tsx
+++ b/frontend/src/components/layouts/PageLayout/index.tsx
@@ -24,7 +24,6 @@ const PageLayout = ({ children, isNeedBreadCrumb = true }: EssentialPropsWithChi
         <Main isShowBreadCrumb={isShowBreadCrumb}>{children}</Main>
         <Footer />
       </S.Wrapper>
-      <TopButton />
     </S.Layout>
   );
 };

--- a/frontend/src/pages/DetailedReviewPage/index.tsx
+++ b/frontend/src/pages/DetailedReviewPage/index.tsx
@@ -1,4 +1,4 @@
-import { ErrorSuspenseContainer, AuthAndServerErrorFallback } from '@/components';
+import { ErrorSuspenseContainer, AuthAndServerErrorFallback, TopButton } from '@/components';
 
 import { DetailedReviewPageContents } from './components';
 
@@ -6,6 +6,7 @@ const DetailedReviewPage = () => {
   return (
     <ErrorSuspenseContainer fallback={AuthAndServerErrorFallback}>
       <DetailedReviewPageContents />
+      <TopButton />
     </ErrorSuspenseContainer>
   );
 };

--- a/frontend/src/pages/ReviewListPage/index.tsx
+++ b/frontend/src/pages/ReviewListPage/index.tsx
@@ -1,4 +1,4 @@
-import { ErrorSuspenseContainer, AuthAndServerErrorFallback } from '@/components';
+import { ErrorSuspenseContainer, AuthAndServerErrorFallback, TopButton } from '@/components';
 
 import PageContents from './components/PageContents';
 
@@ -6,6 +6,7 @@ const ReviewListPage = () => {
   return (
     <ErrorSuspenseContainer fallback={AuthAndServerErrorFallback}>
       <PageContents />
+      <TopButton />
     </ErrorSuspenseContainer>
   );
 };

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -74,6 +74,7 @@ export const colors: ThemeProperty<CSSProperties['color']> = {
 
 export const zIndex: ThemeProperty<CSSProperties['zIndex']> = {
   modal: 999,
+  main: 1,
 };
 
 export const breakpoints = {


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #712 

---

### 🚀 어떤 기능을 구현했나요 ?
- TopButton에 반응형을 도입했습니다.
  - 위치값 조정
  - 사이즈 조정 
- main에 z-index를 추가했습니다.

### 🔥 어떻게 해결했나요 ?
- 기존에는 Layout 컴포넌트에서 TopButton을 보여줬는데, 리뷰 작성 페이지에서는 TopButton이 오히려 불편하다는 QA 결과에 의해 리뷰 목록, 상세 리뷰 페이지에서만 보여주게 되었습니다. 
- 이에 따라 전과 달리 Footer보다 TopButton이 안쪽에 들어가게 되어 Footer가 TopButton을 일부 가렸습니다.
- 이를 막기 위해 zIndex Theme에 main: 1을 추가해 Footer가 Main 아래에 오도록 했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 화면이 작아질 때 TopButton의 위치가 애매해서 카드 안쪽에 오되 너무 안으로 들어가지는 않는 위치에 오게끔 했습니다.
  - 하지만 화면 크기에 따라 예쁘게(?) 올 때도 있고 아래처럼 미묘할 때도 있습니다 😂
- 아래는 450일 때의 모습입니다
![image](https://github.com/user-attachments/assets/0d3ba413-7879-4a73-a5d2-958e02c538bd)


### 📚 참고 자료, 할 말
- 반응형  끝이 없네~~!~