### PR TITLE
[FE] refactor: MSW 환경에서 무한 스크롤 API 응답을 서버와 통일하고, 빈 리뷰에 대한 옵저버 로직 개선

### DIFF
--- a/frontend/src/hooks/review/useGetReviewList/index.ts
+++ b/frontend/src/hooks/review/useGetReviewList/index.ts
@@ -19,9 +19,7 @@ const useGetReviewList = () => {
     staleTime: 1 * 60 * 1000,
   });
 
-  const hasNextPage = !result.data.pages.some((page) => page.reviews.length === 0);
-
-  return { ...result, hasNextPage };
+  return { ...result };
 };
 
 export default useGetReviewList;

--- a/frontend/src/hooks/review/useGetReviewList/index.ts
+++ b/frontend/src/hooks/review/useGetReviewList/index.ts
@@ -19,7 +19,9 @@ const useGetReviewList = () => {
     staleTime: 1 * 60 * 1000,
   });
 
-  return result;
+  const hasNextPage = !result.data.pages.some((page) => page.reviews.length === 0);
+
+  return { ...result, hasNextPage };
 };
 
 export default useGetReviewList;

--- a/frontend/src/mocks/handlers/review.ts
+++ b/frontend/src/mocks/handlers/review.ts
@@ -78,7 +78,7 @@ const getReviewList = (lastReviewId: number | null, size: number) => {
     return HttpResponse.json({
       revieweeName: REVIEW_LIST.revieweeName,
       projectName: REVIEW_LIST.projectName,
-      lastReviewId: !isLastPage && lastReviewId !== null ? lastReviewId + size : null,
+      lastReviewId: paginatedReviews.length > 0 ? paginatedReviews[paginatedReviews.length - 1].reviewId : 0,
       isLastPage: isLastPage,
       reviews: paginatedReviews,
     });

--- a/frontend/src/mocks/mockData/reviewListMockData.ts
+++ b/frontend/src/mocks/mockData/reviewListMockData.ts
@@ -2,7 +2,7 @@ import { ReviewList } from '@/types';
 export const REVIEW_LIST: ReviewList = {
   revieweeName: '쑤쑤',
   projectName: 'review-me',
-  lastReviewId: 12,
+  lastReviewId: 24,
   isLastPage: false,
   reviews: [
     {

--- a/frontend/src/pages/ReviewListPage/components/PageContents/index.tsx
+++ b/frontend/src/pages/ReviewListPage/components/PageContents/index.tsx
@@ -24,7 +24,6 @@ const PageContents = () => {
     fetchNextPage,
     hasNextPage,
     isLoading,
-    isLastPage: data.pages[0].isLastPage,
   });
 
   const handleReviewClick = (id: number) => {

--- a/frontend/src/pages/ReviewListPage/components/PageContents/index.tsx
+++ b/frontend/src/pages/ReviewListPage/components/PageContents/index.tsx
@@ -14,16 +14,10 @@ import * as S from './styles';
 const PageContents = () => {
   const navigate = useNavigate();
 
-  const { data, fetchNextPage, hasNextPage, isLoading, isSuccess } = useGetReviewList();
+  const { data, fetchNextPage, isLoading, isSuccess } = useGetReviewList();
 
   const { param: reviewRequestCode } = useSearchParamAndQuery({
     paramKey: 'reviewRequestCode',
-  });
-
-  const lastReviewElementRef = useInfiniteScroll({
-    fetchNextPage,
-    hasNextPage,
-    isLoading,
   });
 
   const handleReviewClick = (id: number) => {
@@ -31,7 +25,14 @@ const PageContents = () => {
   };
 
   const { projectName, revieweeName } = data.pages[0];
+  const isLastPage = data.pages[data.pages.length - 1].isLastPage;
   const reviews = data.pages.flatMap((page) => page.reviews);
+
+  const lastReviewElementRef = useInfiniteScroll({
+    fetchNextPage,
+    isLoading,
+    isLastPage,
+  });
 
   return (
     isSuccess && (

--- a/frontend/src/pages/ReviewListPage/hooks/useInfiniteScroll.ts
+++ b/frontend/src/pages/ReviewListPage/hooks/useInfiniteScroll.ts
@@ -4,15 +4,14 @@ export interface InfiniteScrollProps {
   fetchNextPage: () => void;
   hasNextPage: boolean;
   isLoading: boolean;
-  isLastPage: boolean;
 }
 
-const useInfiniteScroll = ({ fetchNextPage, hasNextPage, isLoading, isLastPage }: InfiniteScrollProps) => {
+const useInfiniteScroll = ({ fetchNextPage, hasNextPage, isLoading }: InfiniteScrollProps) => {
   const observer = useRef<IntersectionObserver | null>(null);
 
   const lastElementRef = useCallback(
     (node: HTMLElement | null) => {
-      if (isLoading || isLastPage) return;
+      if (isLoading) return;
       if (observer.current) observer.current.disconnect();
 
       observer.current = new IntersectionObserver((entries) => {
@@ -23,7 +22,7 @@ const useInfiniteScroll = ({ fetchNextPage, hasNextPage, isLoading, isLastPage }
 
       if (node) observer.current.observe(node);
     },
-    [isLoading, fetchNextPage, hasNextPage, isLastPage],
+    [isLoading, fetchNextPage, hasNextPage],
   );
 
   return lastElementRef;

--- a/frontend/src/pages/ReviewListPage/hooks/useInfiniteScroll.ts
+++ b/frontend/src/pages/ReviewListPage/hooks/useInfiniteScroll.ts
@@ -2,11 +2,11 @@ import { useCallback, useRef } from 'react';
 
 export interface InfiniteScrollProps {
   fetchNextPage: () => void;
-  hasNextPage: boolean;
   isLoading: boolean;
+  isLastPage: boolean;
 }
 
-const useInfiniteScroll = ({ fetchNextPage, hasNextPage, isLoading }: InfiniteScrollProps) => {
+const useInfiniteScroll = ({ fetchNextPage, isLoading, isLastPage }: InfiniteScrollProps) => {
   const observer = useRef<IntersectionObserver | null>(null);
 
   const lastElementRef = useCallback(
@@ -15,14 +15,14 @@ const useInfiniteScroll = ({ fetchNextPage, hasNextPage, isLoading }: InfiniteSc
       if (observer.current) observer.current.disconnect();
 
       observer.current = new IntersectionObserver((entries) => {
-        if (entries[0].isIntersecting && hasNextPage) {
+        if (entries[0].isIntersecting && !isLastPage) {
           fetchNextPage();
         }
       });
 
       if (node) observer.current.observe(node);
     },
-    [isLoading, fetchNextPage, hasNextPage],
+    [isLoading, fetchNextPage, isLastPage],
   );
 
   return lastElementRef;


### PR DESCRIPTION
- resolves #752 

---

### 🚀 어떤 기능을 구현했나요 ?
- 기존에는 MSW 환경에서의 API 응답 방식이 서버에서 보내주는 응답 방식과 달라서 MSW환경에서는 제대로 무한 스크롤 기능이 작동하는데, 서버와 직접적으로 연동하면 작동하지 않는 문제가 있었습니다. 이 문제를 해결하기 위해, 서버와 MSW 간의 응답 방식을 통일하고, 무한 스크롤 시 더 이상 받은 리뷰가 없을 때 hasNextPage를 false로 반환하도록 수정했습니다.

### 🔥 어떻게 해결했나요 ?


기존에는 msw 핸들러에서 마지막 페이지가 아니고 lastReviewId가 null이 아닐 때, lastReviewId에 size를 더해주고 그러지 않을 경우 null을 반환하는 방식이었습니다. 그러나 서버에서는 lastReviewId에 null을 넣지 않으므로, 수정된 로직에서는 리뷰가 빈 배열이 아닐 경우, lastReviewId에 마지막 리뷰 id를 넣고, 그렇지 않으면 0을 넣도록 수정했습니다.


```tsx
// mocks/handlers/review.ts
// 수정 전
lastReviewId: !isLastPage && lastReviewId !== null ? lastReviewId + size : null

// 수정 후
lastReviewId: paginatedReviews.length > 0 ? paginatedReviews[paginatedReviews.length - 1].reviewId : 0
```


참고로 서버에서는 무한 스크롤 시, 리뷰가 더이상 없을 경우, lastReviewId에 0을 넣어서 보내줍니다.
![스크린샷 2024-09-28 오후 3 00 42](https://github.com/user-attachments/assets/0260f749-a65c-4c50-8d43-87a4bf1c92df)




useInfiniteScroll의 IntersectionObserver 로직에서 isLastPage를 사용하여 옵저버를 해제하는 방식이 아닌 useGetReviewList 훅에서 hasNextPage를 계산해서 보내주는 방식으로 변경했습니다. 받은 리뷰가 더이상 없을 경우 즉, 빈 배열일 경우 hasNextPage를 false로 설정해서 useInfiniteScroll에서 fetchNextPage가 실행되지 않도록 수정했습니다.

```tsx
const useGetReviewList = () => {
  // ...

  const hasNextPage = !result.data.pages.some((page) => page.reviews.length === 0);

  return { ...result, hasNextPage };
};
```

```tsx
const useInfiniteScroll = ({ fetchNextPage, hasNextPage, isLoading }: InfiniteScrollProps) => {
  const observer = useRef<IntersectionObserver | null>(null);

  const lastElementRef = useCallback(
    // ...

      observer.current = new IntersectionObserver((entries) => {
        if (entries[0].isIntersecting && hasNextPage) { // hasNextPage 추가
          fetchNextPage();
        }
      });

      if (node) observer.current.observe(node);
    },
    [isLoading, fetchNextPage, hasNextPage],
  );

  return lastElementRef;
};
```

## ⭐️ 방식 변경 => isLastPage를 활용한 무한 스크롤 구현 ⭐️

위 방식인 hasNextPage를 계산해서 보내주는 방식이 아닌 서버에서 보내주는 isLastPage를 활용하는 방식으로 변경했습니다.

서버에서 보내주는 isLastPage 값을 활용해서 옵저버를 해제하는 방식으로 수정했습니다. 기존에 문제가 발생했던 이유는, 첫 번째 페이지의 isLastPage 값을 사용하면서 항상 false를 넘겨주고 있었기 때문에 옵저버가 해제되지 않고 계속해서 페이지를 요청하게 되는 상황이 발생했습니다. 이를 마지막으로 받은 페이지의 isLastPage 값을 기반으로 하여 옵저버를 해제하도록 해서 문제를 해결했습니다.

```tsx
  const isLastPage = data.pages[data.pages.length - 1].isLastPage;
```


### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- msw 환경에서 살짝 과장 보태서 백만번 확인해봤습니다..... 그래도 한번씩 확인 부탁드립니다....

### 📚 참고 자료, 할 말
무한스크롤_최최최최최최최종