### PR TITLE
[BE] feat: 섹션 이름 조회 API 구현

### DIFF
--- a/backend/src/main/java/reviewme/template/domain/Section.java
+++ b/backend/src/main/java/reviewme/template/domain/Section.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -33,7 +34,7 @@ public class Section {
     @Enumerated(EnumType.STRING)
     private VisibleType visibleType;
 
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "section_id", nullable = false, updatable = false)
     private List<SectionQuestion> questionIds;
 

--- a/backend/src/main/java/reviewme/template/domain/Section.java
+++ b/backend/src/main/java/reviewme/template/domain/Section.java
@@ -5,7 +5,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -34,7 +33,7 @@ public class Section {
     @Enumerated(EnumType.STRING)
     private VisibleType visibleType;
 
-    @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "section_id", nullable = false, updatable = false)
     private List<SectionQuestion> questionIds;
 

--- a/backend/src/main/java/reviewme/template/service/SectionService.java
+++ b/backend/src/main/java/reviewme/template/service/SectionService.java
@@ -1,16 +1,33 @@
 package reviewme.template.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import reviewme.review.service.exception.ReviewGroupNotFoundByReviewRequestCodeException;
+import reviewme.reviewgroup.domain.ReviewGroup;
+import reviewme.reviewgroup.repository.ReviewGroupRepository;
+import reviewme.template.repository.SectionRepository;
+import reviewme.template.service.dto.response.SectionNameResponse;
 import reviewme.template.service.dto.response.SectionNamesResponse;
 
 @Service
 @RequiredArgsConstructor
 public class SectionService {
 
+    private final ReviewGroupRepository reviewGroupRepository;
+    private final SectionRepository sectionRepository;
+
     @Transactional(readOnly = true)
     public SectionNamesResponse getSectionNames(String reviewRequestCode) {
-        return null;
+        ReviewGroup reviewGroup = reviewGroupRepository.findByReviewRequestCode(reviewRequestCode)
+                .orElseThrow(() -> new ReviewGroupNotFoundByReviewRequestCodeException(reviewRequestCode));
+
+        List<SectionNameResponse> sectionNameResponses = sectionRepository.findAllByTemplateId(reviewGroup.getTemplateId())
+                .stream()
+                .map(section -> new SectionNameResponse(section.getId(), section.getSectionName()))
+                .toList();
+
+        return new SectionNamesResponse(sectionNameResponses);
     }
 }

--- a/backend/src/test/java/reviewme/template/service/SectionServiceTest.java
+++ b/backend/src/test/java/reviewme/template/service/SectionServiceTest.java
@@ -37,12 +37,16 @@ class SectionServiceTest {
     @Test
     void 템플릿에_있는_섹션_이름_목록을_응답한다() {
         // given
+        String sectionName1 = "섹션1";
+        String sectionName2 = "섹션2";
+        String sectionName3 = "섹션3";
+
         Section visibleSection1 = sectionRepository.save(
-                new Section(VisibleType.ALWAYS, List.of(1L), null, "섹션1", "헤더", 1));
+                new Section(VisibleType.ALWAYS, List.of(1L), null, sectionName1, "헤더", 1));
         Section visibleSection2 = sectionRepository.save(
-                new Section(VisibleType.ALWAYS, List.of(2L), null, "섹션2", "헤더", 2));
+                new Section(VisibleType.ALWAYS, List.of(2L), null, sectionName2, "헤더", 2));
         Section nonVisibleSection = sectionRepository.save(
-                new Section(VisibleType.CONDITIONAL, List.of(1L), 1L, "섹션3", "헤더", 3));
+                new Section(VisibleType.CONDITIONAL, List.of(1L), 1L, sectionName3, "헤더", 3));
         templateRepository.save(
                 템플릿(List.of(nonVisibleSection.getId(), visibleSection2.getId(), visibleSection1.getId())));
 
@@ -53,8 +57,7 @@ class SectionServiceTest {
 
         // then
         assertThat(actual.sections()).extracting(SectionNameResponse::name)
-                .containsExactly(visibleSection1.getSectionName(), visibleSection2.getSectionName(),
-                        nonVisibleSection.getSectionName());
+                .containsExactly(sectionName1, sectionName2, sectionName3);
     }
 
     @Test

--- a/backend/src/test/java/reviewme/template/service/SectionServiceTest.java
+++ b/backend/src/test/java/reviewme/template/service/SectionServiceTest.java
@@ -1,0 +1,68 @@
+package reviewme.template.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static reviewme.fixture.ReviewGroupFixture.리뷰_그룹;
+import static reviewme.fixture.SectionFixture.조건부로_보이는_섹션;
+import static reviewme.fixture.SectionFixture.항상_보이는_섹션;
+import static reviewme.fixture.TemplateFixture.템플릿;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import reviewme.review.service.exception.ReviewGroupNotFoundByReviewRequestCodeException;
+import reviewme.reviewgroup.domain.ReviewGroup;
+import reviewme.reviewgroup.repository.ReviewGroupRepository;
+import reviewme.support.ServiceTest;
+import reviewme.template.domain.Section;
+import reviewme.template.domain.Template;
+import reviewme.template.repository.SectionRepository;
+import reviewme.template.repository.TemplateRepository;
+import reviewme.template.service.dto.response.SectionNameResponse;
+import reviewme.template.service.dto.response.SectionNamesResponse;
+
+@ServiceTest
+class SectionServiceTest {
+
+    @Autowired
+    private SectionService sectionService;
+
+    @Autowired
+    private ReviewGroupRepository reviewGroupRepository;
+
+    @Autowired
+    private TemplateRepository templateRepository;
+
+    @Autowired
+    private SectionRepository sectionRepository;
+
+    @Test
+    void 템플릿에_있는_섹션_이름_목록을_응답한다() {
+        // given
+        Section visibleSection1 = sectionRepository.save(항상_보이는_섹션(List.of(1L), 1));
+        Section visibleSection2 = sectionRepository.save(항상_보이는_섹션(List.of(2L), 2));
+        Section nonVisibleSection = sectionRepository.save(조건부로_보이는_섹션(List.of(3L), 1L, 3));
+        Template template = templateRepository.save(템플릿(
+                List.of(nonVisibleSection.getId(), visibleSection2.getId(), visibleSection1.getId())));
+
+        ReviewGroup reviewGroup = reviewGroupRepository.save(리뷰_그룹());
+
+        // when
+        SectionNamesResponse actual = sectionService.getSectionNames(reviewGroup.getReviewRequestCode());
+
+        // then
+        assertThat(actual.sections()).extracting(SectionNameResponse::id)
+                .containsExactly(visibleSection1.getId(), visibleSection2.getId(), nonVisibleSection.getId());
+    }
+
+    @Test
+    void 템플릿에_있는_섹션_이름_목록_조회시_리뷰_요청_코드가_존재하지_않는_경우_예외가_발생한다() {
+        // given
+        ReviewGroup reviewGroup = reviewGroupRepository.save(리뷰_그룹());
+
+        // when, then
+        assertThatThrownBy(() -> sectionService.getSectionNames(
+                reviewGroup.getReviewRequestCode() + "wrong"))
+                .isInstanceOf(ReviewGroupNotFoundByReviewRequestCodeException.class);
+    }
+}


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #797 

---

### 🚀 어떤 기능을 구현했나요 ?
- 섹션 조회 이름 목록을 응답하는 API를 구현했습니다.

### 🔥 어떻게 해결했나요 ?
- `/v2/sections` 에 대한 응답으로 리뷰 답변과 상관 없이 모든 섹션 이름을 응답합니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
