### PR TITLE
[BE] feat: 리뷰 모아보기 API 구현

### DIFF
--- a/backend/src/main/java/reviewme/question/repository/OptionItemRepository.java
+++ b/backend/src/main/java/reviewme/question/repository/OptionItemRepository.java
@@ -25,4 +25,14 @@ public interface OptionItemRepository extends JpaRepository<OptionItem, Long> {
             WHERE og.question_id IN (:questionIds)
             """, nativeQuery = true)
     List<OptionItem> findAllByQuestionIds(List<Long> questionIds);
+
+    @Query(value = """
+        SELECT o.* FROM option_item o
+        JOIN option_group og
+        ON o.option_group_id = og.id
+        JOIN question q
+        ON og.question_id = q.id
+        WHERE q.id = :questionId
+    """, nativeQuery = true)
+    List<OptionItem> findAllByQuestionId(long questionId);
 }

--- a/backend/src/main/java/reviewme/question/repository/OptionItemRepository.java
+++ b/backend/src/main/java/reviewme/question/repository/OptionItemRepository.java
@@ -25,14 +25,4 @@ public interface OptionItemRepository extends JpaRepository<OptionItem, Long> {
             WHERE og.question_id IN (:questionIds)
             """, nativeQuery = true)
     List<OptionItem> findAllByQuestionIds(List<Long> questionIds);
-
-    @Query(value = """
-        SELECT o.* FROM option_item o
-        JOIN option_group og
-        ON o.option_group_id = og.id
-        JOIN question q
-        ON og.question_id = q.id
-        WHERE q.id = :questionId
-    """, nativeQuery = true)
-    List<OptionItem> findAllByQuestionId(long questionId);
 }

--- a/backend/src/main/java/reviewme/question/repository/QuestionRepository.java
+++ b/backend/src/main/java/reviewme/question/repository/QuestionRepository.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import reviewme.question.domain.OptionItem;
 import reviewme.question.domain.Question;
 
 @Repository
@@ -41,4 +42,11 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
             WHERE sq.section_id = :sectionId AND rg.review_request_code =:reviewRequestCode
             """, nativeQuery = true)
     List<Question> findAllByReviewRequestCodeAndSectionId(String reviewRequestCode, long sectionId);
+
+    @Query("""
+        SELECT o FROM OptionItem o
+        JOIN OptionGroup og ON o.optionGroupId = og.id
+        WHERE og.questionId = :questionId
+        """)
+    List<OptionItem> findAllOptionItemsById(long questionId);
 }

--- a/backend/src/main/java/reviewme/question/repository/QuestionRepository.java
+++ b/backend/src/main/java/reviewme/question/repository/QuestionRepository.java
@@ -35,8 +35,9 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
             SELECT q FROM Question q
             JOIN SectionQuestion sq ON q.id = sq.questionId
             WHERE sq.sectionId = :sectionId
+            ORDER BY q.position
             """)
-    List<Question> findAllBySectionId(long sectionId);
+    List<Question> findAllBySectionIdOrderByPosition(long sectionId);
 
     @Query("""
             SELECT o FROM OptionItem o

--- a/backend/src/main/java/reviewme/question/repository/QuestionRepository.java
+++ b/backend/src/main/java/reviewme/question/repository/QuestionRepository.java
@@ -34,7 +34,6 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
     @Query(value = """
             SELECT q FROM Question q
             JOIN SectionQuestion sq ON q.id = sq.questionId
-            JOIN TemplateSection ts ON sq.sectionId = ts.sectionId
             WHERE sq.sectionId = :sectionId
             """)
     List<Question> findAllBySectionId(long sectionId);

--- a/backend/src/main/java/reviewme/question/repository/QuestionRepository.java
+++ b/backend/src/main/java/reviewme/question/repository/QuestionRepository.java
@@ -32,21 +32,17 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
     List<Question> findAllByTemplatedId(long templateId);
 
     @Query(value = """
-            SELECT q.* FROM question q
-            JOIN section_question sq 
-            ON q.id = sq.question_id
-            JOIN template_section ts 
-            ON sq.section_id = ts.section_id
-            JOIN review_group rg 
-            ON rg.template_id = ts.template_id
-            WHERE sq.section_id = :sectionId AND rg.review_request_code =:reviewRequestCode
-            """, nativeQuery = true)
-    List<Question> findAllByReviewRequestCodeAndSectionId(String reviewRequestCode, long sectionId);
+            SELECT q FROM Question q
+            JOIN SectionQuestion sq ON q.id = sq.questionId
+            JOIN TemplateSection ts ON sq.sectionId = ts.sectionId
+            WHERE sq.sectionId = :sectionId
+            """)
+    List<Question> findAllBySectionId(long sectionId);
 
     @Query("""
-        SELECT o FROM OptionItem o
-        JOIN OptionGroup og ON o.optionGroupId = og.id
-        WHERE og.questionId = :questionId
-        """)
+            SELECT o FROM OptionItem o
+            JOIN OptionGroup og ON o.optionGroupId = og.id
+            WHERE og.questionId = :questionId
+            """)
     List<OptionItem> findAllOptionItemsById(long questionId);
 }

--- a/backend/src/main/java/reviewme/question/repository/QuestionRepository.java
+++ b/backend/src/main/java/reviewme/question/repository/QuestionRepository.java
@@ -4,8 +4,10 @@ import java.util.List;
 import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 import reviewme.question.domain.Question;
 
+@Repository
 public interface QuestionRepository extends JpaRepository<Question, Long> {
 
     @Query(value = """
@@ -27,4 +29,16 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
             WHERE ts.template_id = :templateId
             """, nativeQuery = true)
     List<Question> findAllByTemplatedId(long templateId);
+
+    @Query(value = """
+            SELECT q.* FROM question q
+            JOIN section_question sq 
+            ON q.id = sq.question_id
+            JOIN template_section ts 
+            ON sq.section_id = ts.section_id
+            JOIN review_group rg 
+            ON rg.template_id = ts.template_id
+            WHERE sq.section_id = :sectionId AND rg.review_request_code =:reviewRequestCode
+            """, nativeQuery = true)
+    List<Question> findAllByReviewRequestCodeAndSectionId(String reviewRequestCode, long sectionId);
 }

--- a/backend/src/main/java/reviewme/question/repository/QuestionRepository.java
+++ b/backend/src/main/java/reviewme/question/repository/QuestionRepository.java
@@ -43,6 +43,7 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
             SELECT o FROM OptionItem o
             JOIN OptionGroup og ON o.optionGroupId = og.id
             WHERE og.questionId = :questionId
+            ORDER BY o.position
             """)
-    List<OptionItem> findAllOptionItemsById(long questionId);
+    List<OptionItem> findAllOptionItemsByIdOrderByPosition(long questionId);
 }

