### PR TITLE
[FE] refactor: 리뷰 목록 페이지에서 isLastPage가 true일 때, IntersectionObserver 해제

### DIFF
--- a/frontend/src/hooks/review/useGetReviewList/index.ts
+++ b/frontend/src/hooks/review/useGetReviewList/index.ts
@@ -9,7 +9,7 @@ const useGetReviewList = () => {
     queryFn: ({ pageParam }) =>
       getReviewListApi({
         lastReviewId: pageParam === 0 ? null : pageParam, // 첫 api 요청 시, null 값 보내기
-        size: pageParam === 0 ? 10 : 5, // 첫 api 요청 시, 10개의 리뷰를 불러오고 그 이후로는 5개씩 불러온다.
+        size: 10,
       }),
 
     initialPageParam: 0,

--- a/frontend/src/mocks/handlers/review.ts
+++ b/frontend/src/mocks/handlers/review.ts
@@ -79,6 +79,7 @@ const getReviewList = (lastReviewId: number | null, size: number) => {
       revieweeName: REVIEW_LIST.revieweeName,
       projectName: REVIEW_LIST.projectName,
       lastReviewId: !isLastPage && lastReviewId !== null ? lastReviewId + size : null,
+      isLastPage: isLastPage,
       reviews: paginatedReviews,
     });
   });

