### PR TITLE
[FE] design : 리뷰 작성 확인 모달에서 리뷰 카드 컨테이너에 마진 추가

### DIFF
--- a/frontend/src/pages/ReviewWritingPage/modals/components/AnswerListRecheckModal/styles.ts
+++ b/frontend/src/pages/ReviewWritingPage/modals/components/AnswerListRecheckModal/styles.ts
@@ -9,14 +9,15 @@ export const AnswerListContainer = styled.div`
   flex-direction: column;
   gap: 1.2rem;
 
-  width: ${({ theme }) => theme.formWidth};
+  width: calc(${({ theme }) => theme.formWidth}- 0.2rem);
+  margin-right: 0.2rem;
 
   ${media.medium} {
     width: ${({ theme }) => {
       const { maxWidth, padding } = theme.contentModalSize;
       const { basic } = theme.scrollbarWidth;
 
-      return `calc(${maxWidth} - (${padding} * 2) - ${basic})`;
+      return `calc(${maxWidth} - (${padding} * 2) - ${basic} - 0.2rem)`;
     }};
   }
 
@@ -25,12 +26,12 @@ export const AnswerListContainer = styled.div`
       const { maxWidth, smallPadding } = theme.contentModalSize;
       const { small } = theme.scrollbarWidth;
 
-      return `calc(${maxWidth} - (${smallPadding} * 2) - ${small})`;
+      return `calc(${maxWidth} - (${smallPadding} * 2) - ${small} - 0.2rem)`;
     }};
   }
 
   @media screen and (max-width: 330px) {
-    width: inherit;
+    width: calc(100% - 0.2rem);
   }
 `;
 


### PR DESCRIPTION


- resolves #725

---

### 🚀 어떤 기능을 구현했나요 ?
- 디바이스에 따라 스크롤에 의해 리뷰 카드 보더가 사라지는 오류가 있어요.  리뷰 작성 확인 모달에 오른쪽 마진을 주어서 해결했어요


### 📚 참고 자료, 할 말
