### PR TITLE
[FE] fix: 영어 이름이고, 조사 선택형이 아닌 경우 undefined가 출력되는 버그 수정

### DIFF
--- a/frontend/src/utils/substituteString.ts
+++ b/frontend/src/utils/substituteString.ts
@@ -17,14 +17,17 @@ const substituteString = ({ content, variables }: SubstituteStringProps) => {
 
   return content.replace(regex, (_, variableName, particleWithoutFinalConsonant, particleWithFinalConsonant) => {
     const value = variables[variableName];
-
+    // 조사 선택형이 아닌 경우 문자열만 치환
+    if (!particleWithFinalConsonant || !particleWithoutFinalConsonant) return value;
+    // 영어 이름인 경우 가능한 조사를 모두 포함해서 치환
     if (hasAlphabet.test(value)) {
       return value + `${particleWithFinalConsonant}(${particleWithoutFinalConsonant})`;
     }
-
-    if (value && particleWithoutFinalConsonant && particleWithFinalConsonant) {
+    // 한글 이름인 경우 받침 유무에 따라 맞는 조사로 치환
+    if (value) {
       return value + (hasFinalConsonant(value) ? particleWithFinalConsonant : particleWithoutFinalConsonant);
     }
+
     return value;
   });
 };


### PR DESCRIPTION
- resolves #732 

---

### 🚀 어떤 기능을 구현했나요 ?
- 영어 이름이고, 조사 선택형이 아닌 경우 undefined가 그대로 출력되는 버그를 수정했습니다.

### 🔥 어떻게 해결했나요 ?
- 조사 선택형인지 여부를 먼저 확인해서 걸러내고, 이후의 분기 작업을 진행합니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
