### PR TITLE
[BE] fix: 섹션에 해당하는 질문만 응답하도록 수정

### DIFF
--- a/backend/src/main/java/reviewme/review/service/mapper/ReviewDetailMapper.java
+++ b/backend/src/main/java/reviewme/review/service/mapper/ReviewDetailMapper.java
@@ -68,6 +68,7 @@ public class ReviewDetailMapper {
                                                        Map<Long, OptionGroup> optionGroupsByQuestion,
                                                        Map<Long, List<OptionItem>> optionItemsByOptionGroup) {
         List<QuestionAnswerResponse> questionResponses = questions.stream()
+                .filter(question -> section.containsQuestionId(question.getId()))
                 .filter(question -> review.hasAnsweredQuestion(question.getId()))
                 .map(question -> mapToQuestionResponse(
                         review, question, optionGroupsByQuestion, optionItemsByOptionGroup)

--- a/backend/src/main/java/reviewme/template/domain/Section.java
+++ b/backend/src/main/java/reviewme/template/domain/Section.java
@@ -65,4 +65,9 @@ public class Section {
     public boolean isVisibleBySelectedOptionIds(Collection<Long> selectedOptionIds) {
         return visibleType == VisibleType.ALWAYS || selectedOptionIds.contains(onSelectedOptionId);
     }
+
+    public boolean containsQuestionId(long questionId) {
+        return questionIds.stream()
+                .anyMatch(sectionQuestion -> sectionQuestion.hasQuestionId(questionId));
+    }
 }

--- a/backend/src/main/java/reviewme/template/domain/SectionQuestion.java
+++ b/backend/src/main/java/reviewme/template/domain/SectionQuestion.java
@@ -29,4 +29,8 @@ public class SectionQuestion {
     public SectionQuestion(long questionId) {
         this.questionId = questionId;
     }
+
+    public boolean hasQuestionId(long questionId) {
+        return this.questionId == questionId;
+    }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -19,6 +19,8 @@ spring:
     hibernate:
       ddl-auto: update
     open-in-view: false
+  flyway:
+    enabled: false
 
 server:
   servlet:


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #733 

as-is:
<img width="692" alt="image" src="https://github.com/user-attachments/assets/aba55cae-d21d-4ea7-b339-eb4921b018df">

to-be:
<img width="615" alt="image" src="https://github.com/user-attachments/assets/ea176d8b-9c72-4a24-a5bf-6a6c9a32ff1b">

---
### 🔥 어떻게 해결했나요 ?
- 각각의 클래스에 알맞은 메서드를 추가했습니다. 필터링 추가해서 섹션에 해당하는 질문만을 반환합니다.

