### PR TITLE
[BE] fix: ID 생성 전략을 IDENTITY로 설정

### DIFF
--- a/backend/src/main/java/reviewme/review/domain/abstraction/Answer.java
+++ b/backend/src/main/java/reviewme/review/domain/abstraction/Answer.java
@@ -22,7 +22,7 @@ import lombok.NoArgsConstructor;
 public abstract class Answer {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.TABLE)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     protected Long id;
 
     @Column(name = "question_id", nullable = false)


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

테이블 생성 전략이 `TABLE`이었는데, 이렇게 되면 하이버네이트 내부에서 `hibernate_sequence` 테이블을 암시적으로 생성합니다. 왜 이때는 `TABLE`로 했는지 모르겠는데 `IDENTITY`로도 충분할 듯해요.

<img width="488" alt="image" src="https://github.com/user-attachments/assets/6dfeddd1-86ed-4633-abb1-50e1ffce9ba9">

스키마 밸리데이션 실패 (`hibernate_sequence`가 어플리케이션에서는 존재하나 데이터베이스에는 존재하지 않음)