### PR TITLE
[BE] refactor: NativeQuery를 JPQL로 변환

### DIFF
--- a/backend/src/main/java/reviewme/question/repository/OptionGroupRepository.java
+++ b/backend/src/main/java/reviewme/question/repository/OptionGroupRepository.java
@@ -12,9 +12,9 @@ public interface OptionGroupRepository extends JpaRepository<OptionGroup, Long> 
 
     Optional<OptionGroup> findByQuestionId(long questionId);
 
-    @Query(value = """
-            SELECT og.* FROM option_group og
-            WHERE og.question_id IN (:questionIds)
-            """, nativeQuery = true)
+    @Query("""
+            SELECT og FROM OptionGroup og
+            WHERE og.questionId IN :questionIds
+            """)
     List<OptionGroup> findAllByQuestionIds(List<Long> questionIds);
 }

--- a/backend/src/main/java/reviewme/question/repository/OptionItemRepository.java
+++ b/backend/src/main/java/reviewme/question/repository/OptionItemRepository.java
@@ -12,17 +12,17 @@ public interface OptionItemRepository extends JpaRepository<OptionItem, Long> {
 
     List<OptionItem> findAllByOptionGroupId(long optionGroupId);
 
-    @Query(value = """
-            SELECT o.* FROM option_item o
-            WHERE o.option_type = :#{#optionType.name()}
-            """, nativeQuery = true)
+    @Query("""
+            SELECT o FROM OptionItem o
+            WHERE o.optionType = :optionType
+            """)
     List<OptionItem> findAllByOptionType(OptionType optionType);
 
-    @Query(value = """
-            SELECT o.* FROM option_item o
-            JOIN option_group og
-            ON o.option_group_id = og.id
-            WHERE og.question_id IN (:questionIds)
-            """, nativeQuery = true)
+    @Query("""
+            SELECT o FROM OptionItem o
+            JOIN OptionGroup og
+            ON o.optionGroupId = og.id
+            WHERE og.questionId IN :questionIds
+            """)
     List<OptionItem> findAllByQuestionIds(List<Long> questionIds);
 }

