### PR TITLE
[BE] fix: Highlight 엔티티의 데이터 타입을 db 테이블와 일치시킨다.

### DIFF
--- a/backend/src/main/java/reviewme/highlight/domain/Highlight.java
+++ b/backend/src/main/java/reviewme/highlight/domain/Highlight.java
@@ -29,7 +29,7 @@ public class Highlight {
     @Embedded
     private HighlightPosition highlightPosition;
 
-    public Highlight(long answerId, long lineIndex, long startIndex, long endIndex) {
+    public Highlight(long answerId, int lineIndex, int startIndex, int endIndex) {
         this.answerId = answerId;
         this.highlightPosition = new HighlightPosition(lineIndex, startIndex, endIndex);
     }

--- a/backend/src/main/java/reviewme/highlight/domain/HighlightPosition.java
+++ b/backend/src/main/java/reviewme/highlight/domain/HighlightPosition.java
@@ -16,15 +16,15 @@ import reviewme.highlight.domain.exception.NegativeHighlightIndexException;
 public class HighlightPosition {
 
     @Column(name = "line_index", nullable = false)
-    private long lineIndex;
+    private int lineIndex;
 
     @Column(name = "start_index", nullable = false)
-    private long startIndex;
+    private int startIndex;
 
     @Column(name = "end_index", nullable = false)
-    private long endIndex;
+    private int endIndex;
 
-    public HighlightPosition(long lineIndex, long startIndex, long endIndex) {
+    public HighlightPosition(int lineIndex, int startIndex, int endIndex) {
         validateNonNegativeIndexNumber(startIndex, endIndex);
         validateEndIndexOverStartIndex(startIndex, endIndex);
         this.lineIndex = lineIndex;

--- a/backend/src/main/java/reviewme/highlight/service/HighlightService.java
+++ b/backend/src/main/java/reviewme/highlight/service/HighlightService.java
@@ -55,7 +55,7 @@ public class HighlightService {
             for (HighlightedLineRequest line : highlight.lines()) {
                 for (HighlightIndexRangeRequest range : line.ranges()) {
                     Highlight highLight = new Highlight(highlight.answerId(),
-                            line.index().intValue(), range.startIndex().intValue(), range.endIndex().intValue());
+                            line.index(), range.startIndex(), range.endIndex());
                     highlights.add(highLight);
                 }
             }

--- a/backend/src/main/java/reviewme/highlight/service/HighlightService.java
+++ b/backend/src/main/java/reviewme/highlight/service/HighlightService.java
@@ -55,7 +55,7 @@ public class HighlightService {
             for (HighlightedLineRequest line : highlight.lines()) {
                 for (HighlightIndexRangeRequest range : line.ranges()) {
                     Highlight highLight = new Highlight(highlight.answerId(),
-                            line.index(), range.startIndex(), range.endIndex());
+                            line.index().intValue(), range.startIndex().intValue(), range.endIndex().intValue());
                     highlights.add(highLight);
                 }
             }

--- a/backend/src/main/java/reviewme/highlight/service/dto/HighlightIndexRangeRequest.java
+++ b/backend/src/main/java/reviewme/highlight/service/dto/HighlightIndexRangeRequest.java
@@ -5,9 +5,9 @@ import jakarta.validation.constraints.NotNull;
 public record HighlightIndexRangeRequest(
 
         @NotNull(message = "시작 인덱스를 입력해주세요.")
-        Long startIndex,
+        int startIndex,
 
         @NotNull(message = "끝 인덱스를 입력해주세요.")
-        Long endIndex
+        int endIndex
 ) {
 }

--- a/backend/src/main/java/reviewme/highlight/service/dto/HighlightIndexRangeRequest.java
+++ b/backend/src/main/java/reviewme/highlight/service/dto/HighlightIndexRangeRequest.java
@@ -5,9 +5,9 @@ import jakarta.validation.constraints.NotNull;
 public record HighlightIndexRangeRequest(
 
         @NotNull(message = "시작 인덱스를 입력해주세요.")
-        int startIndex,
+        Integer startIndex,
 
         @NotNull(message = "끝 인덱스를 입력해주세요.")
-        int endIndex
+        Integer endIndex
 ) {
 }

--- a/backend/src/main/java/reviewme/highlight/service/dto/HighlightedLineRequest.java
+++ b/backend/src/main/java/reviewme/highlight/service/dto/HighlightedLineRequest.java
@@ -8,7 +8,7 @@ import java.util.List;
 public record HighlightedLineRequest(
 
         @NotNull(message = "인덱스를 입력해주세요.")
-        Long index,
+        int index,
 
         @Valid @NotEmpty(message = "하이라이트 범위를 입력해주세요.")
         List<HighlightIndexRangeRequest> ranges

--- a/backend/src/main/java/reviewme/highlight/service/dto/HighlightedLineRequest.java
+++ b/backend/src/main/java/reviewme/highlight/service/dto/HighlightedLineRequest.java
@@ -8,7 +8,7 @@ import java.util.List;
 public record HighlightedLineRequest(
 
         @NotNull(message = "인덱스를 입력해주세요.")
-        int index,
+        Integer index,
 
         @Valid @NotEmpty(message = "하이라이트 범위를 입력해주세요.")
         List<HighlightIndexRangeRequest> ranges

--- a/backend/src/test/java/reviewme/highlight/service/HighlightServiceTest.java
+++ b/backend/src/test/java/reviewme/highlight/service/HighlightServiceTest.java
@@ -115,7 +115,7 @@ class HighlightServiceTest {
 
         // then
         List<Highlight> highlights = highlightRepository.findAll();
-        HighlightPosition position = new HighlightPosition((int) lineIndex, (int) startIndex, (int) endIndex);
+        HighlightPosition position = new HighlightPosition(lineIndex, startIndex, endIndex);
         assertAll(
                 () -> assertThat(highlights.get(0).getAnswerId()).isEqualTo(textAnswer1.getId()),
                 () -> assertThat(highlights.get(1).getAnswerId()).isEqualTo(textAnswer2.getId()),

--- a/backend/src/test/java/reviewme/highlight/service/HighlightServiceTest.java
+++ b/backend/src/test/java/reviewme/highlight/service/HighlightServiceTest.java
@@ -115,7 +115,7 @@ class HighlightServiceTest {
 
         // then
         List<Highlight> highlights = highlightRepository.findAll();
-        HighlightPosition position = new HighlightPosition(lineIndex, startIndex, endIndex);
+        HighlightPosition position = new HighlightPosition((int) lineIndex, (int) startIndex, (int) endIndex);
         assertAll(
                 () -> assertThat(highlights.get(0).getAnswerId()).isEqualTo(textAnswer1.getId()),
                 () -> assertThat(highlights.get(1).getAnswerId()).isEqualTo(textAnswer2.getId()),

--- a/backend/src/test/java/reviewme/highlight/service/HighlightServiceTest.java
+++ b/backend/src/test/java/reviewme/highlight/service/HighlightServiceTest.java
@@ -66,8 +66,8 @@ class HighlightServiceTest {
         TextAnswer textAnswer2 = new TextAnswer(questionId, "text answer2");
         Review review = reviewRepository.save(new Review(templateId, reviewGroupId, List.of(textAnswer1, textAnswer2)));
 
-        HighlightIndexRangeRequest indexRangeRequest = new HighlightIndexRangeRequest(1L, 1L);
-        HighlightedLineRequest lineRequest = new HighlightedLineRequest(0L, List.of(indexRangeRequest));
+        HighlightIndexRangeRequest indexRangeRequest = new HighlightIndexRangeRequest(1, 1);
+        HighlightedLineRequest lineRequest = new HighlightedLineRequest(0, List.of(indexRangeRequest));
         HighlightRequest highlightRequest1 = new HighlightRequest(textAnswer1.getId(), List.of(lineRequest));
         HighlightRequest highlightRequest2 = new HighlightRequest(textAnswer2.getId(), List.of(lineRequest));
         HighlightsRequest highlightsRequest = new HighlightsRequest(
@@ -99,9 +99,9 @@ class HighlightServiceTest {
         TextAnswer textAnswer2 = new TextAnswer(questionId, "text answer2");
         Review review = reviewRepository.save(new Review(templateId, reviewGroupId, List.of(textAnswer1, textAnswer2)));
 
-        long startIndex = 2L;
-        long endIndex = 2L;
-        long lineIndex = 0;
+        int startIndex = 2;
+        int endIndex = 2;
+        int lineIndex = 0;
         HighlightIndexRangeRequest indexRangeRequest = new HighlightIndexRangeRequest(startIndex, endIndex);
         HighlightedLineRequest lineRequest1 = new HighlightedLineRequest(lineIndex, List.of(indexRangeRequest));
         HighlightedLineRequest lineRequest2 = new HighlightedLineRequest(lineIndex, List.of(indexRangeRequest));

--- a/backend/src/test/java/reviewme/highlight/service/validator/HighlightValidatorTest.java
+++ b/backend/src/test/java/reviewme/highlight/service/validator/HighlightValidatorTest.java
@@ -116,7 +116,7 @@ class HighlightValidatorTest {
         Review review = reviewRepository.save(new Review(templateId, reviewGroupId, List.of(textAnswer)));
 
         long answerLineCount = textAnswer.getContent().lines().count();
-        HighlightedLineRequest highlightedLineRequest = new HighlightedLineRequest(answerLineCount, List.of());
+        HighlightedLineRequest highlightedLineRequest = new HighlightedLineRequest((int) answerLineCount, List.of());
         HighlightRequest highlightRequest = new HighlightRequest(textAnswer.getId(), List.of(highlightedLineRequest));
         HighlightsRequest highlightsRequest = new HighlightsRequest(questionId, List.of(highlightRequest));
 


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #828 

---

### 🚀 어떤 기능을 구현했나요 ?
- Highlight 엔티티의 데이터 타입을 db 테이블와 일치시킨다.

### 🔥 어떻게 해결했나요 ?
- Highlight 엔티티의 lineIndex, startIndex, endIndex의 데이터 타입을 테이블과 일치하게 long→ int로 변경하였습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