--- a/backend/src/main/java/reviewme/review/controller/ReviewController.java
+++ b/backend/src/main/java/reviewme/review/controller/ReviewController.java
@@ -68,7 +68,7 @@ public class ReviewController {
 
     @GetMapping("/v2/reviews/gather")
     public ResponseEntity<ReviewsGatheredBySectionResponse> getReceivedReviewsBySectionId(
-            @RequestParam("sectionId") Long sectionId,
+            @RequestParam("sectionId") long sectionId,
             @SessionAttribute("reviewRequestCode") String reviewRequestCode
     ) {
         ReviewsGatheredBySectionResponse response = reviewGatheredLookupService.getReceivedReviewsBySectionId(

--- a/backend/src/main/java/reviewme/review/controller/ReviewController.java
+++ b/backend/src/main/java/reviewme/review/controller/ReviewController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.SessionAttribute;
-import reviewme.review.service.GatheredReviewLookupService;
+import reviewme.review.service.ReviewGatheredLookupService;
 import reviewme.review.service.ReviewDetailLookupService;
 import reviewme.review.service.ReviewListLookupService;
 import reviewme.review.service.ReviewRegisterService;
@@ -30,7 +30,7 @@ public class ReviewController {
     private final ReviewListLookupService reviewListLookupService;
     private final ReviewDetailLookupService reviewDetailLookupService;
     private final ReviewSummaryService reviewSummaryService;
-    private final GatheredReviewLookupService gatheredReviewLookupService;
+    private final ReviewGatheredLookupService reviewGatheredLookupService;
 
     @PostMapping("/v2/reviews")
     public ResponseEntity<Void> createReview(@Valid @RequestBody ReviewRegisterRequest request) {
@@ -71,7 +71,7 @@ public class ReviewController {
             @RequestParam("sectionId") Long sectionId,
             @SessionAttribute("reviewRequestCode") String reviewRequestCode
     ) {
-        ReviewsGatheredBySectionResponse response = gatheredReviewLookupService.getReceivedReviewsBySectionId(
+        ReviewsGatheredBySectionResponse response = reviewGatheredLookupService.getReceivedReviewsBySectionId(
                 reviewRequestCode, sectionId);
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/reviewme/review/repository/AnswerRepository.java
+++ b/backend/src/main/java/reviewme/review/repository/AnswerRepository.java
@@ -21,46 +21,12 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
     List<Answer> findReceivedAnswersByQuestionIds(long reviewGroupId, Collection<Long> questionIds, int limit);
 
     @Query(value = """
-            SELECT a FROM Answer a
-            JOIN Review r ON a.reviewId = r.id
-            WHERE r.reviewGroupId = :reviewGroupId AND a.questionId IN :questionIds
-            ORDER BY r.createdAt DESC
-            """)
-    List<Answer> findReceivedAnswersByQuestionIdsOrderByCreatedAtDesc(long reviewGroupId, Collection<Long> questionIds);
-
-    @Query(value = """
-            SELECT a FROM Answer a
-            JOIN Review r ON a.reviewId = r.id
-            WHERE r.reviewGroupId = :reviewGroupId AND a.questionId IN :questionIds
-            """)
-    List<Answer> findReceivedAnswersByQuestionIds(long reviewGroupId, Collection<Long> questionIds);
-
-    @Query(value = """
-            SELECT a FROM Answer a
-            JOIN Review r ON a.reviewId = r.id
-            WHERE r.reviewGroupId = :reviewGroupId AND a.questionId IN :questionIds
-            """)
-    List<Answer> findReceivedAnswersByQuestionIds(long reviewGroupId, List<Long> questionIds);
-
-    @Query(value = """
-            SELECT a FROM Answer a
-            WHERE a.questionId IN :questionIds
-            """)
-    List<Answer> findAllByQuestionIds(List<Long> questionIds);
-
-    @Query(value = """
             SELECT a.id FROM Answer a
             JOIN Review r
             ON a.reviewId = r.id
             WHERE r.reviewGroupId = :reviewGroupId
             """)
     Set<Long> findIdsByReviewGroupId(long reviewGroupId);
-
-    @Query(value = """
-            SELECT a FROM Answer a
-            WHERE a.questionId IN :questionIds
-            """)
-    List<Answer> findAllByQuestions(List<Long> questionIds);
 
     @Query(value = """
             SELECT a FROM Answer a
@@ -72,9 +38,7 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
 
     @Query(value = """
             SELECT a.id FROM Answer a
-            JOIN Question q
-            ON a.questionId = q.id
-            WHERE q.id = :questionId
+            WHERE a.questionId = :questionId
             """)
     Set<Long> findIdsByQuestionId(long questionId);
 }

--- a/backend/src/main/java/reviewme/review/repository/AnswerRepository.java
+++ b/backend/src/main/java/reviewme/review/repository/AnswerRepository.java
@@ -1,5 +1,6 @@
 package reviewme.review.repository;
 
+import java.util.List;
 import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -16,6 +17,12 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
             WHERE r.reviewGroupId = :reviewGroupId
             """)
     Set<Long> findIdsByReviewGroupId(long reviewGroupId);
+
+    @Query(value = """
+            SELECT a FROM Answer a
+            WHERE a.questionId IN :questionIds
+            """)
+    List<Answer> findAllByQuestions(List<Long> questionIds);
 
     @Query(value = """
             SELECT a FROM Answer a

--- a/backend/src/main/java/reviewme/review/repository/AnswerRepository.java
+++ b/backend/src/main/java/reviewme/review/repository/AnswerRepository.java
@@ -16,6 +16,15 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
             JOIN Review r ON a.reviewId = r.id
             WHERE r.reviewGroupId = :reviewGroupId AND a.questionId IN :questionIds
             ORDER BY r.createdAt DESC
+            LIMIT :limit
+            """)
+    List<Answer> findReceivedAnswersByQuestionIds(long reviewGroupId, Collection<Long> questionIds, int limit);
+
+    @Query(value = """
+            SELECT a FROM Answer a
+            JOIN Review r ON a.reviewId = r.id
+            WHERE r.reviewGroupId = :reviewGroupId AND a.questionId IN :questionIds
+            ORDER BY r.createdAt DESC
             """)
     List<Answer> findReceivedAnswersByQuestionIdsOrderByCreatedAtDesc(long reviewGroupId, Collection<Long> questionIds);
 

--- a/backend/src/main/java/reviewme/review/repository/AnswerRepository.java
+++ b/backend/src/main/java/reviewme/review/repository/AnswerRepository.java
@@ -12,6 +12,13 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
 
     @Query(value = """
             SELECT a FROM Answer a
+            JOIN Review r ON a.reviewId = r.id
+            WHERE r.reviewGroupId = :reviewGroupId AND a.questionId IN :questionIds
+            """)
+    List<Answer> findReceivedAnswersByQuestionIds(long reviewGroupId, List<Long> questionIds);
+
+    @Query(value = """
+            SELECT a FROM Answer a
             WHERE a.questionId IN :questionIds
             """)
     List<Answer> findAllByQuestionIds(List<Long> questionIds);

--- a/backend/src/main/java/reviewme/review/repository/AnswerRepository.java
+++ b/backend/src/main/java/reviewme/review/repository/AnswerRepository.java
@@ -15,6 +15,14 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
             SELECT a FROM Answer a
             JOIN Review r ON a.reviewId = r.id
             WHERE r.reviewGroupId = :reviewGroupId AND a.questionId IN :questionIds
+            ORDER BY r.createdAt DESC
+            """)
+    List<Answer> findReceivedAnswersByQuestionIdsOrderByCreatedAtDesc(long reviewGroupId, Collection<Long> questionIds);
+
+    @Query(value = """
+            SELECT a FROM Answer a
+            JOIN Review r ON a.reviewId = r.id
+            WHERE r.reviewGroupId = :reviewGroupId AND a.questionId IN :questionIds
             """)
     List<Answer> findReceivedAnswersByQuestionIds(long reviewGroupId, Collection<Long> questionIds);
 

--- a/backend/src/main/java/reviewme/review/repository/AnswerRepository.java
+++ b/backend/src/main/java/reviewme/review/repository/AnswerRepository.java
@@ -1,5 +1,6 @@
 package reviewme.review.repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +10,13 @@ import reviewme.review.domain.Answer;
 
 @Repository
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
+
+    @Query(value = """
+            SELECT a FROM Answer a
+            JOIN Review r ON a.reviewId = r.id
+            WHERE r.reviewGroupId = :reviewGroupId AND a.questionId IN :questionIds
+            """)
+    List<Answer> findReceivedAnswersByQuestionIds(long reviewGroupId, Collection<Long> questionIds);
 
     @Query(value = """
             SELECT a FROM Answer a
@@ -39,9 +47,9 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
 
     @Query(value = """
             SELECT a FROM Answer a
-            JOIN Review r 
-            ON a.reviewId = r.id 
-            WHERE r.reviewGroupId = :reviewGroupId 
+            JOIN Review r
+            ON a.reviewId = r.id
+            WHERE r.reviewGroupId = :reviewGroupId
             """)
     Set<Answer> findAllByReviewGroupId(long reviewGroupId);
 

--- a/backend/src/main/java/reviewme/review/repository/AnswerRepository.java
+++ b/backend/src/main/java/reviewme/review/repository/AnswerRepository.java
@@ -11,6 +11,12 @@ import reviewme.review.domain.Answer;
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
 
     @Query(value = """
+            SELECT a FROM Answer a
+            WHERE a.questionId IN :questionIds
+            """)
+    List<Answer> findAllByQuestionIds(List<Long> questionIds);
+
+    @Query(value = """
             SELECT a.id FROM Answer a
             JOIN Review r
             ON a.reviewId = r.id

--- a/backend/src/main/java/reviewme/review/service/GatheredReviewLookupService.java
+++ b/backend/src/main/java/reviewme/review/service/GatheredReviewLookupService.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import reviewme.question.domain.OptionItem;
 import reviewme.question.domain.Question;
-import reviewme.question.repository.OptionItemRepository;
 import reviewme.question.repository.QuestionRepository;
 import reviewme.review.domain.Answer;
 import reviewme.review.domain.CheckboxAnswer;
@@ -31,7 +30,6 @@ public class GatheredReviewLookupService {
 
     private final QuestionRepository questionRepository;
     private final AnswerRepository answerRepository;
-    private final OptionItemRepository optionItemRepository;
 
     @Transactional(readOnly = true)
     public ReviewsGatheredBySectionResponse getReceivedReviewsBySectionId(String reviewRequestCode, long sectionId) {
@@ -88,7 +86,7 @@ public class GatheredReviewLookupService {
                 .collect(Collectors.groupingBy(CheckboxAnswerSelectedOption::getSelectedOptionId,
                         Collectors.counting()));
 
-        List<OptionItem> allOptionItem = optionItemRepository.findAllByQuestionId(question.getId());
+        List<OptionItem> allOptionItem = questionRepository.findAllOptionItemsById(question.getId());
         return allOptionItem.stream()
                 .map(optionItem -> new VoteResponse(
                         optionItem.getContent(),

--- a/backend/src/main/java/reviewme/review/service/GatheredReviewLookupService.java
+++ b/backend/src/main/java/reviewme/review/service/GatheredReviewLookupService.java
@@ -1,14 +1,98 @@
 package reviewme.review.service;
 
+import jakarta.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import reviewme.question.domain.OptionItem;
+import reviewme.question.domain.Question;
+import reviewme.question.repository.OptionItemRepository;
+import reviewme.question.repository.QuestionRepository;
+import reviewme.review.domain.Answer;
+import reviewme.review.domain.CheckboxAnswer;
+import reviewme.review.domain.CheckboxAnswerSelectedOption;
+import reviewme.review.domain.TextAnswer;
+import reviewme.review.repository.AnswerRepository;
+import reviewme.review.service.dto.response.gathered.ReviewsGatheredByQuestionResponse;
 import reviewme.review.service.dto.response.gathered.ReviewsGatheredBySectionResponse;
+import reviewme.review.service.dto.response.gathered.SimpleQuestionResponse;
+import reviewme.review.service.dto.response.gathered.TextResponse;
+import reviewme.review.service.dto.response.gathered.VoteResponse;
 
 @Service
 @RequiredArgsConstructor
 public class GatheredReviewLookupService {
 
+    private final QuestionRepository questionRepository;
+    private final AnswerRepository answerRepository;
+    private final OptionItemRepository optionItemRepository;
+
+    @Transactional(readOnly = true)
     public ReviewsGatheredBySectionResponse getReceivedReviewsBySectionId(String reviewRequestCode, long sectionId) {
-        return null;
+        List<Question> questions = questionRepository
+                .findAllByReviewRequestCodeAndSectionId(reviewRequestCode, sectionId);
+        Map<Long, Question> questionMap = questions.stream()
+                .collect(Collectors.toMap(Question::getId, Function.identity()));
+        List<Answer> answers = answerRepository.findAllByQuestions(new ArrayList<>(questionMap.keySet()));
+
+        Map<Question, List<Answer>> questionIdAnswers = questions.stream()
+                .collect(Collectors.toMap(
+                        Function.identity(),
+                        question -> answers.stream()
+                                .filter(answer -> answer.getQuestionId() == question.getId())
+                                .collect(Collectors.toList())
+                ));
+        return new ReviewsGatheredBySectionResponse(mapToResponse(questionIdAnswers));
+    }
+
+    private List<ReviewsGatheredByQuestionResponse> mapToResponse(Map<Question, List<Answer>> questionsToAnswers) {
+        List<ReviewsGatheredByQuestionResponse> result = new ArrayList<>();
+        for (Entry<Question, List<Answer>> questionAnswers : questionsToAnswers.entrySet()) {
+            Question question = questionAnswers.getKey();
+            result.add(new ReviewsGatheredByQuestionResponse(
+                    new SimpleQuestionResponse(question.getContent(), question.getQuestionType()),
+                    mapToTextResponse(question, questionsToAnswers.get(question)),
+                    mapToVoteResponse(question, questionsToAnswers.get(question))
+            ));
+        }
+        return result;
+    }
+
+    @Nullable
+    List<TextResponse> mapToTextResponse(Question question, List<Answer> answers) {
+        if (question.isSelectable()) {
+            return null;
+        }
+
+        return answers.stream()
+                .map(answer -> (TextAnswer) answer)
+                .map(textAnswer -> new TextResponse(textAnswer.getContent()))
+                .toList();
+    }
+
+    @Nullable
+    List<VoteResponse> mapToVoteResponse(Question question, List<Answer> answers) {
+        if (!question.isSelectable()) {
+            return null;
+        }
+
+        Map<Long, Long> voteCountByOptionItemId = answers.stream()
+                .map(answer -> (CheckboxAnswer) answer)
+                .flatMap(checkboxAnswer -> checkboxAnswer.getSelectedOptionIds().stream())
+                .collect(Collectors.groupingBy(CheckboxAnswerSelectedOption::getSelectedOptionId,
+                        Collectors.counting()));
+
+        List<OptionItem> allOptionItem = optionItemRepository.findAllByQuestionId(question.getId());
+        return allOptionItem.stream()
+                .map(optionItem -> new VoteResponse(
+                        optionItem.getContent(),
+                        voteCountByOptionItemId.getOrDefault(optionItem.getId(), 0L)))
+                .toList();
     }
 }

--- a/backend/src/main/java/reviewme/review/service/ReviewGatheredLookupService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewGatheredLookupService.java
@@ -39,6 +39,10 @@ public class ReviewGatheredLookupService {
         Map<Long, Question> questionIdQuestion = questionRepository
                 .findAllBySectionId(sectionId).stream()
                 .collect(Collectors.toMap(Question::getId, Function.identity()));
+        List<Answer> receivedAnswers = answerRepository.findReceivedAnswersByQuestionIds(
+                reviewGroup.getId(), new ArrayList<>(questionIdQuestion.keySet()));
+        Map<Long, List<Answer>> questionIdAnswers = receivedAnswers.stream()
+                .collect(Collectors.groupingBy(Answer::getQuestionId));
 
         ArrayList<Long> questionIds = new ArrayList<>(questionIdQuestion.keySet());
         Map<Question, List<Answer>> questionAnswers = answerRepository.findAllByQuestionIds(questionIds)

--- a/backend/src/main/java/reviewme/review/service/ReviewGatheredLookupService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewGatheredLookupService.java
@@ -24,7 +24,7 @@ import reviewme.template.repository.SectionRepository;
 @RequiredArgsConstructor
 public class ReviewGatheredLookupService {
 
-    private static final int MAX_ANSWER_LENGTH = 100;
+    private static final int ANSWER_RESPONSE_LIMIT = 100;
 
     private final QuestionRepository questionRepository;
     private final AnswerRepository answerRepository;
@@ -59,7 +59,8 @@ public class ReviewGatheredLookupService {
                 .collect(Collectors.toMap(Question::getId, Function.identity()));
 
         Map<Long, List<Answer>> questionIdAnswers = answerRepository
-                .findReceivedAnswersByQuestionIds(reviewGroup.getId(), questionIdQuestion.keySet(), MAX_ANSWER_LENGTH)
+                .findReceivedAnswersByQuestionIds(reviewGroup.getId(), questionIdQuestion.keySet(),
+                        ANSWER_RESPONSE_LIMIT)
                 .stream()
                 .collect(Collectors.groupingBy(Answer::getQuestionId));
 

--- a/backend/src/main/java/reviewme/review/service/ReviewGatheredLookupService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewGatheredLookupService.java
@@ -37,8 +37,7 @@ public class ReviewGatheredLookupService {
         validateSectionId(sectionId, reviewGroup);
 
         Map<Long, Question> questionIdQuestion = questionRepository
-                .findAllByReviewRequestCodeAndSectionId(reviewRequestCode, sectionId)
-                .stream()
+                .findAllBySectionId(sectionId).stream()
                 .collect(Collectors.toMap(Question::getId, Function.identity()));
 
         ArrayList<Long> questionIds = new ArrayList<>(questionIdQuestion.keySet());

--- a/backend/src/main/java/reviewme/review/service/ReviewGatheredLookupService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewGatheredLookupService.java
@@ -1,6 +1,5 @@
 package reviewme.review.service;
 
-import jakarta.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -9,21 +8,14 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import reviewme.question.domain.OptionItem;
 import reviewme.question.domain.Question;
 import reviewme.question.repository.QuestionRepository;
 import reviewme.review.domain.Answer;
-import reviewme.review.domain.CheckboxAnswer;
-import reviewme.review.domain.CheckboxAnswerSelectedOption;
-import reviewme.review.domain.TextAnswer;
 import reviewme.review.repository.AnswerRepository;
-import reviewme.review.service.dto.response.gathered.ReviewsGatheredByQuestionResponse;
 import reviewme.review.service.dto.response.gathered.ReviewsGatheredBySectionResponse;
-import reviewme.review.service.dto.response.gathered.SimpleQuestionResponse;
-import reviewme.review.service.dto.response.gathered.TextResponse;
-import reviewme.review.service.dto.response.gathered.VoteResponse;
 import reviewme.review.service.exception.ReviewGroupNotFoundByReviewRequestCodeException;
 import reviewme.review.service.exception.SectionNotFoundInTemplateException;
+import reviewme.review.service.mapper.ReviewGatherMapper;
 import reviewme.reviewgroup.domain.ReviewGroup;
 import reviewme.reviewgroup.repository.ReviewGroupRepository;
 import reviewme.template.repository.SectionRepository;
@@ -36,6 +28,8 @@ public class ReviewGatheredLookupService {
     private final AnswerRepository answerRepository;
     private final ReviewGroupRepository reviewGroupRepository;
     private final SectionRepository sectionRepository;
+
+    private final ReviewGatherMapper reviewGatherMapper;
 
     @Transactional(readOnly = true)
     public ReviewsGatheredBySectionResponse getReceivedReviewsBySectionId(String reviewRequestCode, long sectionId) {
@@ -55,7 +49,7 @@ public class ReviewGatheredLookupService {
                 .stream()
                 .collect(Collectors.toMap(Map.Entry::getValue, entry -> questionIdAnswers.getOrDefault(entry.getKey(), List.of())));
 
-        return new ReviewsGatheredBySectionResponse(mapToResponseBySection(questionAnswers));
+        return new ReviewsGatheredBySectionResponse(reviewGatherMapper.mapToResponseBySection(questionAnswers));
     }
 
     private void validateSectionId(long sectionId, ReviewGroup reviewGroup) {
@@ -63,51 +57,5 @@ public class ReviewGatheredLookupService {
         if (!existsByIdAndTemplateId) {
             throw new SectionNotFoundInTemplateException(sectionId, reviewGroup.getTemplateId());
         }
-    }
-
-    private List<ReviewsGatheredByQuestionResponse> mapToResponseBySection(Map<Question, List<Answer>> questionsToAnswers) {
-        return questionsToAnswers.entrySet().stream()
-                .map(entry -> mapToResponseByQuestion(entry.getKey(), entry.getValue()))
-                .toList();
-    }
-
-    private ReviewsGatheredByQuestionResponse mapToResponseByQuestion(Question question, List<Answer> answers) {
-        return new ReviewsGatheredByQuestionResponse(
-                new SimpleQuestionResponse(question.getContent(), question.getQuestionType()),
-                mapToTextResponse(question, answers),
-                mapToVoteResponse(question, answers)
-        );
-    }
-
-    @Nullable
-    List<TextResponse> mapToTextResponse(Question question, List<Answer> answers) {
-        if (question.isSelectable()) {
-            return null;
-        }
-
-        return answers.stream()
-                .map(answer -> (TextAnswer) answer)
-                .map(textAnswer -> new TextResponse(textAnswer.getContent()))
-                .toList();
-    }
-
-    @Nullable
-    List<VoteResponse> mapToVoteResponse(Question question, List<Answer> answers) {
-        if (!question.isSelectable()) {
-            return null;
-        }
-
-        Map<Long, Long> voteCountByOptionItemId = answers.stream()
-                .map(answer -> (CheckboxAnswer) answer)
-                .flatMap(checkboxAnswer -> checkboxAnswer.getSelectedOptionIds().stream())
-                .collect(Collectors.groupingBy(CheckboxAnswerSelectedOption::getSelectedOptionId,
-                        Collectors.counting()));
-
-        List<OptionItem> allOptionItem = questionRepository.findAllOptionItemsById(question.getId());
-        return allOptionItem.stream()
-                .map(optionItem -> new VoteResponse(
-                        optionItem.getContent(),
-                        voteCountByOptionItemId.getOrDefault(optionItem.getId(), 0L)))
-                .toList();
     }
 }

--- a/backend/src/main/java/reviewme/review/service/ReviewGatheredLookupService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewGatheredLookupService.java
@@ -24,6 +24,8 @@ import reviewme.template.repository.SectionRepository;
 @RequiredArgsConstructor
 public class ReviewGatheredLookupService {
 
+    private static final int MAX_ANSWER_LENGTH = 100;
+
     private final QuestionRepository questionRepository;
     private final AnswerRepository answerRepository;
     private final ReviewGroupRepository reviewGroupRepository;
@@ -57,7 +59,7 @@ public class ReviewGatheredLookupService {
                 .collect(Collectors.toMap(Question::getId, Function.identity()));
 
         Map<Long, List<Answer>> questionIdAnswers = answerRepository
-                .findReceivedAnswersByQuestionIdsOrderByCreatedAtDesc(reviewGroup.getId(), questionIdQuestion.keySet())
+                .findReceivedAnswersByQuestionIds(reviewGroup.getId(), questionIdQuestion.keySet(), MAX_ANSWER_LENGTH)
                 .stream()
                 .collect(Collectors.groupingBy(Answer::getQuestionId));
 

--- a/backend/src/main/java/reviewme/review/service/ReviewGatheredLookupService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewGatheredLookupService.java
@@ -25,7 +25,7 @@ import reviewme.review.service.dto.response.gathered.VoteResponse;
 
 @Service
 @RequiredArgsConstructor
-public class GatheredReviewLookupService {
+public class ReviewGatheredLookupService {
 
     private final QuestionRepository questionRepository;
     private final AnswerRepository answerRepository;

--- a/backend/src/main/java/reviewme/review/service/ReviewGatheredLookupService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewGatheredLookupService.java
@@ -52,16 +52,19 @@ public class ReviewGatheredLookupService {
 
     private Map<Question, List<Answer>> getQuestionAnswers(Section section, ReviewGroup reviewGroup) {
         Map<Long, Question> questionIdQuestion = questionRepository
-                .findAllBySectionIdOrderByPosition(section.getId()).stream()
+                .findAllBySectionIdOrderByPosition(section.getId())
+                .stream()
                 .collect(Collectors.toMap(Question::getId, Function.identity()));
 
         Map<Long, List<Answer>> questionIdAnswers = answerRepository
-                .findReceivedAnswersByQuestionIdsOrderByCreatedAtDesc(reviewGroup.getId(), questionIdQuestion.keySet()).stream()
+                .findReceivedAnswersByQuestionIdsOrderByCreatedAtDesc(reviewGroup.getId(), questionIdQuestion.keySet())
+                .stream()
                 .collect(Collectors.groupingBy(Answer::getQuestionId));
 
         return questionIdQuestion.values().stream()
                 .collect(Collectors.toMap(
                         Function.identity(),
-                        question -> questionIdAnswers.getOrDefault(question.getId(), List.of())));
+                        question -> questionIdAnswers.getOrDefault(question.getId(), List.of())
+                ));
     }
 }

--- a/backend/src/main/java/reviewme/review/service/ReviewGatheredLookupService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewGatheredLookupService.java
@@ -56,7 +56,7 @@ public class ReviewGatheredLookupService {
                 .collect(Collectors.toMap(Question::getId, Function.identity()));
 
         Map<Long, List<Answer>> questionIdAnswers = answerRepository
-                .findReceivedAnswersByQuestionIds(reviewGroup.getId(), questionIdQuestion.keySet()).stream()
+                .findReceivedAnswersByQuestionIdsOrderByCreatedAtDesc(reviewGroup.getId(), questionIdQuestion.keySet()).stream()
                 .collect(Collectors.groupingBy(Answer::getQuestionId));
 
         return questionIdQuestion.values().stream()

--- a/backend/src/main/java/reviewme/review/service/ReviewGatheredLookupService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewGatheredLookupService.java
@@ -1,6 +1,5 @@
 package reviewme.review.service;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -43,7 +42,7 @@ public class ReviewGatheredLookupService {
                 .findAllBySectionIdOrderByPosition(section.getId()).stream()
                 .collect(Collectors.toMap(Question::getId, Function.identity()));
         List<Answer> receivedAnswers = answerRepository.findReceivedAnswersByQuestionIds(
-                reviewGroup.getId(), new ArrayList<>(questionIdQuestion.keySet()));
+                reviewGroup.getId(), questionIdQuestion.keySet());
         Map<Long, List<Answer>> questionIdAnswers = receivedAnswers.stream()
                 .collect(Collectors.groupingBy(Answer::getQuestionId));
 

--- a/backend/src/main/java/reviewme/review/service/ReviewGatheredLookupService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewGatheredLookupService.java
@@ -40,7 +40,7 @@ public class ReviewGatheredLookupService {
                 .orElseThrow(() -> new SectionNotFoundInTemplateException(sectionId, reviewGroup.getTemplateId()));
 
         Map<Long, Question> questionIdQuestion = questionRepository
-                .findAllBySectionId(section.getId()).stream()
+                .findAllBySectionIdOrderByPosition(section.getId()).stream()
                 .collect(Collectors.toMap(Question::getId, Function.identity()));
         List<Answer> receivedAnswers = answerRepository.findReceivedAnswersByQuestionIds(
                 reviewGroup.getId(), new ArrayList<>(questionIdQuestion.keySet()));

--- a/backend/src/main/java/reviewme/review/service/dto/response/gathered/HighlightResponse.java
+++ b/backend/src/main/java/reviewme/review/service/dto/response/gathered/HighlightResponse.java
@@ -1,0 +1,9 @@
+package reviewme.review.service.dto.response.gathered;
+
+import java.util.List;
+
+public record HighlightResponse(
+        long lineIndex,
+        List<RangeResponse> ranges
+) {
+}

--- a/backend/src/main/java/reviewme/review/service/dto/response/gathered/RangeResponse.java
+++ b/backend/src/main/java/reviewme/review/service/dto/response/gathered/RangeResponse.java
@@ -1,0 +1,7 @@
+package reviewme.review.service.dto.response.gathered;
+
+public record RangeResponse(
+        long startIndex,
+        long endIndex
+) {
+}

--- a/backend/src/main/java/reviewme/review/service/dto/response/gathered/ReviewsGatheredByQuestionResponse.java
+++ b/backend/src/main/java/reviewme/review/service/dto/response/gathered/ReviewsGatheredByQuestionResponse.java
@@ -7,7 +7,7 @@ public record ReviewsGatheredByQuestionResponse(
         SimpleQuestionResponse question,
 
         @Nullable
-        List<AnswerContentResponse> answers,
+        List<TextResponse> answers,
 
         @Nullable
         List<VoteResponse> votes

--- a/backend/src/main/java/reviewme/review/service/dto/response/gathered/SimpleQuestionResponse.java
+++ b/backend/src/main/java/reviewme/review/service/dto/response/gathered/SimpleQuestionResponse.java
@@ -3,6 +3,7 @@ package reviewme.review.service.dto.response.gathered;
 import reviewme.question.domain.QuestionType;
 
 public record SimpleQuestionResponse(
+        long id,
         String name,
         QuestionType type
 ) {

--- a/backend/src/main/java/reviewme/review/service/dto/response/gathered/TextResponse.java
+++ b/backend/src/main/java/reviewme/review/service/dto/response/gathered/TextResponse.java
@@ -1,6 +1,10 @@
 package reviewme.review.service.dto.response.gathered;
 
+import java.util.List;
+
 public record TextResponse(
-        String content
+        long id,
+        String content,
+        List<HighlightResponse> highlights
 ) {
 }

--- a/backend/src/main/java/reviewme/review/service/dto/response/gathered/TextResponse.java
+++ b/backend/src/main/java/reviewme/review/service/dto/response/gathered/TextResponse.java
@@ -1,6 +1,6 @@
 package reviewme.review.service.dto.response.gathered;
 
-public record AnswerContentResponse(
+public record TextResponse(
         String content
 ) {
 }

--- a/backend/src/main/java/reviewme/review/service/dto/response/gathered/VoteResponse.java
+++ b/backend/src/main/java/reviewme/review/service/dto/response/gathered/VoteResponse.java
@@ -2,6 +2,6 @@ package reviewme.review.service.dto.response.gathered;
 
 public record VoteResponse(
         String content,
-        int count
+        long count
 ) {
 }

--- a/backend/src/main/java/reviewme/review/service/exception/GatheredAnswersTypeNonUniformException.java
+++ b/backend/src/main/java/reviewme/review/service/exception/GatheredAnswersTypeNonUniformException.java
@@ -1,0 +1,13 @@
+package reviewme.review.service.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import reviewme.global.exception.DataInconsistencyException;
+
+@Slf4j
+public class GatheredAnswersTypeNonUniformException extends DataInconsistencyException {
+
+    public GatheredAnswersTypeNonUniformException(Throwable cause) {
+        super("서버 내부 오류가 발생했습니다.");
+        log.error("The types of answers to questions are not uniform.", cause);
+    }
+}

--- a/backend/src/main/java/reviewme/review/service/exception/SectionNotFoundInTemplateException.java
+++ b/backend/src/main/java/reviewme/review/service/exception/SectionNotFoundInTemplateException.java
@@ -8,6 +8,6 @@ public class SectionNotFoundInTemplateException extends NotFoundException {
 
     public SectionNotFoundInTemplateException(long sectionId, long templateId) {
         super("섹션 정보를 찾을 수 없습니다.");
-        log.info("Section is not found in template - sectionId: {}, templateId: {}", sectionId, templateId, this);
+        log.info("Section not found in template - sectionId: {}, templateId: {}", sectionId, templateId, this);
     }
 }

--- a/backend/src/main/java/reviewme/review/service/exception/SectionNotFoundInTemplateException.java
+++ b/backend/src/main/java/reviewme/review/service/exception/SectionNotFoundInTemplateException.java
@@ -1,0 +1,13 @@
+package reviewme.review.service.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import reviewme.global.exception.NotFoundException;
+
+@Slf4j
+public class SectionNotFoundInTemplateException extends NotFoundException {
+
+    public SectionNotFoundInTemplateException(long sectionId, long templateId) {
+        super("섹션 정보를 찾을 수 없습니다.");
+        log.info("Section is not found in template - sectionId: {}, templateId: {}", sectionId, templateId, this);
+    }
+}

--- a/backend/src/main/java/reviewme/review/service/mapper/ReviewGatherMapper.java
+++ b/backend/src/main/java/reviewme/review/service/mapper/ReviewGatherMapper.java
@@ -1,0 +1,73 @@
+package reviewme.review.service.mapper;
+
+import jakarta.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import reviewme.question.domain.OptionItem;
+import reviewme.question.domain.Question;
+import reviewme.question.repository.QuestionRepository;
+import reviewme.review.domain.Answer;
+import reviewme.review.domain.CheckboxAnswer;
+import reviewme.review.domain.CheckboxAnswerSelectedOption;
+import reviewme.review.domain.TextAnswer;
+import reviewme.review.service.dto.response.gathered.ReviewsGatheredByQuestionResponse;
+import reviewme.review.service.dto.response.gathered.SimpleQuestionResponse;
+import reviewme.review.service.dto.response.gathered.TextResponse;
+import reviewme.review.service.dto.response.gathered.VoteResponse;
+
+@Component
+@RequiredArgsConstructor
+public class ReviewGatherMapper {
+
+    private final QuestionRepository questionRepository;
+
+    public List<ReviewsGatheredByQuestionResponse> mapToResponseBySection(
+            Map<Question, List<Answer>> questionsToAnswers) {
+        return questionsToAnswers.entrySet().stream()
+                .map(entry -> mapToResponseByQuestion(entry.getKey(), entry.getValue()))
+                .toList();
+    }
+
+    private ReviewsGatheredByQuestionResponse mapToResponseByQuestion(Question question, List<Answer> answers) {
+        return new ReviewsGatheredByQuestionResponse(
+                new SimpleQuestionResponse(question.getContent(), question.getQuestionType()),
+                mapToTextResponse(question, answers),
+                mapToVoteResponse(question, answers)
+        );
+    }
+
+    @Nullable
+    List<TextResponse> mapToTextResponse(Question question, List<Answer> answers) {
+        if (question.isSelectable()) {
+            return null;
+        }
+
+        return answers.stream()
+                .map(answer -> (TextAnswer) answer)
+                .map(textAnswer -> new TextResponse(textAnswer.getContent()))
+                .toList();
+    }
+
+    @Nullable
+    List<VoteResponse> mapToVoteResponse(Question question, List<Answer> answers) {
+        if (!question.isSelectable()) {
+            return null;
+        }
+
+        Map<Long, Long> voteCountByOptionItemId = answers.stream()
+                .map(answer -> (CheckboxAnswer) answer)
+                .flatMap(checkboxAnswer -> checkboxAnswer.getSelectedOptionIds().stream())
+                .collect(Collectors.groupingBy(CheckboxAnswerSelectedOption::getSelectedOptionId,
+                        Collectors.counting()));
+
+        List<OptionItem> allOptionItem = questionRepository.findAllOptionItemsById(question.getId());
+        return allOptionItem.stream()
+                .map(optionItem -> new VoteResponse(
+                        optionItem.getContent(),
+                        voteCountByOptionItemId.getOrDefault(optionItem.getId(), 0L)))
+                .toList();
+    }
+}

--- a/backend/src/main/java/reviewme/review/service/mapper/ReviewGatherMapper.java
+++ b/backend/src/main/java/reviewme/review/service/mapper/ReviewGatherMapper.java
@@ -40,7 +40,7 @@ public class ReviewGatherMapper {
     }
 
     @Nullable
-    List<TextResponse> mapToTextResponse(Question question, List<Answer> answers) {
+    private List<TextResponse> mapToTextResponse(Question question, List<Answer> answers) {
         if (question.isSelectable()) {
             return null;
         }
@@ -52,7 +52,7 @@ public class ReviewGatherMapper {
     }
 
     @Nullable
-    List<VoteResponse> mapToVoteResponse(Question question, List<Answer> answers) {
+    private List<VoteResponse> mapToVoteResponse(Question question, List<Answer> answers) {
         if (!question.isSelectable()) {
             return null;
         }

--- a/backend/src/main/java/reviewme/review/service/mapper/ReviewGatherMapper.java
+++ b/backend/src/main/java/reviewme/review/service/mapper/ReviewGatherMapper.java
@@ -27,7 +27,8 @@ public class ReviewGatherMapper {
     private final QuestionRepository questionRepository;
 
     public ReviewsGatheredBySectionResponse mapToReviewsGatheredBySection(Map<Question, List<Answer>> questionAnswers) {
-        List<ReviewsGatheredByQuestionResponse> reviews = questionAnswers.entrySet().stream()
+        List<ReviewsGatheredByQuestionResponse> reviews = questionAnswers.entrySet()
+                .stream()
                 .map(entry -> mapToReviewsGatheredByQuestion(entry.getKey(), entry.getValue()))
                 .toList();
 

--- a/backend/src/main/java/reviewme/review/service/mapper/ReviewGatherMapper.java
+++ b/backend/src/main/java/reviewme/review/service/mapper/ReviewGatherMapper.java
@@ -57,7 +57,7 @@ public class ReviewGatherMapper {
             return null;
         }
 
-        Map<Long, Long> voteCountByOptionItemId = answers.stream()
+        Map<Long, Long> optionItemIdVoteCount = answers.stream()
                 .map(answer -> (CheckboxAnswer) answer)
                 .flatMap(checkboxAnswer -> checkboxAnswer.getSelectedOptionIds().stream())
                 .collect(Collectors.groupingBy(CheckboxAnswerSelectedOption::getSelectedOptionId,
@@ -67,7 +67,7 @@ public class ReviewGatherMapper {
         return allOptionItem.stream()
                 .map(optionItem -> new VoteResponse(
                         optionItem.getContent(),
-                        voteCountByOptionItemId.getOrDefault(optionItem.getId(), 0L)))
+                        optionItemIdVoteCount.getOrDefault(optionItem.getId(), 0L)))
                 .toList();
     }
 }

--- a/backend/src/main/java/reviewme/review/service/mapper/ReviewGatherMapper.java
+++ b/backend/src/main/java/reviewme/review/service/mapper/ReviewGatherMapper.java
@@ -14,6 +14,7 @@ import reviewme.review.domain.CheckboxAnswer;
 import reviewme.review.domain.CheckboxAnswerSelectedOption;
 import reviewme.review.domain.TextAnswer;
 import reviewme.review.service.dto.response.gathered.ReviewsGatheredByQuestionResponse;
+import reviewme.review.service.dto.response.gathered.ReviewsGatheredBySectionResponse;
 import reviewme.review.service.dto.response.gathered.SimpleQuestionResponse;
 import reviewme.review.service.dto.response.gathered.TextResponse;
 import reviewme.review.service.dto.response.gathered.VoteResponse;
@@ -24,14 +25,15 @@ public class ReviewGatherMapper {
 
     private final QuestionRepository questionRepository;
 
-    public List<ReviewsGatheredByQuestionResponse> mapToResponseBySection(
-            Map<Question, List<Answer>> questionsToAnswers) {
-        return questionsToAnswers.entrySet().stream()
-                .map(entry -> mapToResponseByQuestion(entry.getKey(), entry.getValue()))
+    public ReviewsGatheredBySectionResponse mapToReviewsGatheredBySection(Map<Question, List<Answer>> questionAnswers) {
+        List<ReviewsGatheredByQuestionResponse> reviews = questionAnswers.entrySet().stream()
+                .map(entry -> mapToReviewsGatheredByQuestion(entry.getKey(), entry.getValue()))
                 .toList();
+
+        return new ReviewsGatheredBySectionResponse(reviews);
     }
 
-    private ReviewsGatheredByQuestionResponse mapToResponseByQuestion(Question question, List<Answer> answers) {
+    private ReviewsGatheredByQuestionResponse mapToReviewsGatheredByQuestion(Question question, List<Answer> answers) {
         return new ReviewsGatheredByQuestionResponse(
                 new SimpleQuestionResponse(question.getId(), question.getContent(), question.getQuestionType()),
                 mapToTextResponse(question, answers),

--- a/backend/src/main/java/reviewme/review/service/mapper/ReviewGatherMapper.java
+++ b/backend/src/main/java/reviewme/review/service/mapper/ReviewGatherMapper.java
@@ -33,7 +33,7 @@ public class ReviewGatherMapper {
 
     private ReviewsGatheredByQuestionResponse mapToResponseByQuestion(Question question, List<Answer> answers) {
         return new ReviewsGatheredByQuestionResponse(
-                new SimpleQuestionResponse(question.getContent(), question.getQuestionType()),
+                new SimpleQuestionResponse(question.getId(), question.getContent(), question.getQuestionType()),
                 mapToTextResponse(question, answers),
                 mapToVoteResponse(question, answers)
         );
@@ -47,7 +47,7 @@ public class ReviewGatherMapper {
 
         return answers.stream()
                 .map(answer -> (TextAnswer) answer)
-                .map(textAnswer -> new TextResponse(textAnswer.getContent()))
+                .map(textAnswer -> new TextResponse(textAnswer.getId(), textAnswer.getContent(), List.of()))
                 .toList();
     }
 

--- a/backend/src/main/java/reviewme/review/service/mapper/ReviewGatherMapper.java
+++ b/backend/src/main/java/reviewme/review/service/mapper/ReviewGatherMapper.java
@@ -66,7 +66,7 @@ public class ReviewGatherMapper {
                 .collect(Collectors.groupingBy(CheckboxAnswerSelectedOption::getSelectedOptionId,
                         Collectors.counting()));
 
-        List<OptionItem> allOptionItem = questionRepository.findAllOptionItemsById(question.getId());
+        List<OptionItem> allOptionItem = questionRepository.findAllOptionItemsByIdOrderByPosition(question.getId());
         return allOptionItem.stream()
                 .map(optionItem -> new VoteResponse(
                         optionItem.getContent(),

--- a/backend/src/main/java/reviewme/reviewgroup/domain/ReviewGroup.java
+++ b/backend/src/main/java/reviewme/reviewgroup/domain/ReviewGroup.java
@@ -44,12 +44,17 @@ public class ReviewGroup {
     private long templateId = 1L;
 
     public ReviewGroup(String reviewee, String projectName, String reviewRequestCode, String groupAccessCode) {
+        this(reviewee, projectName, reviewRequestCode, groupAccessCode, 1L);
+    }
+
+    public ReviewGroup(String reviewee, String projectName, String reviewRequestCode, String groupAccessCode, long templateId) {
         validateRevieweeLength(reviewee);
         validateProjectNameLength(projectName);
         this.reviewee = reviewee;
         this.projectName = projectName;
         this.reviewRequestCode = reviewRequestCode;
         this.groupAccessCode = new GroupAccessCode(groupAccessCode);
+        this.templateId = templateId;
     }
 
     private void validateRevieweeLength(String reviewee) {

--- a/backend/src/main/java/reviewme/template/repository/SectionRepository.java
+++ b/backend/src/main/java/reviewme/template/repository/SectionRepository.java
@@ -1,6 +1,7 @@
 package reviewme.template.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -19,12 +20,10 @@ public interface SectionRepository extends JpaRepository<Section, Long> {
     List<Section> findAllByTemplateId(long templateId);
 
     @Query("""
-            SELECT EXISTS (
-                SELECT 1 FROM Section s
-                JOIN TemplateSection ts ON s.id = ts.sectionId
-                WHERE ts.sectionId = :sectionId
-                AND ts.templateId = :templateId
-            )
+            SELECT s FROM Section s
+            JOIN TemplateSection ts ON s.id = ts.sectionId
+            WHERE ts.sectionId = :sectionId
+            AND ts.templateId = :templateId
             """)
-    boolean existsByIdAndTemplateId(long sectionId, long templateId);
+    Optional<Section> findByIdAndTemplateId(long sectionId, long templateId);
 }

--- a/backend/src/main/java/reviewme/template/repository/SectionRepository.java
+++ b/backend/src/main/java/reviewme/template/repository/SectionRepository.java
@@ -19,10 +19,12 @@ public interface SectionRepository extends JpaRepository<Section, Long> {
     List<Section> findAllByTemplateId(long templateId);
 
     @Query("""
-            SELECT s FROM Section s
-            JOIN TemplateSection ts ON s.id = ts.sectionId
-            WHERE ts.sectionId = :sectionId
-            AND ts.templateId = :templateId
+            SELECT EXISTS (
+                SELECT 1 FROM Section s
+                JOIN TemplateSection ts ON s.id = ts.sectionId
+                WHERE ts.sectionId = :sectionId
+                AND ts.templateId = :templateId
+            )
             """)
     boolean existsByIdAndTemplateId(long sectionId, long templateId);
 }

--- a/backend/src/main/java/reviewme/template/repository/SectionRepository.java
+++ b/backend/src/main/java/reviewme/template/repository/SectionRepository.java
@@ -17,4 +17,12 @@ public interface SectionRepository extends JpaRepository<Section, Long> {
             ORDER BY s.position ASC
             """, nativeQuery = true)
     List<Section> findAllByTemplateId(long templateId);
+
+    @Query("""
+            SELECT s FROM Section s
+            JOIN TemplateSection ts ON s.id = ts.sectionId
+            WHERE ts.sectionId = :sectionId
+            AND ts.templateId = :templateId
+            """)
+    boolean existsByIdAndTemplateId(long sectionId, long templateId);
 }

--- a/backend/src/test/java/reviewme/api/ApiTest.java
+++ b/backend/src/test/java/reviewme/api/ApiTest.java
@@ -29,7 +29,7 @@ import org.springframework.web.context.WebApplicationContext;
 import reviewme.highlight.controller.HighlightController;
 import reviewme.highlight.service.HighlightService;
 import reviewme.review.controller.ReviewController;
-import reviewme.review.service.GatheredReviewLookupService;
+import reviewme.review.service.ReviewGatheredLookupService;
 import reviewme.review.service.ReviewDetailLookupService;
 import reviewme.review.service.ReviewListLookupService;
 import reviewme.review.service.ReviewRegisterService;
@@ -79,7 +79,7 @@ public abstract class ApiTest {
     protected SectionService sectionService;
 
     @MockBean
-    protected GatheredReviewLookupService gatheredReviewLookupService;
+    protected ReviewGatheredLookupService reviewGatheredLookupService;
 
     @MockBean
     protected HighlightService highlightService;

--- a/backend/src/test/java/reviewme/api/ReviewApiTest.java
+++ b/backend/src/test/java/reviewme/api/ReviewApiTest.java
@@ -24,7 +24,7 @@ import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.request.ParameterDescriptor;
 import reviewme.question.domain.QuestionType;
 import reviewme.review.service.dto.request.ReviewRegisterRequest;
-import reviewme.review.service.dto.response.gathered.AnswerContentResponse;
+import reviewme.review.service.dto.response.gathered.TextResponse;
 import reviewme.review.service.dto.response.gathered.ReviewsGatheredByQuestionResponse;
 import reviewme.review.service.dto.response.gathered.ReviewsGatheredBySectionResponse;
 import reviewme.review.service.dto.response.gathered.SimpleQuestionResponse;
@@ -256,8 +256,8 @@ class ReviewApiTest extends ApiTest {
                 new ReviewsGatheredByQuestionResponse(
                         new SimpleQuestionResponse("서술형 질문", QuestionType.TEXT),
                         List.of(
-                                new AnswerContentResponse("산초의 답변"),
-                                new AnswerContentResponse("삼촌의 답변")),
+                                new TextResponse("산초의 답변"),
+                                new TextResponse("삼촌의 답변")),
                         null),
                 new ReviewsGatheredByQuestionResponse(
                         new SimpleQuestionResponse("선택형 질문", QuestionType.CHECKBOX),

--- a/backend/src/test/java/reviewme/api/ReviewApiTest.java
+++ b/backend/src/test/java/reviewme/api/ReviewApiTest.java
@@ -266,7 +266,7 @@ class ReviewApiTest extends ApiTest {
                                 new VoteResponse("짜장", 3),
                                 new VoteResponse("짬뽕", 5))))
         );
-        BDDMockito.given(gatheredReviewLookupService.getReceivedReviewsBySectionId(anyString(), anyLong()))
+        BDDMockito.given(reviewGatheredLookupService.getReceivedReviewsBySectionId(anyString(), anyLong()))
                 .willReturn(response);
 
         CookieDescriptor[] cookieDescriptors = {

--- a/backend/src/test/java/reviewme/api/ReviewApiTest.java
+++ b/backend/src/test/java/reviewme/api/ReviewApiTest.java
@@ -24,13 +24,15 @@ import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.request.ParameterDescriptor;
 import reviewme.question.domain.QuestionType;
 import reviewme.review.service.dto.request.ReviewRegisterRequest;
-import reviewme.review.service.dto.response.gathered.TextResponse;
+import reviewme.review.service.dto.response.gathered.HighlightResponse;
+import reviewme.review.service.dto.response.gathered.RangeResponse;
 import reviewme.review.service.dto.response.gathered.ReviewsGatheredByQuestionResponse;
 import reviewme.review.service.dto.response.gathered.ReviewsGatheredBySectionResponse;
 import reviewme.review.service.dto.response.gathered.SimpleQuestionResponse;
+import reviewme.review.service.dto.response.gathered.TextResponse;
 import reviewme.review.service.dto.response.gathered.VoteResponse;
-import reviewme.review.service.dto.response.list.ReceivedReviewsSummaryResponse;
 import reviewme.review.service.dto.response.list.ReceivedReviewsResponse;
+import reviewme.review.service.dto.response.list.ReceivedReviewsSummaryResponse;
 import reviewme.review.service.dto.response.list.ReviewCategoryResponse;
 import reviewme.review.service.dto.response.list.ReviewListElementResponse;
 import reviewme.review.service.exception.ReviewGroupNotFoundByReviewRequestCodeException;
@@ -254,13 +256,16 @@ class ReviewApiTest extends ApiTest {
     void 자신이_받은_리뷰의_요약를_섹션별로_조회한다() {
         ReviewsGatheredBySectionResponse response = new ReviewsGatheredBySectionResponse(List.of(
                 new ReviewsGatheredByQuestionResponse(
-                        new SimpleQuestionResponse("서술형 질문", QuestionType.TEXT),
+                        new SimpleQuestionResponse(1L, "서술형 질문", QuestionType.TEXT),
                         List.of(
-                                new TextResponse("산초의 답변"),
-                                new TextResponse("삼촌의 답변")),
+                                new TextResponse(1L, "산초의 답변", List.of(
+                                        new HighlightResponse(1, List.of(new RangeResponse(1, 10))),
+                                        new HighlightResponse(2, List.of(new RangeResponse(1, 4)))
+                                )),
+                                new TextResponse(2L, "삼촌의 답변", List.of())),
                         null),
                 new ReviewsGatheredByQuestionResponse(
-                        new SimpleQuestionResponse("선택형 질문", QuestionType.CHECKBOX),
+                        new SimpleQuestionResponse(2L, "선택형 질문", QuestionType.CHECKBOX),
                         null,
                         List.of(
                                 new VoteResponse("짜장", 3),
@@ -278,11 +283,20 @@ class ReviewApiTest extends ApiTest {
         FieldDescriptor[] responseFieldDescriptors = {
                 fieldWithPath("reviews").description("리뷰 목록"),
                 fieldWithPath("reviews[].question").description("질문 정보"),
+                fieldWithPath("reviews[].question.id").description("질문 ID"),
                 fieldWithPath("reviews[].question.name").description("질문 이름"),
                 fieldWithPath("reviews[].question.type").description("질문 유형"),
                 fieldWithPath("reviews[].answers").description("서술형 답변 목록 - question.type이 TEXT가 아니면 null").optional(),
+                fieldWithPath("reviews[].answers[].id").description("답변 ID").optional(),
                 fieldWithPath("reviews[].answers[].content").description("서술형 답변 내용"),
-                fieldWithPath("reviews[].votes").description("객관식 답변 목록 - question.type이 CHECKBOX가 아니면 null").optional(),
+                fieldWithPath("reviews[].answers[].highlights").description("형광펜 정보"),
+                fieldWithPath("reviews[].answers[].highlights[].lineIndex").description("개행으로 구분되는 라인 번호, 0-based"),
+                fieldWithPath("reviews[].answers[].highlights[].ranges").description("형광펜 범위"),
+                fieldWithPath("reviews[].answers[].highlights[].ranges[].startIndex").description(
+                        "하이라이트 시작 인덱스, 0-based"),
+                fieldWithPath("reviews[].answers[].highlights[].ranges[].endIndex").description("하이라이트 끝 인덱스, 0-based"),
+                fieldWithPath("reviews[].votes").description(
+                        "객관식 답변 목록 - question.type이 CHECKBOX가 아니면 null").optional(),
                 fieldWithPath("reviews[].votes[].content").description("객관식 항목"),
                 fieldWithPath("reviews[].votes[].count").description("선택한 사람 수"),
         };

--- a/backend/src/test/java/reviewme/question/repository/OptionItemRepositoryTest.java
+++ b/backend/src/test/java/reviewme/question/repository/OptionItemRepositoryTest.java
@@ -1,7 +1,6 @@
 package reviewme.question.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 import static reviewme.fixture.OptionGroupFixture.선택지_그룹;
 import static reviewme.fixture.OptionItemFixture.선택지;
 import static reviewme.fixture.QuestionFixture.선택형_필수_질문;
@@ -64,28 +63,5 @@ class OptionItemRepositoryTest {
 
         // then
         assertThat(actual).containsExactlyInAnyOrder(optionItem1, optionItem2, optionItem3);
-    }
-
-    @Test
-    void 질문_아이디에_해당하는_모든_옵션_아이템을_불러온다() {
-        // given
-        Question question1 = questionRepository.save(선택형_필수_질문());
-        Question question2 = questionRepository.save(선택형_필수_질문());
-        OptionGroup optionGroup1 = optionGroupRepository.save(선택지_그룹(question1.getId()));
-        OptionGroup optionGroup2 = optionGroupRepository.save(선택지_그룹(question2.getId()));
-
-        OptionItem optionItem1 = optionItemRepository.save(선택지(optionGroup1.getId()));
-        OptionItem optionItem2 = optionItemRepository.save(선택지(optionGroup1.getId()));
-        OptionItem optionItem3 = optionItemRepository.save(선택지(optionGroup2.getId()));
-
-        // when
-        List<OptionItem> optionItemsForQuestion1 = optionItemRepository.findAllByQuestionId(question1.getId());
-        List<OptionItem> optionItemsForQuestion2 = optionItemRepository.findAllByQuestionId(question2.getId());
-
-        // then
-        assertAll(
-                () -> assertThat(optionItemsForQuestion1).containsOnly(optionItem1, optionItem2),
-                () -> assertThat(optionItemsForQuestion2).containsOnly(optionItem3)
-        );
     }
 }

--- a/backend/src/test/java/reviewme/question/repository/OptionItemRepositoryTest.java
+++ b/backend/src/test/java/reviewme/question/repository/OptionItemRepositoryTest.java
@@ -1,6 +1,7 @@
 package reviewme.question.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static reviewme.fixture.OptionGroupFixture.선택지_그룹;
 import static reviewme.fixture.OptionItemFixture.선택지;
 import static reviewme.fixture.QuestionFixture.선택형_필수_질문;
@@ -63,5 +64,28 @@ class OptionItemRepositoryTest {
 
         // then
         assertThat(actual).containsExactlyInAnyOrder(optionItem1, optionItem2, optionItem3);
+    }
+
+    @Test
+    void 질문_아이디에_해당하는_모든_옵션_아이템을_불러온다() {
+        // given
+        Question question1 = questionRepository.save(선택형_필수_질문());
+        Question question2 = questionRepository.save(선택형_필수_질문());
+        OptionGroup optionGroup1 = optionGroupRepository.save(선택지_그룹(question1.getId()));
+        OptionGroup optionGroup2 = optionGroupRepository.save(선택지_그룹(question2.getId()));
+
+        OptionItem optionItem1 = optionItemRepository.save(선택지(optionGroup1.getId()));
+        OptionItem optionItem2 = optionItemRepository.save(선택지(optionGroup1.getId()));
+        OptionItem optionItem3 = optionItemRepository.save(선택지(optionGroup2.getId()));
+
+        // when
+        List<OptionItem> optionItemsForQuestion1 = optionItemRepository.findAllByQuestionId(question1.getId());
+        List<OptionItem> optionItemsForQuestion2 = optionItemRepository.findAllByQuestionId(question2.getId());
+
+        // then
+        assertAll(
+                () -> assertThat(optionItemsForQuestion1).containsOnly(optionItem1, optionItem2),
+                () -> assertThat(optionItemsForQuestion2).containsOnly(optionItem3)
+        );
     }
 }

--- a/backend/src/test/java/reviewme/question/repository/QuestionRepositoryTest.java
+++ b/backend/src/test/java/reviewme/question/repository/QuestionRepositoryTest.java
@@ -1,7 +1,9 @@
 package reviewme.question.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static reviewme.fixture.QuestionFixture.서술형_필수_질문;
+import static reviewme.fixture.ReviewGroupFixture.리뷰_그룹;
 import static reviewme.fixture.SectionFixture.항상_보이는_섹션;
 import static reviewme.fixture.TemplateFixture.템플릿;
 
@@ -11,6 +13,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import reviewme.question.domain.Question;
+import reviewme.reviewgroup.domain.ReviewGroup;
+import reviewme.reviewgroup.repository.ReviewGroupRepository;
 import reviewme.template.domain.Section;
 import reviewme.template.domain.Template;
 import reviewme.template.repository.SectionRepository;
@@ -27,6 +31,9 @@ class QuestionRepositoryTest {
 
     @Autowired
     private TemplateRepository templateRepository;
+
+    @Autowired
+    private ReviewGroupRepository reviewGroupRepository;
 
     @Test
     void 템플릿_아이디로_질문_목록_아이디를_모두_가져온다() {
@@ -70,5 +77,37 @@ class QuestionRepositoryTest {
 
         // then
         assertThat(actual).containsExactlyInAnyOrder(question1, question2);
+    }
+
+    @Test
+    void 리뷰_요청_코드와_섹션_아이디에_해당하는_질문을_모두_가져온다() {
+        // given
+        String reviewRequestCode = "12341234";
+        ReviewGroup reviewGroup = reviewGroupRepository.save(리뷰_그룹(reviewRequestCode, "43214321"));
+
+        Question question1 = questionRepository.save(서술형_필수_질문(1));
+        Question question2 = questionRepository.save(서술형_필수_질문(2));
+        Question question3 = questionRepository.save(서술형_필수_질문(1));
+        Question question4 = questionRepository.save(서술형_필수_질문(2));
+
+        List<Long> sectionQuestion1 = List.of(question1.getId(), question2.getId());
+        List<Long> sectionQuestion2 = List.of(question3.getId(), question4.getId());
+        Section section1 = sectionRepository.save(항상_보이는_섹션(sectionQuestion1));
+        Section section2 = sectionRepository.save(항상_보이는_섹션(sectionQuestion2));
+        List<Long> sectionIds = List.of(section1.getId(), section2.getId());
+        Template template = templateRepository.save(템플릿(sectionIds));
+
+        // when
+        List<Question> questionsInSection1 = questionRepository.findAllByReviewRequestCodeAndSectionId(
+                reviewRequestCode, section1.getId());
+        List<Question> questionsInSection2 = questionRepository.findAllByReviewRequestCodeAndSectionId(
+                reviewRequestCode, section2.getId());
+
+
+        // then
+        assertAll(
+                () -> assertThat(questionsInSection1).containsOnly(question1, question2),
+                () -> assertThat(questionsInSection2).containsOnly(question3, question4)
+        );
     }
 }

--- a/backend/src/test/java/reviewme/question/repository/QuestionRepositoryTest.java
+++ b/backend/src/test/java/reviewme/question/repository/QuestionRepositoryTest.java
@@ -136,12 +136,8 @@ class QuestionRepositoryTest {
 
         // when
         List<OptionItem> optionItemsForQuestion1 = questionRepository.findAllOptionItemsById(question1.getId());
-        List<OptionItem> optionItemsForQuestion2 = questionRepository.findAllOptionItemsById(question2.getId());
 
         // then
-        assertAll(
-                () -> assertThat(optionItemsForQuestion1).containsOnly(optionItem1, optionItem2),
-                () -> assertThat(optionItemsForQuestion2).containsOnly(optionItem3)
-        );
+        assertThat(optionItemsForQuestion1).containsOnly(optionItem1, optionItem2);
     }
 }

--- a/backend/src/test/java/reviewme/question/repository/QuestionRepositoryTest.java
+++ b/backend/src/test/java/reviewme/question/repository/QuestionRepositoryTest.java
@@ -2,7 +2,10 @@ package reviewme.question.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static reviewme.fixture.OptionGroupFixture.선택지_그룹;
+import static reviewme.fixture.OptionItemFixture.선택지;
 import static reviewme.fixture.QuestionFixture.서술형_필수_질문;
+import static reviewme.fixture.QuestionFixture.선택형_필수_질문;
 import static reviewme.fixture.ReviewGroupFixture.리뷰_그룹;
 import static reviewme.fixture.SectionFixture.항상_보이는_섹션;
 import static reviewme.fixture.TemplateFixture.템플릿;
@@ -12,6 +15,8 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import reviewme.question.domain.OptionGroup;
+import reviewme.question.domain.OptionItem;
 import reviewme.question.domain.Question;
 import reviewme.reviewgroup.domain.ReviewGroup;
 import reviewme.reviewgroup.repository.ReviewGroupRepository;
@@ -34,6 +39,12 @@ class QuestionRepositoryTest {
 
     @Autowired
     private ReviewGroupRepository reviewGroupRepository;
+
+    @Autowired
+    private OptionGroupRepository optionGroupRepository;
+
+    @Autowired
+    private OptionItemRepository optionItemRepository;
 
     @Test
     void 템플릿_아이디로_질문_목록_아이디를_모두_가져온다() {
@@ -108,6 +119,29 @@ class QuestionRepositoryTest {
         assertAll(
                 () -> assertThat(questionsInSection1).containsOnly(question1, question2),
                 () -> assertThat(questionsInSection2).containsOnly(question3, question4)
+        );
+    }
+
+    @Test
+    void 질문_아이디에_해당하는_모든_옵션_아이템을_불러온다() {
+        // given
+        Question question1 = questionRepository.save(선택형_필수_질문());
+        Question question2 = questionRepository.save(선택형_필수_질문());
+        OptionGroup optionGroup1 = optionGroupRepository.save(선택지_그룹(question1.getId()));
+        OptionGroup optionGroup2 = optionGroupRepository.save(선택지_그룹(question2.getId()));
+
+        OptionItem optionItem1 = optionItemRepository.save(선택지(optionGroup1.getId()));
+        OptionItem optionItem2 = optionItemRepository.save(선택지(optionGroup1.getId()));
+        OptionItem optionItem3 = optionItemRepository.save(선택지(optionGroup2.getId()));
+
+        // when
+        List<OptionItem> optionItemsForQuestion1 = questionRepository.findAllOptionItemsById(question1.getId());
+        List<OptionItem> optionItemsForQuestion2 = questionRepository.findAllOptionItemsById(question2.getId());
+
+        // then
+        assertAll(
+                () -> assertThat(optionItemsForQuestion1).containsOnly(optionItem1, optionItem2),
+                () -> assertThat(optionItemsForQuestion2).containsOnly(optionItem3)
         );
     }
 }

--- a/backend/src/test/java/reviewme/question/repository/QuestionRepositoryTest.java
+++ b/backend/src/test/java/reviewme/question/repository/QuestionRepositoryTest.java
@@ -89,14 +89,15 @@ class QuestionRepositoryTest {
     }
 
     @Test
-    void 섹션_아이디에_해당하는_질문을_모두_가져온다() {
+    void 섹션_아이디에_해당하는_질문을_순서대로_가져온다() {
         // given
         Question question1 = questionRepository.save(서술형_필수_질문(1));
         Question question2 = questionRepository.save(서술형_필수_질문(2));
-        Question question3 = questionRepository.save(서술형_필수_질문(1));
+        Question question3 = questionRepository.save(서술형_필수_질문(3));
+        Question question4 = questionRepository.save(서술형_필수_질문(1));
 
-        List<Long> sectionQuestion1 = List.of(question1.getId(), question2.getId());
-        List<Long> sectionQuestion2 = List.of(question3.getId());
+        List<Long> sectionQuestion1 = List.of(question1.getId(), question2.getId(), question3.getId());
+        List<Long> sectionQuestion2 = List.of(question4.getId());
         Section section1 = sectionRepository.save(항상_보이는_섹션(sectionQuestion1));
         Section section2 = sectionRepository.save(항상_보이는_섹션(sectionQuestion2));
         Template template = templateRepository.save(템플릿(List.of(section1.getId(), section2.getId())));
@@ -106,10 +107,10 @@ class QuestionRepositoryTest {
         ));
 
         // when
-        List<Question> questionsInSection = questionRepository.findAllBySectionId(section1.getId());
+        List<Question> questionsInSection = questionRepository.findAllBySectionIdOrderByPosition(section1.getId());
 
         // then
-        assertThat(questionsInSection).containsOnly(question1, question2);
+        assertThat(questionsInSection).containsExactly(question1, question2, question3);
     }
 
     @Test

--- a/backend/src/test/java/reviewme/question/repository/QuestionRepositoryTest.java
+++ b/backend/src/test/java/reviewme/question/repository/QuestionRepositoryTest.java
@@ -1,12 +1,10 @@
 package reviewme.question.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 import static reviewme.fixture.OptionGroupFixture.선택지_그룹;
 import static reviewme.fixture.OptionItemFixture.선택지;
 import static reviewme.fixture.QuestionFixture.서술형_필수_질문;
 import static reviewme.fixture.QuestionFixture.선택형_필수_질문;
-import static reviewme.fixture.ReviewGroupFixture.리뷰_그룹;
 import static reviewme.fixture.SectionFixture.항상_보이는_섹션;
 import static reviewme.fixture.TemplateFixture.템플릿;
 
@@ -91,35 +89,27 @@ class QuestionRepositoryTest {
     }
 
     @Test
-    void 리뷰_요청_코드와_섹션_아이디에_해당하는_질문을_모두_가져온다() {
+    void 섹션_아이디에_해당하는_질문을_모두_가져온다() {
         // given
-        String reviewRequestCode = "12341234";
-        ReviewGroup reviewGroup = reviewGroupRepository.save(리뷰_그룹(reviewRequestCode, "43214321"));
-
         Question question1 = questionRepository.save(서술형_필수_질문(1));
         Question question2 = questionRepository.save(서술형_필수_질문(2));
         Question question3 = questionRepository.save(서술형_필수_질문(1));
-        Question question4 = questionRepository.save(서술형_필수_질문(2));
 
         List<Long> sectionQuestion1 = List.of(question1.getId(), question2.getId());
-        List<Long> sectionQuestion2 = List.of(question3.getId(), question4.getId());
+        List<Long> sectionQuestion2 = List.of(question3.getId());
         Section section1 = sectionRepository.save(항상_보이는_섹션(sectionQuestion1));
         Section section2 = sectionRepository.save(항상_보이는_섹션(sectionQuestion2));
-        List<Long> sectionIds = List.of(section1.getId(), section2.getId());
-        Template template = templateRepository.save(템플릿(sectionIds));
+        Template template = templateRepository.save(템플릿(List.of(section1.getId(), section2.getId())));
+
+        ReviewGroup reviewGroup = reviewGroupRepository.save(new ReviewGroup(
+                "reviewee", "projectName", "reviewRequestCode", "groupAccessCode", template.getId()
+        ));
 
         // when
-        List<Question> questionsInSection1 = questionRepository.findAllByReviewRequestCodeAndSectionId(
-                reviewRequestCode, section1.getId());
-        List<Question> questionsInSection2 = questionRepository.findAllByReviewRequestCodeAndSectionId(
-                reviewRequestCode, section2.getId());
-
+        List<Question> questionsInSection = questionRepository.findAllBySectionId(section1.getId());
 
         // then
-        assertAll(
-                () -> assertThat(questionsInSection1).containsOnly(question1, question2),
-                () -> assertThat(questionsInSection2).containsOnly(question3, question4)
-        );
+        assertThat(questionsInSection).containsOnly(question1, question2);
     }
 
     @Test

--- a/backend/src/test/java/reviewme/question/repository/QuestionRepositoryTest.java
+++ b/backend/src/test/java/reviewme/question/repository/QuestionRepositoryTest.java
@@ -114,7 +114,7 @@ class QuestionRepositoryTest {
     }
 
     @Test
-    void 질문_아이디에_해당하는_모든_옵션_아이템을_불러온다() {
+    void 질문_아이디에_해당하는_모든_옵션_아이템을_순서대로_불러온다() {
         // given
         Question question1 = questionRepository.save(선택형_필수_질문());
         Question question2 = questionRepository.save(선택형_필수_질문());
@@ -126,9 +126,10 @@ class QuestionRepositoryTest {
         OptionItem optionItem3 = optionItemRepository.save(선택지(optionGroup2.getId()));
 
         // when
-        List<OptionItem> optionItemsForQuestion1 = questionRepository.findAllOptionItemsById(question1.getId());
+        List<OptionItem> optionItemsForQuestion1
+                = questionRepository.findAllOptionItemsByIdOrderByPosition(question1.getId());
 
         // then
-        assertThat(optionItemsForQuestion1).containsOnly(optionItem1, optionItem2);
+        assertThat(optionItemsForQuestion1).containsExactly(optionItem1, optionItem2);
     }
 }

--- a/backend/src/test/java/reviewme/review/repository/AnswerRepositoryTest.java
+++ b/backend/src/test/java/reviewme/review/repository/AnswerRepositoryTest.java
@@ -27,22 +27,22 @@ import reviewme.template.repository.TemplateRepository;
 class AnswerRepositoryTest {
 
     @Autowired
-    AnswerRepository answerRepository;
+    private AnswerRepository answerRepository;
 
     @Autowired
-    QuestionRepository questionRepository;
+    private QuestionRepository questionRepository;
 
     @Autowired
-    SectionRepository sectionRepository;
+    private SectionRepository sectionRepository;
 
     @Autowired
-    TemplateRepository templateRepository;
+    private TemplateRepository templateRepository;
 
     @Autowired
-    ReviewGroupRepository reviewGroupRepository;
+    private ReviewGroupRepository reviewGroupRepository;
 
     @Autowired
-    ReviewRepository reviewRepository;
+    private ReviewRepository reviewRepository;
 
     @Test
     void 내가_받은_답변들_중_주어진_질문들에_대한_답변들을_최신_작성순으로_제한된_수만_반환한다() {

--- a/backend/src/test/java/reviewme/review/repository/AnswerRepositoryTest.java
+++ b/backend/src/test/java/reviewme/review/repository/AnswerRepositoryTest.java
@@ -1,19 +1,30 @@
 package reviewme.review.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static reviewme.fixture.QuestionFixture.서술형_필수_질문;
+import static reviewme.fixture.ReviewGroupFixture.리뷰_그룹;
+import static reviewme.fixture.SectionFixture.항상_보이는_섹션;
+import static reviewme.fixture.TemplateFixture.템플릿;
 
 import java.util.List;
 import java.util.Set;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import reviewme.fixture.QuestionFixture;
 import reviewme.fixture.ReviewGroupFixture;
+import reviewme.question.domain.Question;
 import reviewme.question.repository.QuestionRepository;
+import reviewme.review.domain.Answer;
 import reviewme.review.domain.Review;
 import reviewme.review.domain.TextAnswer;
 import reviewme.reviewgroup.domain.ReviewGroup;
 import reviewme.reviewgroup.repository.ReviewGroupRepository;
+import reviewme.template.domain.Section;
+import reviewme.template.domain.Template;
+import reviewme.template.repository.SectionRepository;
+import reviewme.template.repository.TemplateRepository;
 
 @DataJpaTest
 class AnswerRepositoryTest {
@@ -22,13 +33,49 @@ class AnswerRepositoryTest {
     AnswerRepository answerRepository;
 
     @Autowired
+    QuestionRepository questionRepository;
+
+    @Autowired
+    SectionRepository sectionRepository;
+
+    @Autowired
+    TemplateRepository templateRepository;
+
+    @Autowired
     ReviewGroupRepository reviewGroupRepository;
 
     @Autowired
     ReviewRepository reviewRepository;
 
-    @Autowired
-    QuestionRepository questionRepository;
+    @Test
+    void 주어진_질문들에_대한_답변들을_반환한다() {
+        // given
+        Question question1 = questionRepository.save(서술형_필수_질문());
+        Question question2 = questionRepository.save(서술형_필수_질문());
+        Section section = sectionRepository.save(항상_보이는_섹션(List.of(question1.getId(), question2.getId())));
+        Template template = templateRepository.save(템플릿(List.of(section.getId())));
+        ReviewGroup reviewGroup = reviewGroupRepository.save(리뷰_그룹());
+
+        TextAnswer answer1 = new TextAnswer(question1.getId(), "답1".repeat(20));
+        TextAnswer answer2 = new TextAnswer(question1.getId(), "답2".repeat(20));
+        TextAnswer answer3 = new TextAnswer(question2.getId(), "답3".repeat(20));
+        Review review1 = reviewRepository.save(new Review(template.getId(), reviewGroup.getId(), List.of(answer1)));
+        Review review2 = reviewRepository.save(new Review(template.getId(), reviewGroup.getId(),
+                List.of(answer2, answer3)));
+
+        // when
+        List<Answer> answerForQuestion1 = answerRepository.findAllByQuestions(List.of(question1.getId()));
+        List<Answer> answerForQuestion2 = answerRepository.findAllByQuestions(List.of(question2.getId()));
+        List<Answer> answerForAllQuestion = answerRepository.findAllByQuestions(
+                List.of(question1.getId(), question2.getId()));
+
+        // then
+        Assertions.assertAll(
+                () -> assertThat(answerForQuestion1).containsOnly(answer1, answer2),
+                () -> assertThat(answerForQuestion2).containsOnly(answer3),
+                () -> assertThat(answerForAllQuestion).containsOnly(answer1, answer2, answer3)
+        );
+    }
 
     @Test
     void 리뷰_그룹_id로_리뷰들을_찾아_id를_반환한다() {

--- a/backend/src/test/java/reviewme/review/repository/AnswerRepositoryTest.java
+++ b/backend/src/test/java/reviewme/review/repository/AnswerRepositoryTest.java
@@ -45,7 +45,7 @@ class AnswerRepositoryTest {
     ReviewRepository reviewRepository;
 
     @Test
-    void 내가_받은_답변들_중_주어진_질문들에_대한_답변들을_반환한다() {
+    void 내가_받은_답변들_중_주어진_질문들에_대한_답변들을_최신_작성순으로_반환한다() {
         // given
         Question question1 = questionRepository.save(서술형_필수_질문());
         Question question2 = questionRepository.save(서술형_필수_질문());
@@ -61,7 +61,7 @@ class AnswerRepositoryTest {
         reviewRepository.save(new Review(template.getId(), reviewGroup.getId(), List.of(answer1, answer2, answer3)));
 
         // when
-        List<Answer> actual = answerRepository.findReceivedAnswersByQuestionIds(
+        List<Answer> actual = answerRepository.findReceivedAnswersByQuestionIdsOrderByCreatedAtDesc(
                 reviewGroup.getId(), List.of(question1.getId(), question2.getId()));
 
         // then

--- a/backend/src/test/java/reviewme/review/repository/AnswerRepositoryTest.java
+++ b/backend/src/test/java/reviewme/review/repository/AnswerRepositoryTest.java
@@ -45,7 +45,7 @@ class AnswerRepositoryTest {
     ReviewRepository reviewRepository;
 
     @Test
-    void 내가_받은_답변들_중_주어진_질문들에_대한_답변들을_최신_작성순으로_반환한다() {
+    void 내가_받은_답변들_중_주어진_질문들에_대한_답변들을_최신_작성순으로_제한된_수만_반환한다() {
         // given
         Question question1 = questionRepository.save(서술형_필수_질문());
         Question question2 = questionRepository.save(서술형_필수_질문());
@@ -57,15 +57,18 @@ class AnswerRepositoryTest {
 
         TextAnswer answer1 = new TextAnswer(question1.getId(), "답1".repeat(20));
         TextAnswer answer2 = new TextAnswer(question2.getId(), "답2".repeat(20));
-        TextAnswer answer3 = new TextAnswer(question3.getId(), "답3".repeat(20));
-        reviewRepository.save(new Review(template.getId(), reviewGroup.getId(), List.of(answer1, answer2, answer3)));
+        TextAnswer answer3 = new TextAnswer(question2.getId(), "답3".repeat(20));
+        TextAnswer answer4 = new TextAnswer(question3.getId(), "답4".repeat(20));
+        reviewRepository.save(new Review(template.getId(), reviewGroup.getId(), List.of(answer1)));
+        reviewRepository.save(new Review(template.getId(), reviewGroup.getId(), List.of(answer2)));
+        reviewRepository.save(new Review(template.getId(), reviewGroup.getId(), List.of(answer3)));
 
         // when
-        List<Answer> actual = answerRepository.findReceivedAnswersByQuestionIdsOrderByCreatedAtDesc(
-                reviewGroup.getId(), List.of(question1.getId(), question2.getId()));
+        List<Answer> actual = answerRepository.findReceivedAnswersByQuestionIds(
+                reviewGroup.getId(), List.of(question1.getId(), question2.getId()), 2);
 
         // then
-        assertThat(actual).containsOnly(answer1, answer2);
+        assertThat(actual).containsExactly(answer3, answer2);
     }
 
     @Test

--- a/backend/src/test/java/reviewme/review/repository/AnswerRepositoryTest.java
+++ b/backend/src/test/java/reviewme/review/repository/AnswerRepositoryTest.java
@@ -8,12 +8,9 @@ import static reviewme.fixture.TemplateFixture.템플릿;
 
 import java.util.List;
 import java.util.Set;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import reviewme.fixture.QuestionFixture;
-import reviewme.fixture.ReviewGroupFixture;
 import reviewme.question.domain.Question;
 import reviewme.question.repository.QuestionRepository;
 import reviewme.review.domain.Answer;
@@ -52,35 +49,28 @@ class AnswerRepositoryTest {
         // given
         Question question1 = questionRepository.save(서술형_필수_질문());
         Question question2 = questionRepository.save(서술형_필수_질문());
-        Section section = sectionRepository.save(항상_보이는_섹션(List.of(question1.getId(), question2.getId())));
+        Question question3 = questionRepository.save(서술형_필수_질문());
+        Section section = sectionRepository.save(항상_보이는_섹션(
+                List.of(question1.getId(), question2.getId(), question3.getId())));
         Template template = templateRepository.save(템플릿(List.of(section.getId())));
         ReviewGroup reviewGroup = reviewGroupRepository.save(리뷰_그룹());
 
         TextAnswer answer1 = new TextAnswer(question1.getId(), "답1".repeat(20));
-        TextAnswer answer2 = new TextAnswer(question1.getId(), "답2".repeat(20));
-        TextAnswer answer3 = new TextAnswer(question2.getId(), "답3".repeat(20));
-        Review review1 = reviewRepository.save(new Review(template.getId(), reviewGroup.getId(), List.of(answer1)));
-        Review review2 = reviewRepository.save(new Review(template.getId(), reviewGroup.getId(),
-                List.of(answer2, answer3)));
+        TextAnswer answer2 = new TextAnswer(question2.getId(), "답2".repeat(20));
+        TextAnswer answer3 = new TextAnswer(question3.getId(), "답3".repeat(20));
+        reviewRepository.save(new Review(template.getId(), reviewGroup.getId(), List.of(answer1, answer2, answer3)));
 
         // when
-        List<Answer> answerForQuestion1 = answerRepository.findAllByQuestions(List.of(question1.getId()));
-        List<Answer> answerForQuestion2 = answerRepository.findAllByQuestions(List.of(question2.getId()));
-        List<Answer> answerForAllQuestion = answerRepository.findAllByQuestions(
-                List.of(question1.getId(), question2.getId()));
+        List<Answer> actual = answerRepository.findAllByQuestions(List.of(question1.getId(), question2.getId()));
 
         // then
-        Assertions.assertAll(
-                () -> assertThat(answerForQuestion1).containsOnly(answer1, answer2),
-                () -> assertThat(answerForQuestion2).containsOnly(answer3),
-                () -> assertThat(answerForAllQuestion).containsOnly(answer1, answer2, answer3)
-        );
+        assertThat(actual).containsOnly(answer1, answer2);
     }
 
     @Test
     void 리뷰_그룹_id로_리뷰들을_찾아_id를_반환한다() {
         // given
-        ReviewGroup reviewGroup = reviewGroupRepository.save(ReviewGroupFixture.리뷰_그룹());
+        ReviewGroup reviewGroup = reviewGroupRepository.save(리뷰_그룹());
         TextAnswer answer1 = new TextAnswer(1L, "text answer1");
         TextAnswer answer2 = new TextAnswer(1L, "text answer2");
         Review review = reviewRepository.save(new Review(1L, reviewGroup.getId(), List.of(answer1, answer2)));
@@ -95,9 +85,9 @@ class AnswerRepositoryTest {
     @Test
     void 질문_id로_리뷰들을_찾아_id를_반환한다() {
         // given
-        ReviewGroup reviewGroup = reviewGroupRepository.save(ReviewGroupFixture.리뷰_그룹());
-        long questionId1 = questionRepository.save(QuestionFixture.서술형_필수_질문()).getId();
-        long questionId2 = questionRepository.save(QuestionFixture.서술형_필수_질문()).getId();
+        ReviewGroup reviewGroup = reviewGroupRepository.save(리뷰_그룹());
+        long questionId1 = questionRepository.save(서술형_필수_질문()).getId();
+        long questionId2 = questionRepository.save(서술형_필수_질문()).getId();
         TextAnswer textAnswer1_Q1 = new TextAnswer(questionId1, "text answer1 by Q1");
         TextAnswer textAnswer2_Q1 = new TextAnswer(questionId1, "text answer2 by Q1");
         TextAnswer textAnswer1_Q2 = new TextAnswer(questionId2, "text answer1 by Q2");

--- a/backend/src/test/java/reviewme/review/repository/AnswerRepositoryTest.java
+++ b/backend/src/test/java/reviewme/review/repository/AnswerRepositoryTest.java
@@ -45,7 +45,7 @@ class AnswerRepositoryTest {
     ReviewRepository reviewRepository;
 
     @Test
-    void 주어진_질문들에_대한_답변들을_반환한다() {
+    void 내가_받은_답변들_중_주어진_질문들에_대한_답변들을_반환한다() {
         // given
         Question question1 = questionRepository.save(서술형_필수_질문());
         Question question2 = questionRepository.save(서술형_필수_질문());
@@ -61,7 +61,8 @@ class AnswerRepositoryTest {
         reviewRepository.save(new Review(template.getId(), reviewGroup.getId(), List.of(answer1, answer2, answer3)));
 
         // when
-        List<Answer> actual = answerRepository.findAllByQuestionIds(List.of(question1.getId(), question2.getId()));
+        List<Answer> actual = answerRepository.findReceivedAnswersByQuestionIds(
+                reviewGroup.getId(), List.of(question1.getId(), question2.getId()));
 
         // then
         assertThat(actual).containsOnly(answer1, answer2);

--- a/backend/src/test/java/reviewme/review/repository/AnswerRepositoryTest.java
+++ b/backend/src/test/java/reviewme/review/repository/AnswerRepositoryTest.java
@@ -61,7 +61,7 @@ class AnswerRepositoryTest {
         reviewRepository.save(new Review(template.getId(), reviewGroup.getId(), List.of(answer1, answer2, answer3)));
 
         // when
-        List<Answer> actual = answerRepository.findAllByQuestions(List.of(question1.getId(), question2.getId()));
+        List<Answer> actual = answerRepository.findAllByQuestionIds(List.of(question1.getId(), question2.getId()));
 
         // then
         assertThat(actual).containsOnly(answer1, answer2);

--- a/backend/src/test/java/reviewme/review/service/GatheredReviewLookupServiceTest.java
+++ b/backend/src/test/java/reviewme/review/service/GatheredReviewLookupServiceTest.java
@@ -1,0 +1,393 @@
+package reviewme.review.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static reviewme.fixture.OptionGroupFixture.선택지_그룹;
+import static reviewme.fixture.OptionItemFixture.선택지;
+import static reviewme.fixture.QuestionFixture.서술형_옵션_질문;
+import static reviewme.fixture.QuestionFixture.서술형_필수_질문;
+import static reviewme.fixture.QuestionFixture.선택형_옵션_질문;
+import static reviewme.fixture.QuestionFixture.선택형_필수_질문;
+import static reviewme.fixture.ReviewGroupFixture.리뷰_그룹;
+import static reviewme.fixture.SectionFixture.항상_보이는_섹션;
+import static reviewme.fixture.TemplateFixture.템플릿;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import reviewme.question.domain.OptionGroup;
+import reviewme.question.domain.OptionItem;
+import reviewme.question.domain.OptionType;
+import reviewme.question.domain.Question;
+import reviewme.question.repository.OptionGroupRepository;
+import reviewme.question.repository.OptionItemRepository;
+import reviewme.question.repository.QuestionRepository;
+import reviewme.review.domain.CheckboxAnswer;
+import reviewme.review.domain.Review;
+import reviewme.review.domain.TextAnswer;
+import reviewme.review.repository.ReviewRepository;
+import reviewme.review.service.dto.response.gathered.ReviewsGatheredBySectionResponse;
+import reviewme.reviewgroup.domain.ReviewGroup;
+import reviewme.reviewgroup.repository.ReviewGroupRepository;
+import reviewme.support.ServiceTest;
+import reviewme.template.domain.Section;
+import reviewme.template.domain.Template;
+import reviewme.template.repository.SectionRepository;
+import reviewme.template.repository.TemplateRepository;
+
+@ServiceTest
+class GatheredReviewLookupServiceTest {
+
+    @Autowired
+    private ReviewGroupRepository reviewGroupRepository;
+
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @Autowired
+    private SectionRepository sectionRepository;
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    @Autowired
+    private OptionGroupRepository optionGroupRepository;
+
+    @Autowired
+    private OptionItemRepository optionItemRepository;
+
+    @Autowired
+    private TemplateRepository templateRepository;
+
+    @Autowired
+    private GatheredReviewLookupService reviewLookupService;
+
+    private String reviewRequestCode;
+    private ReviewGroup reviewGroup;
+
+    @BeforeEach
+    void saveReviewGroup() {
+        reviewRequestCode = "1111";
+        reviewGroup = reviewGroupRepository.save(리뷰_그룹(reviewRequestCode, "2222"));
+    }
+
+    @Nested
+    @DisplayName("섹션에 해당하는 서술형 응답을 질문별로 묶어 반환한다")
+    class GatherAnswerByQuestionTest {
+
+        @Test
+        void 섹션_하위_질문이_하나인_경우() {
+            // given - 질문 저장
+            Question question1 = questionRepository.save(서술형_필수_질문());
+
+            // given - 섹션, 템플릿 저장
+            Section section1 = sectionRepository.save(항상_보이는_섹션(List.of(question1.getId())));
+            Template template = templateRepository.save(템플릿(List.of(section1.getId())));
+
+            // given - 리뷰 답변 저장
+            TextAnswer answerKB = new TextAnswer(question1.getId(), "커비가 작성한 서술형 답변1");
+            TextAnswer answerSC = new TextAnswer(question1.getId(), "산초가 작성한 서술형 답변1");
+            reviewRepository.save(new Review(template.getId(), reviewGroup.getId(), List.of(answerKB)));
+            reviewRepository.save(new Review(template.getId(), reviewGroup.getId(), List.of(answerSC)));
+
+            // when
+            ReviewsGatheredBySectionResponse actual = reviewLookupService.getReceivedReviewsBySectionId(
+                    reviewRequestCode, section1.getId());
+
+            // then
+            assertThat(actual.reviews()).hasSize(1);
+            assertThat(actual.reviews().get(0).question().name()).isEqualTo(question1.getContent());
+            assertThat(actual.reviews().get(0).answers()).extracting("content")
+                    .containsOnly("커비가 작성한 서술형 답변1", "산초가 작성한 서술형 답변1");
+            assertThat(actual.reviews().get(0).votes()).isNull();
+        }
+
+        @Test
+        void 섹션_하위_질문이_여러개인_경우() {
+            // given - 질문 저장
+            Question question1 = questionRepository.save(서술형_필수_질문());
+            Question question2 = questionRepository.save(서술형_필수_질문());
+
+            // given - 섹션, 템플릿 저장
+            Section section1 = sectionRepository.save(항상_보이는_섹션(List.of(question1.getId(), question2.getId())));
+            Template template = templateRepository.save(템플릿(List.of(section1.getId())));
+
+            // given - 리뷰 답변 저장
+            TextAnswer answerAR1 = new TextAnswer(question1.getId(), "아루가 작성한 서술형 답변1");
+            TextAnswer answerAR2 = new TextAnswer(question2.getId(), "아루가 작성한 서술형 답변2");
+            TextAnswer answerTD1 = new TextAnswer(question1.getId(), "테드가 작성한 서술형 답변1");
+            TextAnswer answerTD2 = new TextAnswer(question2.getId(), "테드가 작성한 서술형 답변2");
+            reviewRepository.save(new Review(template.getId(), reviewGroup.getId(), List.of(answerAR1, answerAR2)));
+            reviewRepository.save(new Review(template.getId(), reviewGroup.getId(), List.of(answerTD1, answerTD2)));
+
+            // when
+            ReviewsGatheredBySectionResponse actual = reviewLookupService.getReceivedReviewsBySectionId(
+                    reviewRequestCode, section1.getId());
+
+            // then
+            assertThat(actual.reviews())
+                    .hasSize(2);
+            assertThat(actual.reviews())
+                    .extracting("question.name")
+                    .containsOnly(question1.getContent(), question2.getContent());
+            assertThat(actual.reviews().get(0).answers())
+                    .extracting("content")
+                    .containsExactlyInAnyOrder("아루가 작성한 서술형 답변1", "테드가 작성한 서술형 답변1");
+            assertThat(actual.reviews().get(1).answers())
+                    .extracting("content")
+                    .containsExactlyInAnyOrder("아루가 작성한 서술형 답변2", "테드가 작성한 서술형 답변2");
+            assertThat(actual.reviews().get(0).votes()).isNull();
+        }
+
+        @Test
+        void 여러개의_섹션이_있는_경우_주어진_섹션ID에_해당하는_것만_반환한다() {
+            // given - 질문 저장
+            Question question1 = questionRepository.save(서술형_필수_질문());
+            Question question2 = questionRepository.save(서술형_필수_질문());
+
+            // given - 섹션, 템플릿 저장
+            Section section1 = sectionRepository.save(항상_보이는_섹션(List.of(question1.getId())));
+            Section section2 = sectionRepository.save(항상_보이는_섹션(List.of(question2.getId())));
+            Template template = templateRepository.save(템플릿(List.of(section1.getId(), section2.getId())));
+
+            // given - 리뷰 답변 저장
+            TextAnswer answerAR1 = new TextAnswer(question1.getId(), "아루가 작성한 서술형 답변1");
+            TextAnswer answerAR2 = new TextAnswer(question2.getId(), "아루가 작성한 서술형 답변2");
+            TextAnswer answerTD1 = new TextAnswer(question1.getId(), "테드가 작성한 서술형 답변1");
+            TextAnswer answerTD2 = new TextAnswer(question2.getId(), "테드가 작성한 서술형 답변2");
+            reviewRepository.save(new Review(template.getId(), reviewGroup.getId(), List.of(answerAR1, answerAR2)));
+            reviewRepository.save(new Review(template.getId(), reviewGroup.getId(), List.of(answerTD1, answerTD2)));
+
+            // when
+            ReviewsGatheredBySectionResponse actual = reviewLookupService.getReceivedReviewsBySectionId(
+                    reviewRequestCode, section1.getId());
+
+            // then
+            assertThat(actual.reviews())
+                    .hasSize(1);
+            assertThat(actual.reviews())
+                    .extracting("question.name")
+                    .containsOnly(question1.getContent());
+            assertThat(actual.reviews().get(0).answers())
+                    .extracting("content")
+                    .containsExactlyInAnyOrder("아루가 작성한 서술형 답변1", "테드가 작성한 서술형 답변1");
+            assertThat(actual.reviews().get(0).votes()).isNull();
+        }
+
+        @Test
+        void 섹션에_필수가_아닌_질문이_있는_경우_답변된_내용만_반환한다() {
+            // given - 질문 저장
+            Question question1 = questionRepository.save(서술형_옵션_질문());
+            Question question2 = questionRepository.save(서술형_옵션_질문());
+
+            // given - 섹션, 템플릿 저장
+            Section section1 = sectionRepository.save(항상_보이는_섹션(List.of(question1.getId(), question2.getId())));
+            Template template = templateRepository.save(템플릿(List.of(section1.getId())));
+
+            // given - 리뷰 답변 저장
+            TextAnswer answerSC1 = new TextAnswer(question1.getId(), "산초가 작성한 서술형 답변1");
+            TextAnswer answerSC2 = new TextAnswer(question2.getId(), "산초가 작성한 서술형 답변2");
+            TextAnswer answerAR = new TextAnswer(question1.getId(), "아루가 작성한 서술형 답변");
+            reviewRepository.save(new Review(template.getId(), reviewGroup.getId(), List.of(answerSC1, answerSC2)));
+            reviewRepository.save(new Review(template.getId(), reviewGroup.getId(), List.of(answerAR)));
+
+            // when
+            ReviewsGatheredBySectionResponse actual = reviewLookupService.getReceivedReviewsBySectionId(
+                    reviewRequestCode, section1.getId());
+
+            // then
+            assertThat(actual.reviews())
+                    .hasSize(2);
+            assertThat(actual.reviews())
+                    .extracting("question.name")
+                    .containsOnly(question1.getContent(), question2.getContent());
+            assertThat(actual.reviews().get(0).answers())
+                    .extracting("content")
+                    .containsExactlyInAnyOrder("산초가 작성한 서술형 답변1", "아루가 작성한 서술형 답변");
+            assertThat(actual.reviews().get(1).answers())
+                    .extracting("content")
+                    .containsExactly("산초가 작성한 서술형 답변2");
+            assertThat(actual.reviews().get(0).votes()).isNull();
+        }
+
+        @Test
+        void 질문에_응답이_없는_경우_질문_내용은_반환되_응답은_빈_배열로_반환한다() {
+            // given - 질문 저장
+            Question question1 = questionRepository.save(서술형_필수_질문());
+
+            // given - 섹션, 템플릿 저장
+            Section section1 = sectionRepository.save(항상_보이는_섹션(List.of(question1.getId())));
+            Template template = templateRepository.save(템플릿(List.of(section1.getId())));
+
+            // when
+            ReviewsGatheredBySectionResponse actual = reviewLookupService.getReceivedReviewsBySectionId(
+                    reviewRequestCode, section1.getId());
+
+            // then
+            assertThat(actual.reviews()).hasSize(1);
+            assertThat(actual.reviews().get(0).question().name()).isEqualTo(question1.getContent());
+            assertThat(actual.reviews().get(0).answers()).isEmpty();
+            assertThat(actual.reviews().get(0).votes()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("섹션에 해당하는 선택형 응답을 질문별로 묶고, 선택된 횟수를 계산하여 반환한다")
+    class GatherOptionAnswerByQuestionTest {
+
+        @Test
+        void 섹션_하위_질문이_하나인_경우() {
+            // given - 질문 저장
+            Question question1 = questionRepository.save(선택형_필수_질문());
+            OptionGroup optionGroup = optionGroupRepository.save(선택지_그룹(question1.getId()));
+            OptionItem optionItem1 = optionItemRepository.save(
+                    new OptionItem("짜장", optionGroup.getId(), 1, OptionType.CATEGORY));
+            OptionItem optionItem2 = optionItemRepository.save(
+                    new OptionItem("짬뽕", optionGroup.getId(), 2, OptionType.CATEGORY));
+
+            // given - 섹션, 템플릿 저장
+            Section section1 = sectionRepository.save(항상_보이는_섹션(List.of(question1.getId())));
+            Template template = templateRepository.save(템플릿(List.of(section1.getId())));
+
+            // given - 리뷰 답변 저장
+            CheckboxAnswer answer1 = new CheckboxAnswer(question1.getId(), List.of(optionItem1.getId()));
+            CheckboxAnswer answer2 = new CheckboxAnswer(question1.getId(),
+                    List.of(optionItem1.getId(), optionItem2.getId()));
+            reviewRepository.save(new Review(template.getId(), reviewGroup.getId(), List.of(answer1)));
+            reviewRepository.save(new Review(template.getId(), reviewGroup.getId(), List.of(answer2)));
+
+            // when
+            ReviewsGatheredBySectionResponse actual = reviewLookupService.getReceivedReviewsBySectionId(
+                    reviewRequestCode, section1.getId());
+
+            // then
+            assertThat(actual.reviews()).hasSize(1);
+            assertThat(actual.reviews().get(0).question().name()).isEqualTo(question1.getContent());
+            assertThat(actual.reviews().get(0).votes())
+                    .extracting("content", "count")
+                    .containsExactlyInAnyOrder(
+                            tuple("짜장", 2L),
+                            tuple("짬뽕", 1L)
+                    );
+            assertThat(actual.reviews().get(0).answers()).isNull();
+        }
+
+        @Test
+        void 섹션_하위_질문이_여러개인_경우() {
+            // given - 질문 저장
+            Question question1 = questionRepository.save(선택형_옵션_질문());
+            Question question2 = questionRepository.save(선택형_옵션_질문());
+            OptionGroup optionGroup1 = optionGroupRepository.save(선택지_그룹(question1.getId()));
+            OptionGroup optionGroup2 = optionGroupRepository.save(선택지_그룹(question2.getId()));
+            OptionItem optionItem1 = optionItemRepository.save(
+                    new OptionItem("중식", optionGroup1.getId(), 1, OptionType.CATEGORY));
+            OptionItem optionItem2 = optionItemRepository.save(
+                    new OptionItem("분식", optionGroup2.getId(), 2, OptionType.CATEGORY));
+
+            // given - 섹션, 템플릿 저장
+            Section section1 = sectionRepository.save(항상_보이는_섹션(List.of(question1.getId(), question2.getId())));
+            Template template = templateRepository.save(템플릿(List.of(section1.getId())));
+
+            // given - 리뷰 답변 저장
+            CheckboxAnswer answer1 = new CheckboxAnswer(question1.getId(), List.of(optionItem1.getId()));
+            CheckboxAnswer answer2 = new CheckboxAnswer(question2.getId(), List.of(optionItem2.getId()));
+            reviewRepository.save(new Review(template.getId(), reviewGroup.getId(), List.of(answer1, answer2)));
+
+            // when
+            ReviewsGatheredBySectionResponse actual = reviewLookupService.getReceivedReviewsBySectionId(
+                    reviewRequestCode, section1.getId());
+
+            // then
+            assertThat(actual.reviews()).hasSize(2);
+            assertThat(actual.reviews())
+                    .extracting("question.name")
+                    .containsOnly(question1.getContent(), question2.getContent());
+            assertThat(actual.reviews().get(0).votes())
+                    .extracting("content", "count")
+                    .containsOnly(tuple("중식", 1L));
+            assertThat(actual.reviews().get(1).votes())
+                    .extracting("content", "count")
+                    .containsOnly(tuple("분식", 1L));
+            assertThat(actual.reviews().get(0).answers()).isNull();
+        }
+
+        @Test
+        void 아무도_고르지_않은_선택지는_0개로_계산하여_반환한다() {
+            // given - 질문 저장
+            Question question1 = questionRepository.save(선택형_필수_질문());
+            OptionGroup optionGroup = optionGroupRepository.save(선택지_그룹(question1.getId()));
+            OptionItem optionItem1 = optionItemRepository.save(
+                    new OptionItem("우테코 산초", optionGroup.getId(), 1, OptionType.CATEGORY));
+            OptionItem optionItem2 = optionItemRepository.save(
+                    new OptionItem("제이든 산초", optionGroup.getId(), 2, OptionType.CATEGORY));
+
+            // given - 섹션, 템플릿 저장
+            Section section1 = sectionRepository.save(항상_보이는_섹션(List.of(question1.getId())));
+            Template template = templateRepository.save(템플릿(List.of(section1.getId())));
+
+            // given - 리뷰 답변 저장
+            CheckboxAnswer answer1 = new CheckboxAnswer(question1.getId(), List.of(optionItem1.getId()));
+            CheckboxAnswer answer2 = new CheckboxAnswer(question1.getId(), List.of(optionItem1.getId()));
+            reviewRepository.save(new Review(template.getId(), reviewGroup.getId(), List.of(answer1)));
+            reviewRepository.save(new Review(template.getId(), reviewGroup.getId(), List.of(answer2)));
+
+            // when
+            ReviewsGatheredBySectionResponse actual = reviewLookupService.getReceivedReviewsBySectionId(
+                    reviewRequestCode, section1.getId());
+
+            // then
+            assertThat(actual.reviews()).hasSize(1);
+            assertThat(actual.reviews().get(0).question().name()).isEqualTo(question1.getContent());
+            assertThat(actual.reviews().get(0).votes())
+                    .extracting("content", "count")
+                    .containsExactlyInAnyOrder(
+                            tuple("우테코 산초", 2L),
+                            tuple("제이든 산초", 0L)
+                    );
+            assertThat(actual.reviews().get(0).answers()).isNull();
+        }
+    }
+
+    @Test
+    void 서술형_질문에_대한_응답과_선택형_질문에_대한_응답을_함께_반환한다() {
+        // given - 질문 저장
+        Question question1 = questionRepository.save(서술형_필수_질문());
+        Question question2 = questionRepository.save(선택형_필수_질문());
+        OptionGroup optionGroup = optionGroupRepository.save(선택지_그룹(question2.getId()));
+        OptionItem optionItem1 = optionItemRepository.save(선택지(optionGroup.getId()));
+        OptionItem optionItem2 = optionItemRepository.save(선택지(optionGroup.getId()));
+
+        // given - 섹션, 템플릿 저장
+        Section section1 = sectionRepository.save(항상_보이는_섹션(List.of(question1.getId(), question2.getId())));
+        Template template = templateRepository.save(템플릿(List.of(section1.getId())));
+
+        // given - 리뷰 답변 저장
+        TextAnswer answer1 = new TextAnswer(question1.getId(), "아루가 작성한 서술형 답변");
+        CheckboxAnswer answer2 = new CheckboxAnswer(question2.getId(), List.of(optionItem1.getId(), optionItem2.getId()));
+        reviewRepository.save(new Review(template.getId(), reviewGroup.getId(), List.of(answer1, answer2)));
+
+        // when
+        ReviewsGatheredBySectionResponse actual = reviewLookupService.getReceivedReviewsBySectionId(
+                reviewRequestCode, section1.getId());
+
+        // then
+        assertThat(actual.reviews()).hasSize(2);
+        assertThat(actual.reviews())
+                .extracting("question.name")
+                .containsOnly(question1.getContent(), question2.getContent());
+        assertThat(actual.reviews().get(0).answers())
+                .extracting("content")
+                .containsExactly("아루가 작성한 서술형 답변");
+        assertThat(actual.reviews().get(0).votes()).isNull();
+        assertThat(actual.reviews().get(1).votes())
+                .extracting("content", "count")
+                .containsExactlyInAnyOrder(
+                        tuple(optionItem1.getContent(), 1L),
+                        tuple(optionItem2.getContent(), 1L)
+                );
+        assertThat(actual.reviews().get(1).answers()).isNull();
+    }
+}

--- a/backend/src/test/java/reviewme/review/service/ReviewGatheredLookupServiceTest.java
+++ b/backend/src/test/java/reviewme/review/service/ReviewGatheredLookupServiceTest.java
@@ -287,7 +287,7 @@ class ReviewGatheredLookupServiceTest {
         }
 
         @Test
-        void 질문에_응답이_없는_경우_질문_내용은_반환되_응답은_빈_배열로_반환한다() {
+        void 질문에_응답이_없는_경우_질문_내용은_반환하되_응답은_빈_배열로_반환한다() {
             // given - 질문 저장
             Question question1 = questionRepository.save(서술형_필수_질문());
 

--- a/backend/src/test/java/reviewme/review/service/ReviewGatheredLookupServiceTest.java
+++ b/backend/src/test/java/reviewme/review/service/ReviewGatheredLookupServiceTest.java
@@ -90,7 +90,7 @@ class ReviewGatheredLookupServiceTest {
         Section section;
 
         @BeforeEach
-        void 질문들을_정해진_규칙에_맞게_반환한다() {
+        void setUp() {
             // given
             requiredTextQuestion = questionRepository.save(서술형_필수_질문(1));
             optionalTextQuestion = questionRepository.save(서술형_옵션_질문(2));
@@ -109,6 +109,23 @@ class ReviewGatheredLookupServiceTest {
                     reviewRequestCode, section.getId());
 
             assertThat(actual.reviews()).hasSize(4);
+        }
+
+        @Test
+        void 섹션_하위의_질문ID를_반환한다() {
+            // when
+            ReviewsGatheredBySectionResponse actual = reviewLookupService.getReceivedReviewsBySectionId(
+                    reviewRequestCode, section.getId());
+
+            // then
+            assertThat(actual.reviews())
+                    .extracting(ReviewsGatheredByQuestionResponse::question)
+                    .extracting(SimpleQuestionResponse::id)
+                    .containsExactly(
+                            requiredTextQuestion.getId(),
+                            optionalTextQuestion.getId(),
+                            requiredCheckboxQuestion.getId(),
+                            optionalCheckboxQuestion.getId());
         }
 
         @Test

--- a/backend/src/test/java/reviewme/review/service/ReviewGatheredLookupServiceTest.java
+++ b/backend/src/test/java/reviewme/review/service/ReviewGatheredLookupServiceTest.java
@@ -22,7 +22,6 @@ import reviewme.question.domain.OptionGroup;
 import reviewme.question.domain.OptionItem;
 import reviewme.question.domain.OptionType;
 import reviewme.question.domain.Question;
-import reviewme.question.domain.QuestionType;
 import reviewme.question.repository.OptionGroupRepository;
 import reviewme.question.repository.OptionItemRepository;
 import reviewme.question.repository.QuestionRepository;
@@ -77,112 +76,6 @@ class ReviewGatheredLookupServiceTest {
     void saveReviewGroup() {
         reviewRequestCode = "1111";
         reviewGroup = reviewGroupRepository.save(리뷰_그룹(reviewRequestCode, "2222"));
-    }
-
-    @Nested
-    @DisplayName("질문들을 규칙에 맞게 반환한다")
-    class GatherQuestionsBySectionTest {
-
-        Question requiredTextQuestion;
-        Question optionalTextQuestion;
-        Question requiredCheckboxQuestion;
-        Question optionalCheckboxQuestion;
-        Section section;
-
-        @BeforeEach
-        void setUp() {
-            // given
-            requiredTextQuestion = questionRepository.save(서술형_필수_질문(1));
-            optionalTextQuestion = questionRepository.save(서술형_옵션_질문(2));
-            requiredCheckboxQuestion = questionRepository.save(선택형_필수_질문(3));
-            optionalCheckboxQuestion = questionRepository.save(선택형_옵션_질문(4));
-            section = sectionRepository.save(항상_보이는_섹션(List.of(
-                    requiredTextQuestion.getId(), optionalTextQuestion.getId(),
-                    requiredCheckboxQuestion.getId(), optionalCheckboxQuestion.getId())));
-            templateRepository.save(템플릿(List.of(section.getId())));
-        }
-
-        @Test
-        void 섹션_하위의_질문_개수만큼_반환한다() {
-            // when
-            ReviewsGatheredBySectionResponse actual = reviewLookupService.getReceivedReviewsBySectionId(
-                    reviewRequestCode, section.getId());
-
-            assertThat(actual.reviews()).hasSize(4);
-        }
-
-        @Test
-        void 섹션_하위의_질문ID를_반환한다() {
-            // when
-            ReviewsGatheredBySectionResponse actual = reviewLookupService.getReceivedReviewsBySectionId(
-                    reviewRequestCode, section.getId());
-
-            // then
-            assertThat(actual.reviews())
-                    .extracting(ReviewsGatheredByQuestionResponse::question)
-                    .extracting(SimpleQuestionResponse::id)
-                    .containsExactly(
-                            requiredTextQuestion.getId(),
-                            optionalTextQuestion.getId(),
-                            requiredCheckboxQuestion.getId(),
-                            optionalCheckboxQuestion.getId());
-        }
-
-        @Test
-        void 섹션_하위의_질문_내용을_순서대로_반환한다() {
-            // when
-            ReviewsGatheredBySectionResponse actual = reviewLookupService.getReceivedReviewsBySectionId(
-                    reviewRequestCode, section.getId());
-
-            // then
-            assertThat(actual.reviews())
-                    .extracting(ReviewsGatheredByQuestionResponse::question)
-                    .extracting(SimpleQuestionResponse::name)
-                    .containsExactly(
-                            requiredTextQuestion.getContent(),
-                            optionalTextQuestion.getContent(),
-                            requiredCheckboxQuestion.getContent(),
-                            optionalCheckboxQuestion.getContent());
-        }
-
-        @Test
-        void 섹션_하위의_질문_타입을_반환한다() {
-            // when
-            ReviewsGatheredBySectionResponse actual = reviewLookupService.getReceivedReviewsBySectionId(
-                    reviewRequestCode, section.getId());
-
-            // then
-            assertThat(actual.reviews())
-                    .extracting(ReviewsGatheredByQuestionResponse::question)
-                    .extracting(SimpleQuestionResponse::type)
-                    .containsExactly(
-                            QuestionType.TEXT,
-                            QuestionType.TEXT,
-                            QuestionType.CHECKBOX,
-                            QuestionType.CHECKBOX
-                    );
-        }
-
-        @Test
-        void 질문의_타입에_해당하지_않는_응답은_null로_반환한다() {
-            // when
-            ReviewsGatheredBySectionResponse actual = reviewLookupService.getReceivedReviewsBySectionId(
-                    reviewRequestCode, section.getId());
-
-            // then
-            List<ReviewsGatheredByQuestionResponse> textQuestions = actual.reviews().stream()
-                    .filter(review -> review.question().type() == QuestionType.TEXT)
-                    .toList();
-            List<ReviewsGatheredByQuestionResponse> checkboxQuestions = actual.reviews().stream()
-                    .filter(review -> review.question().type() == QuestionType.CHECKBOX)
-                    .toList();
-            assertThat(textQuestions)
-                    .extracting(ReviewsGatheredByQuestionResponse::votes)
-                    .containsOnlyNulls();
-            assertThat(checkboxQuestions)
-                    .extracting(ReviewsGatheredByQuestionResponse::answers)
-                    .containsOnlyNulls();
-        }
     }
 
     @Nested

--- a/backend/src/test/java/reviewme/review/service/ReviewGatheredLookupServiceTest.java
+++ b/backend/src/test/java/reviewme/review/service/ReviewGatheredLookupServiceTest.java
@@ -34,6 +34,7 @@ import reviewme.review.service.dto.response.gathered.ReviewsGatheredByQuestionRe
 import reviewme.review.service.dto.response.gathered.ReviewsGatheredBySectionResponse;
 import reviewme.review.service.dto.response.gathered.SimpleQuestionResponse;
 import reviewme.review.service.dto.response.gathered.TextResponse;
+import reviewme.review.service.dto.response.gathered.VoteResponse;
 import reviewme.reviewgroup.domain.ReviewGroup;
 import reviewme.reviewgroup.repository.ReviewGroupRepository;
 import reviewme.support.ServiceTest;
@@ -219,10 +220,10 @@ class ReviewGatheredLookupServiceTest {
 
             // then
             assertThat(actual.reviews().get(0).answers())
-                    .extracting("content")
+                    .extracting(TextResponse::content)
                     .containsExactlyInAnyOrder("아루가 작성한 서술형 답변1", "테드가 작성한 서술형 답변1");
             assertThat(actual.reviews().get(1).answers())
-                    .extracting("content")
+                    .extracting(TextResponse::content)
                     .containsExactlyInAnyOrder("아루가 작성한 서술형 답변2", "테드가 작성한 서술형 답변2");
         }
 
@@ -251,7 +252,7 @@ class ReviewGatheredLookupServiceTest {
 
             // then
             assertThat(actual.reviews().get(0).answers())
-                    .extracting("content")
+                    .extracting(TextResponse::content)
                     .containsExactlyInAnyOrder("아루가 작성한 서술형 답변1", "테드가 작성한 서술형 답변1");
         }
 
@@ -278,10 +279,10 @@ class ReviewGatheredLookupServiceTest {
 
             // then
             assertThat(actual.reviews().get(0).answers())
-                    .extracting("content")
+                    .extracting(TextResponse::content)
                     .containsExactlyInAnyOrder("산초가 작성한 서술형 답변1", "아루가 작성한 서술형 답변");
             assertThat(actual.reviews().get(1).answers())
-                    .extracting("content")
+                    .extracting(TextResponse::content)
                     .containsExactly("산초가 작성한 서술형 답변2");
         }
 
@@ -337,7 +338,7 @@ class ReviewGatheredLookupServiceTest {
 
             // then
             assertThat(actual.reviews().get(0).votes())
-                    .extracting("content", "count")
+                    .extracting(VoteResponse::content, VoteResponse::count)
                     .containsExactlyInAnyOrder(
                             tuple("짜장", 2L),
                             tuple("짬뽕", 1L)
@@ -371,10 +372,10 @@ class ReviewGatheredLookupServiceTest {
 
             // then
             assertThat(actual.reviews().get(0).votes())
-                    .extracting("content", "count")
+                    .extracting(VoteResponse::content, VoteResponse::count)
                     .containsOnly(tuple("중식", 1L));
             assertThat(actual.reviews().get(1).votes())
-                    .extracting("content", "count")
+                    .extracting(VoteResponse::content, VoteResponse::count)
                     .containsOnly(tuple("분식", 1L));
         }
 
@@ -404,7 +405,7 @@ class ReviewGatheredLookupServiceTest {
 
             // then
             assertThat(actual.reviews().get(0).votes())
-                    .extracting("content", "count")
+                    .extracting(VoteResponse::content, VoteResponse::count)
                     .containsExactlyInAnyOrder(
                             tuple("우테코 산초", 2L),
                             tuple("제이든 산초", 0L)
@@ -438,14 +439,15 @@ class ReviewGatheredLookupServiceTest {
         // then
         assertThat(actual.reviews()).hasSize(2);
         assertThat(actual.reviews())
-                .extracting("question.name")
+                .extracting(ReviewsGatheredByQuestionResponse::question)
+                .extracting(SimpleQuestionResponse::name)
                 .containsOnly(question1.getContent(), question2.getContent());
         assertThat(actual.reviews().get(0).answers())
-                .extracting("content")
+                .extracting(TextResponse::content)
                 .containsExactly("아루가 작성한 서술형 답변");
         assertThat(actual.reviews().get(0).votes()).isNull();
         assertThat(actual.reviews().get(1).votes())
-                .extracting("content", "count")
+                .extracting(VoteResponse::content, VoteResponse::count)
                 .containsExactlyInAnyOrder(
                         tuple(optionItem1.getContent(), 1L),
                         tuple(optionItem2.getContent(), 1L)

--- a/backend/src/test/java/reviewme/review/service/ReviewGatheredLookupServiceTest.java
+++ b/backend/src/test/java/reviewme/review/service/ReviewGatheredLookupServiceTest.java
@@ -39,7 +39,7 @@ import reviewme.template.repository.SectionRepository;
 import reviewme.template.repository.TemplateRepository;
 
 @ServiceTest
-class GatheredReviewLookupServiceTest {
+class ReviewGatheredLookupServiceTest {
 
     @Autowired
     private ReviewGroupRepository reviewGroupRepository;
@@ -63,7 +63,7 @@ class GatheredReviewLookupServiceTest {
     private TemplateRepository templateRepository;
 
     @Autowired
-    private GatheredReviewLookupService reviewLookupService;
+    private ReviewGatheredLookupService reviewLookupService;
 
     private String reviewRequestCode;
     private ReviewGroup reviewGroup;

--- a/backend/src/test/java/reviewme/review/service/mapper/ReviewGatherMapperTest.java
+++ b/backend/src/test/java/reviewme/review/service/mapper/ReviewGatherMapperTest.java
@@ -1,0 +1,137 @@
+package reviewme.review.service.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static reviewme.fixture.OptionGroupFixture.선택지_그룹;
+import static reviewme.fixture.OptionItemFixture.선택지;
+import static reviewme.fixture.QuestionFixture.서술형_옵션_질문;
+import static reviewme.fixture.QuestionFixture.선택형_옵션_질문;
+
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import reviewme.question.domain.OptionGroup;
+import reviewme.question.domain.OptionItem;
+import reviewme.question.domain.Question;
+import reviewme.question.repository.OptionGroupRepository;
+import reviewme.question.repository.OptionItemRepository;
+import reviewme.question.repository.QuestionRepository;
+import reviewme.review.domain.CheckboxAnswer;
+import reviewme.review.domain.Review;
+import reviewme.review.domain.TextAnswer;
+import reviewme.review.repository.ReviewRepository;
+import reviewme.review.service.dto.response.gathered.ReviewsGatheredByQuestionResponse;
+import reviewme.review.service.dto.response.gathered.ReviewsGatheredBySectionResponse;
+import reviewme.review.service.dto.response.gathered.SimpleQuestionResponse;
+import reviewme.review.service.dto.response.gathered.TextResponse;
+import reviewme.review.service.dto.response.gathered.VoteResponse;
+import reviewme.support.ServiceTest;
+import reviewme.template.repository.SectionRepository;
+
+@ServiceTest
+class ReviewGatherMapperTest {
+
+    @Autowired
+    private ReviewGatherMapper reviewGatherMapper;
+
+    @Autowired
+    private SectionRepository sectionRepository;
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    @Autowired
+    private OptionGroupRepository optionGroupRepository;
+
+    @Autowired
+    private OptionItemRepository optionItemRepository;
+
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @Test
+    void 질문과_하위_답변을_규칙에_맞게_반환한다() {
+        // given
+        Question question1 = questionRepository.save(서술형_옵션_질문(1));
+        Question question2 = questionRepository.save(선택형_옵션_질문(2));
+        OptionGroup optionGroup = optionGroupRepository.save(선택지_그룹(question2.getId()));
+        OptionItem optionItem1 = optionItemRepository.save(선택지(optionGroup.getId()));
+        OptionItem optionItem2 = optionItemRepository.save(선택지(optionGroup.getId()));
+        optionItemRepository.saveAll(List.of(optionItem1, optionItem2));
+
+        TextAnswer textAnswer1 = new TextAnswer(question1.getId(), "프엔 서술형 답변");
+        TextAnswer textAnswer2 = new TextAnswer(question1.getId(), "백엔드 서술형 답변");
+        CheckboxAnswer checkboxAnswer = new CheckboxAnswer(
+                question2.getId(), List.of(optionItem1.getId(), optionItem2.getId()));
+        reviewRepository.save(new Review(1L, 1L, List.of(textAnswer1, textAnswer2, checkboxAnswer)));
+
+        // when
+        ReviewsGatheredBySectionResponse actual = reviewGatherMapper.mapToReviewsGatheredBySection(Map.of(
+                question1, List.of(textAnswer1, textAnswer2),
+                question2, List.of(checkboxAnswer)));
+
+        // then
+        assertAll(
+                () -> 질문의_수만큼_반환한다(actual, 2),
+                () -> 질문의_내용을_반환한다(actual, question1.getContent(), question2.getContent()),
+                () -> 서술형_답변을_반환한다(actual, "프엔 서술형 답변", "백엔드 서술형 답변"),
+                () -> 선택형_답변을_반환한다(actual,
+                        Tuple.tuple(optionItem1.getContent(), 1L),
+                        Tuple.tuple(optionItem2.getContent(), 1L))
+        );
+    }
+
+    @Test
+    void 서술형_질문에_답변이_없으면_질문_정보는_반환하되_답변은_빈_배열로_반환한다() {
+        // given
+        Question question1 = questionRepository.save(서술형_옵션_질문(1));
+        Question question2 = questionRepository.save(서술형_옵션_질문(2));
+
+        // when
+        ReviewsGatheredBySectionResponse actual = reviewGatherMapper.mapToReviewsGatheredBySection(Map.of(
+                question1, List.of(),
+                question2, List.of()));
+
+        // then
+        assertAll(
+                () -> 질문의_수만큼_반환한다(actual, 2),
+                () -> 질문의_내용을_반환한다(actual, question1.getContent(), question2.getContent()),
+                () -> assertThat(actual.reviews())
+                        .flatExtracting(ReviewsGatheredByQuestionResponse::answers)
+                        .isEmpty()
+        );
+    }
+
+    private void 질문의_수만큼_반환한다(ReviewsGatheredBySectionResponse actual, int expectedSize) {
+        assertThat(actual.reviews()).hasSize(expectedSize);
+    }
+
+    private void 질문의_내용을_반환한다(ReviewsGatheredBySectionResponse actual, String... expectedContents) {
+        assertThat(actual.reviews())
+                .extracting(ReviewsGatheredByQuestionResponse::question)
+                .extracting(SimpleQuestionResponse::name)
+                .containsExactly(expectedContents);
+    }
+
+    private void 서술형_답변을_반환한다(ReviewsGatheredBySectionResponse actual, String... expectedAnswerContents) {
+        List<TextResponse> textResponse = actual.reviews()
+                .stream()
+                .filter(review -> review.answers() != null)
+                .flatMap(reviewsGatheredByQuestionResponse -> reviewsGatheredByQuestionResponse.answers().stream())
+                .toList();
+        assertThat(textResponse).extracting(TextResponse::content).containsExactly(expectedAnswerContents);
+    }
+
+    private void 선택형_답변을_반환한다(ReviewsGatheredBySectionResponse actual, Tuple... expectedVotes) {
+        List<VoteResponse> voteResponses = actual.reviews()
+                .stream()
+                .filter(review -> review.votes() != null)
+                .flatMap(reviewsGatheredByQuestionResponse -> reviewsGatheredByQuestionResponse.votes().stream())
+                .toList();
+        assertThat(voteResponses)
+                .extracting(VoteResponse::content, VoteResponse::count)
+                .containsExactly(expectedVotes);
+    }
+}

--- a/backend/src/test/java/reviewme/template/repository/SectionRepositoryTest.java
+++ b/backend/src/test/java/reviewme/template/repository/SectionRepositoryTest.java
@@ -1,6 +1,7 @@
 package reviewme.template.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static reviewme.fixture.SectionFixture.항상_보이는_섹션;
 import static reviewme.fixture.TemplateFixture.템플릿;
 
@@ -37,5 +38,24 @@ class SectionRepositoryTest {
 
         // then
         assertThat(actual).containsExactly(section1, section2, section3);
+    }
+
+    @Test
+    void 템플릿_아이디와_섹션_아이디에_해당하는_섹션이_존재하는지_확인한다() {
+        // given
+        List<Long> questionIds = List.of(1L);
+        Section section1 = sectionRepository.save(항상_보이는_섹션(questionIds));
+        Section section2 = sectionRepository.save(항상_보이는_섹션(questionIds));
+        Template template = templateRepository.save(템플릿(List.of(section1.getId())));
+
+        // when
+        boolean actual1 = sectionRepository.existsByIdAndTemplateId(section1.getId(), template.getId());
+        boolean actual2 = sectionRepository.existsByIdAndTemplateId(section2.getId(), template.getId());
+
+        // then
+        assertAll(
+            () -> assertThat(actual1).isTrue(),
+            () -> assertThat(actual2).isFalse()
+        );
     }
 }

--- a/backend/src/test/java/reviewme/template/repository/SectionRepositoryTest.java
+++ b/backend/src/test/java/reviewme/template/repository/SectionRepositoryTest.java
@@ -6,6 +6,7 @@ import static reviewme.fixture.SectionFixture.항상_보이는_섹션;
 import static reviewme.fixture.TemplateFixture.템플릿;
 
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -41,7 +42,7 @@ class SectionRepositoryTest {
     }
 
     @Test
-    void 템플릿_아이디와_섹션_아이디에_해당하는_섹션이_존재하는지_확인한다() {
+    void 템플릿_아이디와_섹션_아이디에_해당하는_섹션을_반환한다() {
         // given
         List<Long> questionIds = List.of(1L);
         Section section1 = sectionRepository.save(항상_보이는_섹션(questionIds));
@@ -49,13 +50,13 @@ class SectionRepositoryTest {
         Template template = templateRepository.save(템플릿(List.of(section1.getId())));
 
         // when
-        boolean actual1 = sectionRepository.existsByIdAndTemplateId(section1.getId(), template.getId());
-        boolean actual2 = sectionRepository.existsByIdAndTemplateId(section2.getId(), template.getId());
+        Optional<Section> actual1 = sectionRepository.findByIdAndTemplateId(section1.getId(), template.getId());
+        Optional<Section> actual2 = sectionRepository.findByIdAndTemplateId(section2.getId(), template.getId());
 
         // then
         assertAll(
-            () -> assertThat(actual1).isTrue(),
-            () -> assertThat(actual2).isFalse()
+            () -> assertThat(actual1).isPresent(),
+            () -> assertThat(actual2).isEmpty()
         );
     }
 }


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #793 

---

### 🚀 어떤 기능을 구현했나요 ?
- 내가 받은 리뷰를 섹션을 기준으로 보되 질문을 단위로 묶어서 보는 API 를 구현했습니다.

### 🔥 어떻게 해결했나요 ?
시행착오가 조금 있습니다 ㅎㅎ
처음에는 한방쿼리로 데이터 가져오기 & 매핑까지 해보려 했습니다.
하지만 JOIN 이 너무 많다는 생각이 들었고, 더 효율적이라는 생각도 들지 않았습니다.
시행착오는 [이 커밋](https://github.com/nayonsoso/2024-review-me/blob/76b69974040230209b490c8c686ee397b8188a66/backend/src/main/java/reviewme/question/repository/GatheringReviewRepository.java)에서 볼 수 있습니다.
아마 제가 한방쿼리를 작성하는 실력이 좋지 않아서 그랬던 걸 수도 있습니다😓
한방쿼리를 정말로 쿼리 하나만 하는게 아니라 몇가지로 나누어서 더 효율적으로 작성하는 방법도 있더라고요.
그런데 우선은 제가 익숙한 방법으로 해야 구현을 끝마칠 수 있을거란 생각이 들어서, 서비스 코드에서 매핑하는 방법으로 바꿨습니다.
