### PR TITLE
[FE] design: 모바일 환경에서 리뷰 작성 완료 페이지 버튼 및 폰트 사이즈 수정

### DIFF
--- a/frontend/src/pages/ReviewWritingCompletePage/styles.ts
+++ b/frontend/src/pages/ReviewWritingCompletePage/styles.ts
@@ -12,17 +12,21 @@ export const Container = styled.div`
   left: 50%;
   transform: translate(-50%, -50%);
 
+  width: 100%;
+
   display: flex;
   flex-direction: column;
-  gap: 5rem;
+  gap: 3.5rem;
   align-items: center;
   justify-content: center;
 `;
 
 export const ReviewComplete = styled.div`
   display: flex;
-  gap: 1rem;
+  justify-content: center;
   align-items: center;
+  gap: 1rem;
+  width: 100%;
 
   img {
     ${media.xSmall} {
@@ -46,15 +50,17 @@ export const HomeIcon = styled.img`
   height: 2rem;
 
   ${media.xSmall} {
-    width: 1rem;
-    height: 1rem;
+    width: 1.2rem;
+    height: 1.2rem;
   }
 `;
 
 export const HomeText = styled.p`
   margin-left: 0.5rem;
+  height: 1.6rem;
 
   ${media.xSmall} {
-    font-size: 1rem;
+    height: 1.2rem;
+    font-size: 1.2rem;
   }
 `;


### PR DESCRIPTION

- resolves #711 

---

### 🚀 어떤 기능을 구현했나요 ?
- 모바일 환경에서 리뷰 작성 완료 페이지 버튼과 폰트 사이즈를 늘렸습니다.

### 🔥 어떻게 해결했나요 ?
- 리뷰 작성 완료 페이지에서 미세하게 버튼과 폰트 사이즈를 늘렸습니다.
<img width="497" alt="스크린샷 2024-09-26 오후 8 43 01" src="https://github.com/user-attachments/assets/d460542e-afb1-4b51-bb69-047797c2e257">


### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 모바일 환경에서 사이즈가 적절한지 확인 부탁드릴게요!

### 📚 참고 자료, 할 말
- 리뷰미 5차 데모데이 화이팅!!!!