### PR TITLE
[FE] fix: 섹션별 답변 모아보기의 중복 출력 문제 해결 및 리스트 형식으로 출력

### DIFF
--- a/frontend/src/components/highlight/EditorLineBlock/index.tsx
+++ b/frontend/src/components/highlight/EditorLineBlock/index.tsx
@@ -3,6 +3,8 @@ import { EditorLine, HighlightRange } from '@/types';
 
 import Syntax from '../Syntax';
 
+import * as S from './style';
+
 interface EditorLineBlockProps {
   line: EditorLine;
   lineIndex: number;
@@ -60,9 +62,9 @@ const EditorLineBlock = ({ line, lineIndex }: EditorLineBlockProps) => {
   };
 
   return (
-    <p className={EDITOR_LINE_CLASS_NAME} data-index={lineIndex}>
+    <S.EditorLineBlock className={EDITOR_LINE_CLASS_NAME} data-index={lineIndex}>
       {renderSentenceList()}
-    </p>
+    </S.EditorLineBlock>
   );
 };
 

--- a/frontend/src/components/highlight/EditorLineBlock/style.ts
+++ b/frontend/src/components/highlight/EditorLineBlock/style.ts
@@ -1,0 +1,8 @@
+import styled from '@emotion/styled';
+
+export const EditorLineBlock = styled.p`
+  display: list-item;
+  margin-left: 3rem;
+  text-indent: -2.2rem;
+  list-style-type: disc;
+`;

--- a/frontend/src/components/highlight/HighlightEditor/index.tsx
+++ b/frontend/src/components/highlight/HighlightEditor/index.tsx
@@ -92,7 +92,7 @@ const HighlightEditor = ({ questionId, answerList }: HighlightEditorProps) => {
   }, [isEditable]);
 
   return (
-    <div ref={editorRef} style={{ position: 'relative' }}>
+    <S.HighlightEditorContainer ref={editorRef}>
       <S.SwitchButtonWrapper>
         <EditSwitchButton isEditable={isEditable} handleEditToggleButton={handleEditToggleButton} />
       </S.SwitchButtonWrapper>
@@ -120,7 +120,7 @@ const HighlightEditor = ({ questionId, answerList }: HighlightEditorProps) => {
       {isEditable && removalTarget && removerPosition && (
         <HighlightRemoverWrapper buttonPosition={removerPosition} removeHighlightByClick={removeHighlightByClick} />
       )}
-    </div>
+    </S.HighlightEditorContainer>
   );
 };
 

--- a/frontend/src/components/highlight/HighlightEditor/style.ts
+++ b/frontend/src/components/highlight/HighlightEditor/style.ts
@@ -1,5 +1,15 @@
 import styled from '@emotion/styled';
 
+export const HighlightEditorContainer = styled.div`
+  position: relative;
+
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  padding: 1rem;
+`;
+
 export const SwitchButtonWrapper = styled.div`
   display: flex;
   justify-content: end;

--- a/frontend/src/pages/ReviewCollectionPage/index.tsx
+++ b/frontend/src/pages/ReviewCollectionPage/index.tsx
@@ -41,9 +41,6 @@ const ReviewCollectionPage = () => {
                       {review.answers && (
                         <HighlightEditor questionId={review.question.id} answerList={review.answers} />
                       )}
-                      {review.answers?.map((answer, index) => {
-                        return <S.ReviewAnswer key={index}>{answer.content}</S.ReviewAnswer>;
-                      })}
                     </S.ReviewAnswerContainer>
                   )}
                 </Accordion>


### PR DESCRIPTION
- resolves #819 

---

### 🚀 어떤 기능을 구현했나요 ?
- 모아보기 페이지에서 에디터와 기존 코드가 모두 사용되어 답변이 두 번 출력되는 문제를 해결했습니다.
- 에디터에서 답변을 list 스타일로 출력하도록 수정했습니다.

### 🔥 어떻게 해결했나요 ?
- 모아보기 페이지에서 일부 코드 삭제
- 에디터 일부 코드에 스타일 설정

![image](https://github.com/user-attachments/assets/8fb39841-4b76-430f-8037-867678b342d0)

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?

### 📚 참고 자료, 할 말
