### PR TITLE
[BE] fix: delete 쿼리가 한 번만 나가도록 jpql을 사용한다.

### DIFF
--- a/backend/src/main/java/reviewme/highlight/domain/exception/NegativeHighlightIndexException.java
+++ b/backend/src/main/java/reviewme/highlight/domain/exception/NegativeHighlightIndexException.java
@@ -7,7 +7,7 @@ import reviewme.global.exception.BadRequestException;
 public class NegativeHighlightIndexException extends BadRequestException {
 
     public NegativeHighlightIndexException(long startIndex, long endIndex) {
-        super("하이라이트 위치는 1 이상의 수이어야 해요.");
+        super("하이라이트 위치는 0 이상의 수이어야 해요.");
         log.info("Highlight index is a negative number - startIndex: {}, endIndex: {}", startIndex, endIndex);
     }
 }

--- a/backend/src/main/java/reviewme/highlight/repository/HighlightRepository.java
+++ b/backend/src/main/java/reviewme/highlight/repository/HighlightRepository.java
@@ -1,7 +1,17 @@
 package reviewme.highlight.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import reviewme.highlight.domain.Highlight;
 
 public interface HighlightRepository extends JpaRepository<Highlight, Long> {
+
+    @Modifying
+    @Query("""
+            DELETE FROM Highlight h
+            WHERE h.answerId IN :answersByReviewQuestion
+            """)
+    void deleteAllByIds(List<Long> answersByReviewQuestion);
 }

--- a/backend/src/main/java/reviewme/highlight/service/HighlightService.java
+++ b/backend/src/main/java/reviewme/highlight/service/HighlightService.java
@@ -46,7 +46,7 @@ public class HighlightService {
                 .map(Answer::getId)
                 .toList();
 
-        highlightRepository.deleteAllById(answersByReviewQuestion);
+        highlightRepository.deleteAllByIds(answersByReviewQuestion);
     }
 
     private void saveNewHighlight(HighlightsRequest highlightsRequest) {


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #832 

---

### 🚀 어떤 기능을 구현했나요 ?
- delete 쿼리가 한 번만 나가도록 jpql을 사용한다.

### 🔥 어떻게 해결했나요 ?
- delete 쿼리가 한 번만 나가도록 jpql을 사용한다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