--- a/frontend/src/mocks/mockData/reviewListMockData.ts
+++ b/frontend/src/mocks/mockData/reviewListMockData.ts
@@ -3,6 +3,7 @@ export const REVIEW_LIST: ReviewList = {
   revieweeName: '쑤쑤',
   projectName: 'review-me',
   lastReviewId: 12,
+  isLastPage: false,
   reviews: [
     {
       reviewId: 5,

--- a/frontend/src/pages/ReviewListPage/components/PageContents/index.tsx
+++ b/frontend/src/pages/ReviewListPage/components/PageContents/index.tsx
@@ -20,7 +20,12 @@ const PageContents = () => {
     paramKey: 'reviewRequestCode',
   });
 
-  const lastReviewElementRef = useInfiniteScroll({ fetchNextPage, hasNextPage, isLoading });
+  const lastReviewElementRef = useInfiniteScroll({
+    fetchNextPage,
+    hasNextPage,
+    isLoading,
+    isLastPage: data.pages[0].isLastPage,
+  });
 
   const handleReviewClick = (id: number) => {
     navigate(`/${ROUTE.detailedReview}/${reviewRequestCode}/${id}`);

--- a/frontend/src/pages/ReviewListPage/hooks/useInfiniteScroll.ts
+++ b/frontend/src/pages/ReviewListPage/hooks/useInfiniteScroll.ts
@@ -4,14 +4,15 @@ export interface InfiniteScrollProps {
   fetchNextPage: () => void;
   hasNextPage: boolean;
   isLoading: boolean;
+  isLastPage: boolean;
 }
 
-const useInfiniteScroll = ({ fetchNextPage, hasNextPage, isLoading }: InfiniteScrollProps) => {
+const useInfiniteScroll = ({ fetchNextPage, hasNextPage, isLoading, isLastPage }: InfiniteScrollProps) => {
   const observer = useRef<IntersectionObserver | null>(null);
 
   const lastElementRef = useCallback(
     (node: HTMLElement | null) => {
-      if (isLoading) return;
+      if (isLoading || isLastPage) return;
       if (observer.current) observer.current.disconnect();
 
       observer.current = new IntersectionObserver((entries) => {
@@ -22,7 +23,7 @@ const useInfiniteScroll = ({ fetchNextPage, hasNextPage, isLoading }: InfiniteSc
 
       if (node) observer.current.observe(node);
     },
-    [isLoading, fetchNextPage, hasNextPage],
+    [isLoading, fetchNextPage, hasNextPage, isLastPage],
   );
 
   return lastElementRef;

--- a/frontend/src/pages/ReviewWritingCompletePage/styles.ts
+++ b/frontend/src/pages/ReviewWritingCompletePage/styles.ts
@@ -12,20 +12,21 @@ export const Container = styled.div`
   left: 50%;
   transform: translate(-50%, -50%);
 
-  width: 100%;
-
   display: flex;
   flex-direction: column;
   gap: 3.5rem;
   align-items: center;
   justify-content: center;
+
+  width: 100%;
 `;
 
 export const ReviewComplete = styled.div`
   display: flex;
-  justify-content: center;
-  align-items: center;
   gap: 1rem;
+  align-items: center;
+  justify-content: center;
+
   width: 100%;
 
   img {
@@ -56,8 +57,8 @@ export const HomeIcon = styled.img`
 `;
 
 export const HomeText = styled.p`
-  margin-left: 0.5rem;
   height: 1.6rem;
+  margin-left: 0.5rem;
 
   ${media.xSmall} {
     height: 1.2rem;

--- a/frontend/src/pages/ReviewWritingPage/modals/components/AnswerListRecheckModal/index.tsx
+++ b/frontend/src/pages/ReviewWritingPage/modals/components/AnswerListRecheckModal/index.tsx
@@ -30,41 +30,43 @@ const AnswerListRecheckModal = ({ questionSectionList, answerMap, closeModal }: 
 
   return (
     <ContentModal handleClose={closeModal}>
-      <S.AnswerListContainer>
-        {questionSectionList.map((section) => (
-          <ReviewWritingCardLayout cardSection={section} key={section.sectionId}>
-            {section.questions.map((question) => (
-              <QnABoxLayout question={question} isNeedGuideLine={false} key={question.questionId}>
-                {question.questionType === 'CHECKBOX' && (
-                  <>
-                    {question.optionGroup?.options.map((option, index) => (
-                      <CheckboxItem
-                        key={`${question.questionId}_${index}`}
-                        id={`${question.questionId}_${index}`}
-                        name={`${question.questionId}_${index}`}
-                        isChecked={isSelectedChoice(question.questionId, option.optionId)}
-                        isDisabled={true}
-                        label={option.content}
-                        $isReadonly={true}
-                      />
-                    ))}
-                  </>
-                )}
+      <S.AnswerListModalContent>
+        <S.AnswerListContainer>
+          {questionSectionList.map((section) => (
+            <ReviewWritingCardLayout cardSection={section} key={section.sectionId}>
+              {section.questions.map((question) => (
+                <QnABoxLayout question={question} isNeedGuideLine={false} key={question.questionId}>
+                  {question.questionType === 'CHECKBOX' && (
+                    <>
+                      {question.optionGroup?.options.map((option, index) => (
+                        <CheckboxItem
+                          key={`${question.questionId}_${index}`}
+                          id={`${question.questionId}_${index}`}
+                          name={`${question.questionId}_${index}`}
+                          isChecked={isSelectedChoice(question.questionId, option.optionId)}
+                          isDisabled={true}
+                          label={option.content}
+                          $isReadonly={true}
+                        />
+                      ))}
+                    </>
+                  )}
 
-                {question.questionType === 'TEXT' && (
-                  <>
-                    {findTextAnswer(question.questionId) ? (
-                      <MultilineTextViewer text={findTextAnswer(question.questionId) as string} />
-                    ) : (
-                      <S.EmptyTextAnswer>작성한 답변이 없어요</S.EmptyTextAnswer>
-                    )}
-                  </>
-                )}
-              </QnABoxLayout>
-            ))}
-          </ReviewWritingCardLayout>
-        ))}
-      </S.AnswerListContainer>
+                  {question.questionType === 'TEXT' && (
+                    <>
+                      {findTextAnswer(question.questionId) ? (
+                        <MultilineTextViewer text={findTextAnswer(question.questionId) as string} />
+                      ) : (
+                        <S.EmptyTextAnswer>작성한 답변이 없어요</S.EmptyTextAnswer>
+                      )}
+                    </>
+                  )}
+                </QnABoxLayout>
+              ))}
+            </ReviewWritingCardLayout>
+          ))}
+        </S.AnswerListContainer>
+      </S.AnswerListModalContent>
     </ContentModal>
   );
 };

--- a/frontend/src/pages/ReviewWritingPage/modals/components/AnswerListRecheckModal/styles.ts
+++ b/frontend/src/pages/ReviewWritingPage/modals/components/AnswerListRecheckModal/styles.ts
@@ -2,6 +2,11 @@ import styled from '@emotion/styled';
 
 import media from '@/utils/media';
 
+export const AnswerListModalContent = styled.div`
+  width: 100%;
+  overflow-x: hidden;
+`;
+
 export const AnswerListContainer = styled.div`
   position: relative;
 

--- a/frontend/src/pages/ReviewWritingPage/modals/components/AnswerListRecheckModal/styles.ts
+++ b/frontend/src/pages/ReviewWritingPage/modals/components/AnswerListRecheckModal/styles.ts
@@ -3,8 +3,8 @@ import styled from '@emotion/styled';
 import media from '@/utils/media';
 
 export const AnswerListModalContent = styled.div`
-  width: 100%;
   overflow-x: hidden;
+  width: 100%;
 `;
 
 export const AnswerListContainer = styled.div`

--- a/frontend/src/types/review.ts
+++ b/frontend/src/types/review.ts
@@ -74,6 +74,7 @@ export interface ReviewList {
   revieweeName: string;
   projectName: string;
   lastReviewId: number | null;
+  isLastPage: boolean;
   reviews: ReviewInfo[];
 }
 


### PR DESCRIPTION
- resolves #736 

---

### 🚀 어떤 기능을 구현했나요 ?
- 서버로부터 isLastPage를 받아서 true일 경우 observer를 해제했습니다.
- 작성 내용 확인 모달에서 가로 스크롤을 숨겼습니다.

### 🔥 어떻게 해결했나요 ?
리뷰 목록 페이지에서 상세 페이지로 이동한 후 다시 목록 페이지로 돌아올 때, 동일한 리뷰가 중복으로 추가되는 오류가 있었습니다. 모든 리뷰를 다 받았음에도 불구하고 마지막 리뷰에 IntersectionObserver가 계속 달려서 발생한 문제로 파악됩니다.

이를 해결하기 위해 서버에서 isLastPage 값을 함께 보내주도록 수정했습니다. isLastPage가 true일 경우, 더 이상 추가적인 데이터를 불러오지 않도록 IntersectionObserver를 해제했습니다. 그리고 리뷰 요청 개수 size 디폴트값이 5가 아닌 10으로 변경되었습니다!!

### 문제 상황
https://github.com/user-attachments/assets/1eaf1b2c-0b8e-4561-bf37-2dc95057020e

### 작성 내용 확인 모달 가로 스크롤 숨기기
- `AnswerListContainer`를
 감싸는 `AnswerListModalContent`를 추가해서 `overflow-x: hidden`을 주었습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
- 화이팅...