### PR TITLE
[BE] fix: Dto 하위 필드에 `@Valid` 추가

### DIFF
--- a/backend/src/main/java/reviewme/review/service/dto/request/ReviewRegisterRequest.java
+++ b/backend/src/main/java/reviewme/review/service/dto/request/ReviewRegisterRequest.java
@@ -1,5 +1,6 @@
 package reviewme.review.service.dto.request;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
@@ -9,7 +10,7 @@ public record ReviewRegisterRequest(
         @NotBlank(message = "리뷰 요청 코드를 입력해주세요.")
         String reviewRequestCode,
 
-        @NotEmpty(message = "답변 내용을 입력해주세요.")
+        @Valid @NotEmpty(message = "답변 내용을 입력해주세요.")
         List<ReviewAnswerRequest> answers
 ) {
 }

--- a/backend/src/main/java/reviewme/reviewgroup/controller/ReviewGroupController.java
+++ b/backend/src/main/java/reviewme/reviewgroup/controller/ReviewGroupController.java
@@ -40,7 +40,7 @@ public class ReviewGroupController {
 
     @PostMapping("/v2/groups/check")
     public ResponseEntity<Void> checkGroupAccessCode(
-            @RequestBody @Valid CheckValidAccessRequest request,
+            @Valid @RequestBody CheckValidAccessRequest request,
             HttpServletRequest httpRequest
     ) {
         reviewGroupService.checkGroupAccessCode(request);


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #826 

---

### 🚀 어떤 기능을 구현했나요 ?
- DTO 하위에 `@Valid`를 붙였습니다.

### 🔥 어떻게 해결했나요 ?
- 살펴보니 한 군데밖에 없더라고요.., 이슈에는 있어서 우선 PR로 해결합니다 🚀 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- `RequestBody` 받는 곳이 생각보다 없습니다. 혹시나 놓친 부분 있나 확인해주세요 🙇🏻 

### 📚 참고 자료, 할 말
- Bean Validaton JSR-303에 이미 나와 있었네요 😓 
`@Valid is an orthogonal concept to the notion of group. If two groups are in sequence, the first group must pass for all associated objects before the second group is evaluated. Note however that the Default group sequence overriding is local to the class it is defined on and is not propagated to the associated objects.`
https://beanvalidation.org/1.0/spec/#constraintdeclarationvalidationprocess-validationroutine-graphvalidation