### PR TITLE
[BE] fix: 정렬 기준 추가

### DIFF
--- a/backend/src/main/java/reviewme/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/reviewme/review/repository/ReviewRepository.java
@@ -21,7 +21,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             SELECT r.* FROM review r
             WHERE r.review_group_id = :reviewGroupId
             AND (:lastReviewId IS NULL OR r.id < :lastReviewId)
-            ORDER BY r.created_at DESC 
+            ORDER BY r.created_at DESC, r.id DESC
             LIMIT :limit
             """, nativeQuery = true)
     List<Review> findByReviewGroupIdWithLimit(long reviewGroupId, Long lastReviewId, int limit);

--- a/backend/src/main/java/reviewme/review/service/mapper/ReviewListMapper.java
+++ b/backend/src/main/java/reviewme/review/service/mapper/ReviewListMapper.java
@@ -23,10 +23,10 @@ public class ReviewListMapper {
     private final ReviewPreviewGenerator reviewPreviewGenerator = new ReviewPreviewGenerator();
 
     public List<ReviewListElementResponse> mapToReviewList(ReviewGroup reviewGroup, Long lastReviewId, int size) {
-        List<OptionItem> categoryOptionIds = optionItemRepository.findAllByOptionType(OptionType.CATEGORY);
+        List<OptionItem> categoryOptionItems = optionItemRepository.findAllByOptionType(OptionType.CATEGORY);
         return reviewRepository.findByReviewGroupIdWithLimit(reviewGroup.getId(), lastReviewId, size)
                 .stream()
-                .map(review -> mapToReviewListElementResponse(review, categoryOptionIds))
+                .map(review -> mapToReviewListElementResponse(review, categoryOptionItems))
                 .toList();
     }
 

--- a/backend/src/test/java/reviewme/review/service/mapper/ReviewListMapperTest.java
+++ b/backend/src/test/java/reviewme/review/service/mapper/ReviewListMapperTest.java
@@ -1,0 +1,90 @@
+package reviewme.review.service.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static reviewme.fixture.QuestionFixture.선택형_필수_질문;
+import static reviewme.fixture.ReviewGroupFixture.리뷰_그룹;
+import static reviewme.fixture.SectionFixture.항상_보이는_섹션;
+import static reviewme.fixture.TemplateFixture.템플릿;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import reviewme.question.domain.Question;
+import reviewme.question.repository.QuestionRepository;
+import reviewme.review.domain.Review;
+import reviewme.review.domain.TextAnswer;
+import reviewme.review.repository.ReviewRepository;
+import reviewme.review.service.dto.response.list.ReviewListElementResponse;
+import reviewme.reviewgroup.domain.ReviewGroup;
+import reviewme.reviewgroup.repository.ReviewGroupRepository;
+import reviewme.support.ServiceTest;
+import reviewme.template.domain.Section;
+import reviewme.template.domain.Template;
+import reviewme.template.repository.SectionRepository;
+import reviewme.template.repository.TemplateRepository;
+
+@ServiceTest
+class ReviewListMapperTest {
+
+    @Autowired
+    private ReviewListMapper reviewListMapper;
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    @Autowired
+    private ReviewGroupRepository reviewGroupRepository;
+
+    @Autowired
+    private SectionRepository sectionRepository;
+
+    @Autowired
+    private TemplateRepository templateRepository;
+
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @Test
+    void 리뷰_그룹에_있는_리뷰를_반환() {
+        // given - 리뷰 그룹
+        ReviewGroup reviewGroup = reviewGroupRepository.save(리뷰_그룹());
+
+        // given - 질문 저장
+        Question question = questionRepository.save(선택형_필수_질문());
+
+        // given - 섹션, 템플릿 저장
+        Section section = sectionRepository.save(항상_보이는_섹션(List.of(question.getId())));
+        Template template = templateRepository.save(템플릿(List.of(section.getId())));
+
+        // given - 리뷰 답변 저장
+        TextAnswer textAnswer = new TextAnswer(question.getId(), "텍스트형 응답");
+        Review review1 = new Review(template.getId(), reviewGroup.getId(), List.of(textAnswer), List.of());
+        Review review2 = new Review(template.getId(), reviewGroup.getId(), List.of(textAnswer), List.of());
+        Review review3 = new Review(template.getId(), reviewGroup.getId(), List.of(textAnswer), List.of());
+        Review review4 = new Review(template.getId(), reviewGroup.getId(), List.of(textAnswer), List.of());
+        Review review5 = new Review(template.getId(), reviewGroup.getId(), List.of(textAnswer), List.of());
+        Review review6 = new Review(template.getId(), reviewGroup.getId(), List.of(textAnswer), List.of());
+        Review review7 = new Review(template.getId(), reviewGroup.getId(), List.of(textAnswer), List.of());
+        Review review8 = new Review(template.getId(), reviewGroup.getId(), List.of(textAnswer), List.of());
+        Review review9 = new Review(template.getId(), reviewGroup.getId(), List.of(textAnswer), List.of());
+        Review review10 = new Review(template.getId(), reviewGroup.getId(), List.of(textAnswer), List.of());
+        reviewRepository.saveAll(
+                List.of(review1, review2, review3, review4, review5, review6, review7, review8, review9, review10));
+
+        long lastReviewId = 8L;
+        int size = 5;
+
+        // when
+        List<ReviewListElementResponse> responses = reviewListMapper.mapToReviewList(
+                reviewGroup, lastReviewId, size);
+
+        // then
+        assertAll(
+                () -> assertThat(responses).hasSize(size),
+                () -> assertThat(responses).extracting(ReviewListElementResponse::reviewId)
+                        .containsExactly(
+                                review7.getId(), review6.getId(), review5.getId(), review4.getId(), review3.getId())
+        );
+    }
+}

--- a/backend/src/test/java/reviewme/review/service/mapper/ReviewListMapperTest.java
+++ b/backend/src/test/java/reviewme/review/service/mapper/ReviewListMapperTest.java
@@ -46,7 +46,7 @@ class ReviewListMapperTest {
     private ReviewRepository reviewRepository;
 
     @Test
-    void 리뷰_그룹에_있는_리뷰를_반환() {
+    void 리뷰_그룹에_있는_리뷰를_반환한다() {
         // given - 리뷰 그룹
         ReviewGroup reviewGroup = reviewGroupRepository.save(리뷰_그룹());
 


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #746 

---

### 🚀 어떤 기능을 구현했나요 ?
- 리뷰 목록 조회 시, 생성일이 동일한 중복된 경우, 중복된 데이터 중에서 랜덤으로 리스팅 하게 됩니다.
- 이 경우, lastReviewId 로 조건을 걸기 때문에 영영 나오지 않게 되는 리뷰가 생길 수 있습니다.
- 생성일이 중복된 경우 id를 기준으로 2차 정렬할 수 있도록 기준을 추가합니다.

### 🔥 어떻게 해결했나요 ?
- order by 2차 정렬 추가했습니다

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
