### PR TITLE
[BE] fix: Flyway Auto Increment 설정 수정

### DIFF
--- a/backend/src/main/resources/db/migration/V2__answer_abstraction.sql
+++ b/backend/src/main/resources/db/migration/V2__answer_abstraction.sql
@@ -44,11 +44,10 @@ CREATE TABLE new_checkbox_answer_selected_option
 );
 
 -- MYSQL에서는 아래와 같이 초기화합니다.
-ALTER TABLE new_review
-    AUTO_INCREMENT = 1500000;
-ALTER TABLE new_checkbox_answer
-    AUTO_INCREMENT = 1500000;
-ALTER TABLE new_text_answer
-    AUTO_INCREMENT = 1500000;
-ALTER TABLE new_checkbox_answer_selected_option
-    AUTO_INCREMENT = 1500000;
+-- 아래 두 테이블은 Answer의 ID를 따라가므로, 조절할 필요가 없습니다.
+-- ALTER TABLE new_checkbox_answer AUTO_INCREMENT = 1500000;
+-- ALTER TABLE new_text_answer AUTO_INCREMENT = 1500000;
+
+ALTER TABLE answer AUTO_INCREMENT = 1500000;
+ALTER TABLE new_review AUTO_INCREMENT = 1500000;
+ALTER TABLE new_checkbox_answer_selected_option AUTO_INCREMENT = 1500000;


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

험난한 마이그레이션...

<img width="529" alt="image" src="https://github.com/user-attachments/assets/0ab3a339-e0a1-44f6-9c1f-224d7c1aa3c6">

Answer 자체는 새로 들어오는 테이블이라서 따로 ID 설정을 안 해도 될 줄 알았는데요, Answer를 상속받는 친구들이 자신의 ID를 Answer의 ID로 가지게 됩니다. 따라서 Answer의 값만을 변경해주면 되어요. (new_answer_*의 auto_increment가 변경되지 않음 -> answer를 따라감)

Dev 환경의 새로 만들어진 Flyway 행, 테이블은 삭제할 예정이예요