### PR TITLE
[BE] fix: 리뷰 그룹 생성 요청 검증 `@NotEmpty`로 변경

### DIFF
--- a/backend/src/main/java/reviewme/reviewgroup/service/dto/ReviewGroupCreationRequest.java
+++ b/backend/src/main/java/reviewme/reviewgroup/service/dto/ReviewGroupCreationRequest.java
@@ -1,13 +1,14 @@
 package reviewme.reviewgroup.service.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 
 public record ReviewGroupCreationRequest(
 
-        @NotBlank(message = "리뷰이 이름을 입력해주세요.")
+        @NotEmpty(message = "리뷰이 이름을 입력해주세요.")
         String revieweeName,
 
-        @NotBlank(message = "프로젝트 이름을 입력해주세요.")
+        @NotEmpty(message = "프로젝트 이름을 입력해주세요.")
         String projectName,
 
         @NotBlank(message = "비밀번호를 입력해주세요.")


### PR DESCRIPTION

<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #743 

---

### 🚀 어떤 기능을 구현했나요 ?
- 리뷰 그룹 생성에서 리뷰이, 프로젝트 이름 검증 시 서비스에서 검증하도록, 요청 객체에서의 검증은 NotEmpty로 변경

### 🔥 어떻게 해결했나요 ?
- 리뷰 그룹 생성에서 리뷰이, 프로젝트 이름 검증 시 서비스에서 검증하도록, 요청 객체에서의 검증은 NotEmpty로 변경

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
