### PR TITLE
[FE] design: CardForm의 시작 위치를 고정

### DIFF
--- a/frontend/src/pages/ReviewWritingPage/form/components/CardForm/styles.ts
+++ b/frontend/src/pages/ReviewWritingPage/form/components/CardForm/styles.ts
@@ -4,14 +4,19 @@ import media from '@/utils/media';
 
 export const CardFormContainer = styled.div`
   position: relative;
+
+  display: flex;
+  align-items: start;
+
   width: fit-content;
   min-width: ${({ theme }) => theme.formWidth};
   max-width: 90rem;
+  min-height: inherit;
+  padding-top: 3rem;
 
   ${media.medium} {
     width: 80vw;
     min-width: initial;
-    margin-top: 2.4rem;
   }
 
   @media screen and (max-width: 500px) {


### PR DESCRIPTION


- resolves #753

---

### 🚀 해결하려는 오류
#### 질문폼 길이에 따라 질문폼 시작위치가 변경되는 오류 
시작위치가 변경되다보니 LayoutShift가 일어난다는 점, 그로 인해 리뷰를 작성하는 리뷰어의 시각적 피로도가 있을 거라는 점이 우려되었어요. 
https://github.com/user-attachments/assets/162c5164-51d4-4070-af22-95be8dbe3aeb

### 🔥 어떻게 해결했나요 ?
` align-items: start`를 사용해, 데스크탑과 모바일 모두 질문폼의 시작위치를 위쪽으로 고정했어요.

https://github.com/user-attachments/assets/8f57d3d7-2c40-4306-91f3-e8b93e946cac

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?


### 📚 참고 자료, 할 말
- 해당 오류 발견해준 올리 감사요!!