### PR TITLE
[BE] refactor: 리뷰 그룹에 템플릿 정보를 하드코딩 하지 않도록 변경

### DIFF
--- a/backend/src/main/java/reviewme/reviewgroup/domain/ReviewGroup.java
+++ b/backend/src/main/java/reviewme/reviewgroup/domain/ReviewGroup.java
@@ -41,13 +41,10 @@ public class ReviewGroup {
     private GroupAccessCode groupAccessCode;
 
     @Column(name = "template_id", nullable = false)
-    private long templateId = 1L;
+    private long templateId;
 
-    public ReviewGroup(String reviewee, String projectName, String reviewRequestCode, String groupAccessCode) {
-        this(reviewee, projectName, reviewRequestCode, groupAccessCode, 1L);
-    }
-
-    public ReviewGroup(String reviewee, String projectName, String reviewRequestCode, String groupAccessCode, long templateId) {
+    public ReviewGroup(String reviewee, String projectName, String reviewRequestCode, String groupAccessCode,
+                       long templateId) {
         validateRevieweeLength(reviewee);
         validateProjectNameLength(projectName);
         this.reviewee = reviewee;

--- a/backend/src/main/java/reviewme/reviewgroup/service/ReviewGroupService.java
+++ b/backend/src/main/java/reviewme/reviewgroup/service/ReviewGroupService.java
@@ -10,15 +10,20 @@ import reviewme.reviewgroup.repository.ReviewGroupRepository;
 import reviewme.reviewgroup.service.dto.CheckValidAccessRequest;
 import reviewme.reviewgroup.service.dto.ReviewGroupCreationRequest;
 import reviewme.reviewgroup.service.dto.ReviewGroupCreationResponse;
+import reviewme.template.domain.Template;
+import reviewme.template.repository.TemplateRepository;
+import reviewme.template.service.exception.TemplateNotFoundException;
 
 @Service
 @RequiredArgsConstructor
 public class ReviewGroupService {
 
     private static final int REVIEW_REQUEST_CODE_LENGTH = 8;
+    private static final long DEFAULT_TEMPLATE_ID = 1L;
 
     private final ReviewGroupRepository reviewGroupRepository;
     private final RandomCodeGenerator randomCodeGenerator;
+    private final TemplateRepository templateRepository;
 
     @Transactional
     public ReviewGroupCreationResponse createReviewGroup(ReviewGroupCreationRequest request) {
@@ -27,9 +32,13 @@ public class ReviewGroupService {
             reviewRequestCode = randomCodeGenerator.generate(REVIEW_REQUEST_CODE_LENGTH);
         } while (reviewGroupRepository.existsByReviewRequestCode(reviewRequestCode));
 
+        Template template = templateRepository.findById(DEFAULT_TEMPLATE_ID)
+                .orElseThrow(() -> new TemplateNotFoundException(DEFAULT_TEMPLATE_ID));
+
         ReviewGroup reviewGroup = reviewGroupRepository.save(
                 new ReviewGroup(
-                        request.revieweeName(), request.projectName(), reviewRequestCode, request.groupAccessCode()
+                        request.revieweeName(), request.projectName(), reviewRequestCode, request.groupAccessCode(),
+                        template.getId()
                 )
         );
         return new ReviewGroupCreationResponse(reviewGroup.getReviewRequestCode());

--- a/backend/src/main/java/reviewme/template/service/exception/TemplateNotFoundException.java
+++ b/backend/src/main/java/reviewme/template/service/exception/TemplateNotFoundException.java
@@ -1,0 +1,13 @@
+package reviewme.template.service.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import reviewme.global.exception.DataInconsistencyException;
+
+@Slf4j
+public class TemplateNotFoundException extends DataInconsistencyException {
+
+    public TemplateNotFoundException(long templateId) {
+        super("서버 내부에서 문제가 발생했어요. 서버에 문의해주세요.");
+        log.error("Template not found - templateId: {}", templateId, this);
+    }
+}

--- a/backend/src/test/java/reviewme/fixture/ReviewGroupFixture.java
+++ b/backend/src/test/java/reviewme/fixture/ReviewGroupFixture.java
@@ -9,6 +9,6 @@ public class ReviewGroupFixture {
     }
 
     public static ReviewGroup 리뷰_그룹(String reviewRequestCode, String groupAccessCode) {
-        return new ReviewGroup("revieweeName", "projectName", reviewRequestCode, groupAccessCode);
+        return new ReviewGroup("revieweeName", "projectName", reviewRequestCode, groupAccessCode, 1L);
     }
 }

--- a/backend/src/test/java/reviewme/reviewgroup/ReviewGroupTest.java
+++ b/backend/src/test/java/reviewme/reviewgroup/ReviewGroupTest.java
@@ -20,9 +20,9 @@ class ReviewGroupTest {
 
         // when, then
         assertAll(
-                () -> assertThatCode(() -> new ReviewGroup(minLengthName, "project", "reviewCode", "groupCode"))
+                () -> assertThatCode(() -> new ReviewGroup(minLengthName, "project", "reviewCode", "groupCode", 1L))
                         .doesNotThrowAnyException(),
-                () -> assertThatCode(() -> new ReviewGroup(maxLengthName, "project", "reviewCode", "groupCode"))
+                () -> assertThatCode(() -> new ReviewGroup(maxLengthName, "project", "reviewCode", "groupCode", 1L))
                         .doesNotThrowAnyException()
         );
     }
@@ -37,9 +37,9 @@ class ReviewGroupTest {
 
         // when, then
         assertAll(
-                () -> assertThatCode(() -> new ReviewGroup(insufficientName, "project", "reviewCode", "groupCode"))
+                () -> assertThatCode(() -> new ReviewGroup(insufficientName, "project", "reviewCode", "groupCode", 1L))
                         .isInstanceOf(BadRequestException.class),
-                () -> assertThatThrownBy(() -> new ReviewGroup(exceedName, "project", "reviewCode", "groupCode"))
+                () -> assertThatThrownBy(() -> new ReviewGroup(exceedName, "project", "reviewCode", "groupCode", 1L))
                         .isInstanceOf(BadRequestException.class)
         );
     }
@@ -54,9 +54,9 @@ class ReviewGroupTest {
 
         // when, then
         assertAll(
-                () -> assertThatThrownBy(() -> new ReviewGroup("reviwee", insufficientName, "reviewCode", "groupCode"))
+                () -> assertThatThrownBy(() -> new ReviewGroup("reviwee", insufficientName, "reviewCode", "groupCode", 1L))
                         .isInstanceOf(BadRequestException.class),
-                () -> assertThatThrownBy(() -> new ReviewGroup("reviwee", exceedName, "reviewCode", "groupCode"))
+                () -> assertThatThrownBy(() -> new ReviewGroup("reviwee", exceedName, "reviewCode", "groupCode", 1L))
                         .isInstanceOf(BadRequestException.class)
         );
     }

--- a/backend/src/test/java/reviewme/reviewgroup/service/ReviewGroupLookupServiceTest.java
+++ b/backend/src/test/java/reviewme/reviewgroup/service/ReviewGroupLookupServiceTest.java
@@ -28,7 +28,8 @@ class ReviewGroupLookupServiceTest {
                 "ted",
                 "review-me",
                 "reviewRequestCode",
-                "groupAccessCode"
+                "groupAccessCode",
+                1L
         ));
 
         // when

--- a/backend/src/test/java/reviewme/reviewgroup/service/ReviewGroupServiceTest.java
+++ b/backend/src/test/java/reviewme/reviewgroup/service/ReviewGroupServiceTest.java
@@ -9,7 +9,9 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 import static reviewme.fixture.ReviewGroupFixture.리뷰_그룹;
+import static reviewme.fixture.TemplateFixture.템플릿;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -21,6 +23,7 @@ import reviewme.reviewgroup.service.dto.CheckValidAccessRequest;
 import reviewme.reviewgroup.service.dto.ReviewGroupCreationRequest;
 import reviewme.reviewgroup.service.dto.ReviewGroupCreationResponse;
 import reviewme.support.ServiceTest;
+import reviewme.template.repository.TemplateRepository;
 
 @ServiceTest
 @ExtendWith(MockitoExtension.class)
@@ -35,9 +38,13 @@ class ReviewGroupServiceTest {
     @Autowired
     private ReviewGroupRepository reviewGroupRepository;
 
+    @Autowired
+    private TemplateRepository templateRepository;
+
     @Test
     void 코드가_중복되는_경우_다시_생성한다() {
         // given
+        templateRepository.save(템플릿(List.of()));
         reviewGroupRepository.save(리뷰_그룹("0000", "1111"));
         given(randomCodeGenerator.generate(anyInt()))
                 .willReturn("0000") // ReviewRequestCode


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #809 

---

### 🚀 어떤 기능을 구현했나요 ?
- 현재 리뷰 그룹에 templateId가 1로 하드코딩 되어있습니다. 추후 확장성 고려 및 테스트에서 템플릿 id를 직접 넣어서 다양한 케이스를 테스트할 수 있도록 생성자를 통해서 등록하는 것으로 변경합니다.
- 우선은 템플릿 확장에 대한 논의가 없기 때문에 reviewGorupService에서 리뷰 그룹 등록 시, 1번 템플릿을 디폴트로 리뷰 그룹을 등록하는 것으로 합니다.

### 🔥 어떻게 해결했나요 ?
- reviewGroup 생성자에 templateId 추가

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