--- a/backend/src/main/java/reviewme/question/repository/QuestionRepository.java
+++ b/backend/src/main/java/reviewme/question/repository/QuestionRepository.java
@@ -11,27 +11,27 @@ import reviewme.question.domain.Question;
 @Repository
 public interface QuestionRepository extends JpaRepository<Question, Long> {
 
-    @Query(value = """
-            SELECT q.id FROM question q
-            JOIN section_question sq
-            ON q.id = sq.question_id
-            JOIN template_section ts
-            ON sq.section_id = ts.section_id
-            WHERE ts.template_id = :templateId
-            """, nativeQuery = true)
+    @Query("""
+            SELECT q.id FROM Question q
+            JOIN SectionQuestion sq
+            ON q.id = sq.questionId
+            JOIN TemplateSection ts
+            ON sq.sectionId = ts.sectionId
+            WHERE ts.templateId = :templateId
+            """)
     Set<Long> findAllQuestionIdByTemplateId(long templateId);
 
-    @Query(value = """
-            SELECT q.* FROM question q
-            JOIN section_question sq
-            ON q.id = sq.question_id
-            JOIN template_section ts
-            ON sq.section_id = ts.section_id
-            WHERE ts.template_id = :templateId
-            """, nativeQuery = true)
+    @Query("""
+            SELECT q FROM Question q
+            JOIN SectionQuestion sq
+            ON q.id = sq.questionId
+            JOIN TemplateSection ts
+            ON sq.sectionId = ts.sectionId
+            WHERE ts.templateId = :templateId
+            """)
     List<Question> findAllByTemplatedId(long templateId);
 
-    @Query(value = """
+    @Query("""
             SELECT q FROM Question q
             JOIN SectionQuestion sq ON q.id = sq.questionId
             WHERE sq.sectionId = :sectionId

--- a/backend/src/main/java/reviewme/review/repository/AnswerRepository.java
+++ b/backend/src/main/java/reviewme/review/repository/AnswerRepository.java
@@ -11,7 +11,7 @@ import reviewme.review.domain.Answer;
 @Repository
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
 
-    @Query(value = """
+    @Query("""
             SELECT a FROM Answer a
             JOIN Review r ON a.reviewId = r.id
             WHERE r.reviewGroupId = :reviewGroupId AND a.questionId IN :questionIds
@@ -20,7 +20,7 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
             """)
     List<Answer> findReceivedAnswersByQuestionIds(long reviewGroupId, Collection<Long> questionIds, int limit);
 
-    @Query(value = """
+    @Query("""
             SELECT a.id FROM Answer a
             JOIN Review r
             ON a.reviewId = r.id
@@ -28,7 +28,7 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
             """)
     Set<Long> findIdsByReviewGroupId(long reviewGroupId);
 
-    @Query(value = """
+    @Query("""
             SELECT a FROM Answer a
             JOIN Review r
             ON a.reviewId = r.id
@@ -36,7 +36,7 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
             """)
     Set<Answer> findAllByReviewGroupId(long reviewGroupId);
 
-    @Query(value = """
+    @Query("""
             SELECT a.id FROM Answer a
             WHERE a.questionId = :questionId
             """)

--- a/backend/src/main/java/reviewme/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/reviewme/review/repository/ReviewRepository.java
@@ -9,35 +9,31 @@ import reviewme.review.domain.Review;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
-    @Query(value = """
-            SELECT r.* FROM new_review r
-            WHERE r.review_group_id = :reviewGroupId
-            ORDER BY r.created_at DESC
-            """, nativeQuery = true)
+    @Query("""
+            SELECT r FROM Review r
+            WHERE r.reviewGroupId = :reviewGroupId
+            ORDER BY r.createdAt DESC
+            """)
     List<Review> findAllByGroupId(long reviewGroupId);
 
-    @Query(value = """
-            SELECT r.* FROM new_review r
-            WHERE r.review_group_id = :reviewGroupId
+    @Query("""
+            SELECT r FROM Review r
+            WHERE r.reviewGroupId = :reviewGroupId
             AND (:lastReviewId IS NULL OR r.id < :lastReviewId)
-            ORDER BY r.created_at DESC, r.id DESC
+            ORDER BY r.createdAt DESC, r.id DESC
             LIMIT :limit
-            """, nativeQuery = true)
+            """)
     List<Review> findByReviewGroupIdWithLimit(long reviewGroupId, Long lastReviewId, int limit);
 
     Optional<Review> findByIdAndReviewGroupId(long reviewId, long reviewGroupId);
 
-    @Query(value = """
-            SELECT COUNT(r.id) FROM new_review r
-            WHERE r.review_group_id = :reviewGroupId
+    @Query("""
+            SELECT COUNT(r.id) > 0 FROM Review r
+            WHERE r.reviewGroupId = :reviewGroupId
             AND r.id < :reviewId
-            AND CAST(r.created_at AS DATE) <= :createdDate
-            """, nativeQuery = true)
-    Long existsOlderReviewInGroupInLong(long reviewGroupId, long reviewId, LocalDate createdDate);
-
-    default boolean existsOlderReviewInGroup(long reviewGroupId, long reviewId, LocalDate createdDate) {
-        return existsOlderReviewInGroupInLong(reviewGroupId, reviewId, createdDate) > 0;
-    }
+            AND CAST(r.createdAt AS java.time.LocalDate) <= :createdDate
+            """)
+    boolean existsOlderReviewInGroup(long reviewGroupId, long reviewId, LocalDate createdDate);
 
     int countByReviewGroupId(long reviewGroupId);
 }

--- a/backend/src/main/java/reviewme/template/repository/SectionRepository.java
+++ b/backend/src/main/java/reviewme/template/repository/SectionRepository.java
@@ -10,13 +10,13 @@ import reviewme.template.domain.Section;
 @Repository
 public interface SectionRepository extends JpaRepository<Section, Long> {
 
-    @Query(value = """
-            SELECT s.* FROM section s
-            JOIN template_section ts
-            ON s.id = ts.section_id
-            WHERE ts.template_id = :templateId
+    @Query("""
+            SELECT s FROM Section s
+            JOIN TemplateSection ts
+            ON s.id = ts.sectionId
+            WHERE ts.templateId = :templateId
             ORDER BY s.position ASC
-            """, nativeQuery = true)
+            """)
     List<Section> findAllByTemplateId(long templateId);
 
     @Query("""


### PR DESCRIPTION

- JPQL에서 지원하는 다양한 기능을 사용할 수 있는데, 의존성을 떼서 조인하면 Native을 써야 하는 줄 알았네요. 기존 `nativeQuery`를 모두 JPQL로 전환하고, 이를 통해 컴파일 시간에 오류를 확인할 수 있도록 합니다. SQL을 작성하지 않으니 MySQL하고도 호환될 것이라고 기대해요.