### PR TITLE
[FE] feat: 새로고침 및 창을 닫는 동작에 대해 경고 alert 띄우기

### DIFF
--- a/frontend/src/pages/ReviewWritingPage/form/components/CardForm/index.tsx
+++ b/frontend/src/pages/ReviewWritingPage/form/components/CardForm/index.tsx
@@ -36,7 +36,7 @@ const CardForm = () => {
   useUpdateDefaultAnswers();
 
   // 모달
-  const { handleOpenModal, closeModal, isOpen, isNavigationUnblocked } = useCardFormModal();
+  const { handleOpenModal, closeModal, isOpen } = useCardFormModal();
 
   const handleNavigateConfirmButtonClick = () => {
     closeModal(CARD_FORM_MODAL_KEY.navigateConfirm);
@@ -46,7 +46,6 @@ const CardForm = () => {
 
   // 작성 중인 답변이 있는 경우 페이지 이동을 막는 기능
   const { blocker } = useNavigateBlocker({
-    isNavigationUnblocked,
     openNavigateConfirmModal: () => handleOpenModal('navigateConfirm'),
   });
 

--- a/frontend/src/pages/ReviewWritingPage/form/components/CardForm/index.tsx
+++ b/frontend/src/pages/ReviewWritingPage/form/components/CardForm/index.tsx
@@ -36,19 +36,17 @@ const CardForm = () => {
   useUpdateDefaultAnswers();
 
   // 모달
-  const { handleOpenModal, closeModal, isOpen, isOpenModalDisablingBlocker } = useCardFormModal();
+  const { handleOpenModal, closeModal, isOpen, isUnblocked } = useCardFormModal();
 
   const handleNavigateConfirmButtonClick = () => {
     closeModal(CARD_FORM_MODAL_KEY.navigateConfirm);
 
-    if (blocker.proceed) {
-      blocker.proceed();
-    }
+    if (blocker.proceed) blocker.proceed();
   };
 
   // 작성 중인 답변이 있는 경우 페이지 이동을 막는 기능
   const { blocker } = useNavigateBlocker({
-    isOpenModalDisablingBlocker,
+    isUnblocked,
     openNavigateConfirmModal: () => handleOpenModal('navigateConfirm'),
   });
 

--- a/frontend/src/pages/ReviewWritingPage/form/components/CardForm/index.tsx
+++ b/frontend/src/pages/ReviewWritingPage/form/components/CardForm/index.tsx
@@ -36,7 +36,7 @@ const CardForm = () => {
   useUpdateDefaultAnswers();
 
   // 모달
-  const { handleOpenModal, closeModal, isOpen, isUnblocked } = useCardFormModal();
+  const { handleOpenModal, closeModal, isOpen, isNavigationUnblocked } = useCardFormModal();
 
   const handleNavigateConfirmButtonClick = () => {
     closeModal(CARD_FORM_MODAL_KEY.navigateConfirm);
@@ -46,7 +46,7 @@ const CardForm = () => {
 
   // 작성 중인 답변이 있는 경우 페이지 이동을 막는 기능
   const { blocker } = useNavigateBlocker({
-    isUnblocked,
+    isNavigationUnblocked,
     openNavigateConfirmModal: () => handleOpenModal('navigateConfirm'),
   });
 

--- a/frontend/src/pages/ReviewWritingPage/form/hooks/useNavigateBlocker.ts
+++ b/frontend/src/pages/ReviewWritingPage/form/hooks/useNavigateBlocker.ts
@@ -8,6 +8,7 @@ interface UseNavigateBlockerProps {
   isOpenModalDisablingBlocker: boolean;
   openNavigateConfirmModal: () => void;
 }
+
 /**
  * @param isOpenModalDisablingBlocker : 이동 확인 모달과 리뷰 제출 확인 모달 모달들이 열려있는 지 여부 (모달의 이동/제출 버튼 클릭 시 페이지 이동해야하기 때문에 필요)
  * 작성한 답변이 있는 상태에서 작성한 페이지에서 다른 페이지로 이동하려할때 이동을 막거나, 이동을 진행하는 blocker를 반환하는 훅
@@ -17,10 +18,17 @@ const useNavigateBlocker = ({ isOpenModalDisablingBlocker, openNavigateConfirmMo
 
   const isAnswerInProgress = () => {
     if (!answerMap) return false;
-
     return [...answerMap.values()].some((answer) => !!answer.selectedOptionIds?.length || !!answer.text?.length);
   };
 
+  // 페이지 새로고침 및 닫기에 대한 처리 by BeforeUnloadEvent
+  const handleNavigationBlock = (event: BeforeUnloadEvent) => {
+    if (isAnswerInProgress() && !isOpenModalDisablingBlocker) {
+      event.preventDefault();
+    }
+  };
+
+  // 페이지 히스토리에 영향을 주는 페이지 이동은 useBlocker가 처리
   const blocker = useBlocker(({ currentLocation, nextLocation }) => {
     if (isOpenModalDisablingBlocker) return false;
     const isLeavingPage = currentLocation.pathname !== nextLocation.pathname;
@@ -32,6 +40,14 @@ const useNavigateBlocker = ({ isOpenModalDisablingBlocker, openNavigateConfirmMo
       openNavigateConfirmModal();
     }
   }, [blocker]);
+
+  useEffect(() => {
+    window.addEventListener('beforeunload', handleNavigationBlock);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleNavigationBlock);
+    };
+  }, [answerMap, isOpenModalDisablingBlocker]);
 
   return {
     blocker,

--- a/frontend/src/pages/ReviewWritingPage/form/hooks/useNavigateBlocker.ts
+++ b/frontend/src/pages/ReviewWritingPage/form/hooks/useNavigateBlocker.ts
@@ -5,15 +5,10 @@ import { useRecoilValue } from 'recoil';
 import { answerMapAtom } from '@/recoil';
 
 interface UseNavigateBlockerProps {
-  isNavigationUnblocked: boolean;
   openNavigateConfirmModal: () => void;
 }
 
-/**
- * @param isNavigationUnblocked : useBlocker로 라우팅을 막지 않는(다른 페이지로 이동 가능한) 상태인지를 의미함
- * 작성한 답변이 있는 상태에서 작성한 페이지에서 다른 페이지로 이동하려할때 이동을 막거나, 이동을 진행하는 blocker를 반환하는 훅
- */
-const useNavigateBlocker = ({ isNavigationUnblocked, openNavigateConfirmModal }: UseNavigateBlockerProps) => {
+const useNavigateBlocker = ({ openNavigateConfirmModal }: UseNavigateBlockerProps) => {
   const answerMap = useRecoilValue(answerMapAtom);
 
   const isAnswerInProgress = () => {
@@ -23,14 +18,15 @@ const useNavigateBlocker = ({ isNavigationUnblocked, openNavigateConfirmModal }:
 
   // 페이지 새로고침 및 닫기에 대한 처리: 브라우저 기본 alert 등장
   const handleNavigationBlock = (event: BeforeUnloadEvent) => {
-    if (isAnswerInProgress() && !isNavigationUnblocked) event.preventDefault();
+    if (isAnswerInProgress()) event.preventDefault();
   };
 
-  // 페이지 히스토리에 영향을 주는 페이지 이동은 useBlocker가 처리
+  // 페이지 히스토리에 영향을 주는 페이지 이동 처리: useBlocker 이용
   const blocker = useBlocker(({ currentLocation, nextLocation }) => {
-    if (isNavigationUnblocked) return false;
     const isLeavingPage = currentLocation.pathname !== nextLocation.pathname;
-    return isAnswerInProgress() && isLeavingPage;
+    const isMoveToCompletePage = nextLocation.pathname.includes('complete');
+    // 리뷰 작성 완료 페이지로 이동하는 url 변경인 경우에는 navigateConfirm 모달을 띄우지 않음
+    return isAnswerInProgress() && isLeavingPage && !isMoveToCompletePage;
   });
 
   useEffect(() => {
@@ -45,7 +41,7 @@ const useNavigateBlocker = ({ isNavigationUnblocked, openNavigateConfirmModal }:
     return () => {
       window.removeEventListener('beforeunload', handleNavigationBlock);
     };
-  }, [answerMap, isNavigationUnblocked]);
+  }, [answerMap]);
 
   return {
     blocker,

--- a/frontend/src/pages/ReviewWritingPage/form/hooks/useNavigateBlocker.ts
+++ b/frontend/src/pages/ReviewWritingPage/form/hooks/useNavigateBlocker.ts
@@ -5,17 +5,15 @@ import { useRecoilValue } from 'recoil';
 import { answerMapAtom } from '@/recoil';
 
 interface UseNavigateBlockerProps {
-  isUnblocked: boolean;
+  isNavigationUnblocked: boolean;
   openNavigateConfirmModal: () => void;
 }
 
-
-
 /**
- * @param isUnblocked : useBlocker로 라우팅을 막지 않는(다른 페이지로 이동 가능한) 상태인지를 의미함 
+ * @param isNavigationUnblocked : useBlocker로 라우팅을 막지 않는(다른 페이지로 이동 가능한) 상태인지를 의미함
  * 작성한 답변이 있는 상태에서 작성한 페이지에서 다른 페이지로 이동하려할때 이동을 막거나, 이동을 진행하는 blocker를 반환하는 훅
  */
-const useNavigateBlocker = ({ isUnblocked, openNavigateConfirmModal }: UseNavigateBlockerProps) => {
+const useNavigateBlocker = ({ isNavigationUnblocked, openNavigateConfirmModal }: UseNavigateBlockerProps) => {
   const answerMap = useRecoilValue(answerMapAtom);
 
   const isAnswerInProgress = () => {
@@ -23,16 +21,14 @@ const useNavigateBlocker = ({ isUnblocked, openNavigateConfirmModal }: UseNaviga
     return [...answerMap.values()].some((answer) => !!answer.selectedOptionIds?.length || !!answer.text?.length);
   };
 
-  // 페이지 새로고침 및 닫기에 대한 처리 by BeforeUnloadEvent
+  // 페이지 새로고침 및 닫기에 대한 처리: 브라우저 기본 alert 등장
   const handleNavigationBlock = (event: BeforeUnloadEvent) => {
-    if (isAnswerInProgress() && !isUnblocked) {
-      event.preventDefault();
-    }
+    if (isAnswerInProgress() && !isNavigationUnblocked) event.preventDefault();
   };
 
   // 페이지 히스토리에 영향을 주는 페이지 이동은 useBlocker가 처리
   const blocker = useBlocker(({ currentLocation, nextLocation }) => {
-    if (isUnblocked) return false;
+    if (isNavigationUnblocked) return false;
     const isLeavingPage = currentLocation.pathname !== nextLocation.pathname;
     return isAnswerInProgress() && isLeavingPage;
   });
@@ -49,7 +45,7 @@ const useNavigateBlocker = ({ isUnblocked, openNavigateConfirmModal }: UseNaviga
     return () => {
       window.removeEventListener('beforeunload', handleNavigationBlock);
     };
-  }, [answerMap, isUnblocked]);
+  }, [answerMap, isNavigationUnblocked]);
 
   return {
     blocker,

--- a/frontend/src/pages/ReviewWritingPage/form/hooks/useNavigateBlocker.ts
+++ b/frontend/src/pages/ReviewWritingPage/form/hooks/useNavigateBlocker.ts
@@ -5,15 +5,17 @@ import { useRecoilValue } from 'recoil';
 import { answerMapAtom } from '@/recoil';
 
 interface UseNavigateBlockerProps {
-  isOpenModalDisablingBlocker: boolean;
+  isUnblocked: boolean;
   openNavigateConfirmModal: () => void;
 }
 
+
+
 /**
- * @param isOpenModalDisablingBlocker : 이동 확인 모달과 리뷰 제출 확인 모달 모달들이 열려있는 지 여부 (모달의 이동/제출 버튼 클릭 시 페이지 이동해야하기 때문에 필요)
+ * @param isUnblocked : useBlocker로 라우팅을 막지 않는(다른 페이지로 이동 가능한) 상태인지를 의미함 
  * 작성한 답변이 있는 상태에서 작성한 페이지에서 다른 페이지로 이동하려할때 이동을 막거나, 이동을 진행하는 blocker를 반환하는 훅
  */
-const useNavigateBlocker = ({ isOpenModalDisablingBlocker, openNavigateConfirmModal }: UseNavigateBlockerProps) => {
+const useNavigateBlocker = ({ isUnblocked, openNavigateConfirmModal }: UseNavigateBlockerProps) => {
   const answerMap = useRecoilValue(answerMapAtom);
 
   const isAnswerInProgress = () => {
@@ -23,14 +25,14 @@ const useNavigateBlocker = ({ isOpenModalDisablingBlocker, openNavigateConfirmMo
 
   // 페이지 새로고침 및 닫기에 대한 처리 by BeforeUnloadEvent
   const handleNavigationBlock = (event: BeforeUnloadEvent) => {
-    if (isAnswerInProgress() && !isOpenModalDisablingBlocker) {
+    if (isAnswerInProgress() && !isUnblocked) {
       event.preventDefault();
     }
   };
 
   // 페이지 히스토리에 영향을 주는 페이지 이동은 useBlocker가 처리
   const blocker = useBlocker(({ currentLocation, nextLocation }) => {
-    if (isOpenModalDisablingBlocker) return false;
+    if (isUnblocked) return false;
     const isLeavingPage = currentLocation.pathname !== nextLocation.pathname;
     return isAnswerInProgress() && isLeavingPage;
   });
@@ -47,7 +49,7 @@ const useNavigateBlocker = ({ isOpenModalDisablingBlocker, openNavigateConfirmMo
     return () => {
       window.removeEventListener('beforeunload', handleNavigationBlock);
     };
-  }, [answerMap, isOpenModalDisablingBlocker]);
+  }, [answerMap, isUnblocked]);
 
   return {
     blocker,

--- a/frontend/src/pages/ReviewWritingPage/modals/hooks/useCardFormModal.ts
+++ b/frontend/src/pages/ReviewWritingPage/modals/hooks/useCardFormModal.ts
@@ -13,8 +13,7 @@ const useCardFormModal = () => {
     handleOpenModal,
     closeModal,
     isOpen,
-    isOpenModalDisablingBlocker:
-      isOpen(CARD_FORM_MODAL_KEY.recheck) || isOpen(CARD_FORM_MODAL_KEY.submitConfirm),
+    isUnblocked: isOpen(CARD_FORM_MODAL_KEY.submitConfirm),
   };
 };
 

--- a/frontend/src/pages/ReviewWritingPage/modals/hooks/useCardFormModal.ts
+++ b/frontend/src/pages/ReviewWritingPage/modals/hooks/useCardFormModal.ts
@@ -14,7 +14,7 @@ const useCardFormModal = () => {
     closeModal,
     isOpen,
     isOpenModalDisablingBlocker:
-      isOpen(CARD_FORM_MODAL_KEY.navigateConfirm) || isOpen(CARD_FORM_MODAL_KEY.submitConfirm),
+      isOpen(CARD_FORM_MODAL_KEY.recheck) || isOpen(CARD_FORM_MODAL_KEY.submitConfirm),
   };
 };
 

--- a/frontend/src/pages/ReviewWritingPage/modals/hooks/useCardFormModal.ts
+++ b/frontend/src/pages/ReviewWritingPage/modals/hooks/useCardFormModal.ts
@@ -13,7 +13,6 @@ const useCardFormModal = () => {
     handleOpenModal,
     closeModal,
     isOpen,
-    isNavigationUnblocked: isOpen(CARD_FORM_MODAL_KEY.submitConfirm),
   };
 };
 

--- a/frontend/src/pages/ReviewWritingPage/modals/hooks/useCardFormModal.ts
+++ b/frontend/src/pages/ReviewWritingPage/modals/hooks/useCardFormModal.ts
@@ -13,7 +13,7 @@ const useCardFormModal = () => {
     handleOpenModal,
     closeModal,
     isOpen,
-    isUnblocked: isOpen(CARD_FORM_MODAL_KEY.submitConfirm),
+    isNavigationUnblocked: isOpen(CARD_FORM_MODAL_KEY.submitConfirm),
   };
 };
 


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #827 

---

### 🚀 어떤 기능을 구현했나요 ?
- 새로고침, 창 닫기 동작이 일어나기 전 의도한 동작인지 확인하고 내용이 날아간다는 alert을 띄우는 기능을 구현했습니다.
- 기존에 열린 모달이 있는지 확인하는 `isOpenModalDisablingBlocker`의 값을 정할 때, 작성 페이지에서 사용하는 모달인 recheck 혹은 submitConfirm이 열려 있는지를 확인해야 하는데 페이지 이동을 확인하는 navigateConfirm의 상태를 체크하고 있던 버그를 수정했습니다. (만약 의도한 동작이었다면 알려주세요!)

### 🔥 어떻게 해결했나요 ?
#### beforeunload 이벤트
- 페이지가 닫히거나 새로고침되기 직전에 트리거 -> 사용자에게 alert을 보여줄 수 있음
- 단 악용의 소지가 있기에 커스텀 모달을 띄우는 것은 불가능, 브라우저 기본 alert과 메세지만 보여줄 수 있음
  - 모달을 띄우기 위해 새로고침, 창 닫기를 다른 방식으로 처리할 수 있는지를 살펴봤는데, 라우팅 관련 동작을 담당할 수 있는 react-router-dom의 `useBlocker`와 달리 저 두 동작은 브라우저가 전적으로 책임지는 로직이라  `beforeunload`를 사용하지 않고서는 접근할 수가 없었습니다. 
- 대부분의 브라우저에서 지원하나 IOS Safari에서 불안정하게 동작할 수 있음
 - 아예 미지원하는 게 아니라 alert을 개발자가 트리거하는 동작들만 막고 이벤트 자체는 지원합니다.
 - 정확한 동작을 테스트해볼 수가 없어서 GPT한테 물어봤는데 의도한 상황에서는 동작하는 것 같습니다. 다만 개발 서버에 올려서 확인해봐야 할 것 같아요...
> GPT: 사용자가 새로고침을 하거나 탭을 닫으려 할 때, 브라우저가 제공하는 기본 경고 창은 표시될 수 있습니다. 
사용자가 직접적으로 상호작용하지 않은 상태, 즉 터치 없이 페이지가 백그라운드로 전환되거나, 탭이 닫힐 때 발생하는 beforeunload 이벤트는 차단될 수 있습니다.
이 말은, 사용자 상호작용 없이 페이지가 떠나는 상황에서는 beforeunload 이벤트가 트리거되지 않거나, 경고 메시지가 표시되지 않을 수 있다는 의미입니다.


<br>

대안을 찾아봤지만 아쉽게도 `beforeunload`를 대체할 수 있는 방안을 찾지 못했습니다.
대안으로 `pagehide` 이벤트가 많이 언급되는데, 이 이벤트는 클래스의 소멸자마냥 페이지가 언로드될 때 실행되는 이벤트라 UI 상호작용이 불가능합니다.
그래서 아예 매커니즘을 바꿔 경고 모달을 띄우는 대신 세션 스토리지 혹은 서버에 중간 데이터를 저장하는 방식을 권장하고, 이 동작을 `pagehide`로 처리하는 예제가 많았습니다.

호환성 문제를 떠나 UX 측면에서도 경고 모달을 띄워주는 것보다 데이터를 로컬에라도 저장한 뒤 다시 돌아왔을 때 복원해주는 방식을 권장하는 것 같습니다.
개인적으로 답변을 로컬이나 세션 스토리지에 저장하는 게 낫다고 생각합니다만 논의된 바가 없고 시급한 문제는 아니라고 생각해 alert만 띄우는 코드로 PR 올립니다!

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 기존 구현에 맞춰 `isOpenModalDisablingBlocker`를 이용했습니다. 즉 한 페이지에 2개 이상의 모달을 띄우지 않습니다. (현재 통일성을 위해 alert로 띄우는 경우도 막아놨습니다)
- 그런데 이렇게 되면 작성 확인 모달이나 제출 확인 모달이 떠 있는 상황에서 새로고침 등을 하는 경우에는 이동 확인 모달을 띄울 수 없습니다. 리뷰를 다 작성한 상황에서 사용자가 실수로 새로고침을 누르면(이럴 확률이 적긴 하겠지만요)경고 없이 내용이 다 날아갑니다.

- 그래서 `isOpenModalDisablingBlocker` 제한을 해제하는 것도 고려했는데, 뒤로 가기 상황에서 문제가 됩니다.
1. 새로고침, 창 닫기 alert -> 어차피 alert이라 모달과 같이 떠 있어도 크게 거슬리지 않음
![image](https://github.com/user-attachments/assets/b0281ce3-bb10-4889-afc2-95885bc9ca1e)

ㄴ 이런 느낌입니다. 근데 캡쳐본으로 다시 보니 거슬리는 것 같기도...🤣

3. 뒤로가기 -> 모달이 이중으로 뜸!!
ㄴ 모달 떠 있을 때 && 뒤로가기 이벤트일 때 새로고침, 창 닫기 동작 때처럼 alert 띄우기가 가능은 했습니다. 다만 저 동작들이 일어났을 때 띄워주는 alert(확인 누르면 새고고침, 취소 누르면 아무 일도 하지 않음)와 똑같이 동작하게 만들 수 있는지는 아직 모르겠습니다. 필요하다면 시도해볼게요
4. 그 외의 페이지 이동(로고 클릭, breadCrumb)-> 어차피 모달 켜져 있는 상황에서는 누를 수 없기 때문에 이동 확인 모달이 그 위에 또 뜰 염려가 없음 -> `isOpenModalDisablingBlocker` 제한이 꼭 필요하지 않음

### 📚 참고 자료, 할 말
#### 결론
1. IOS Safari 환경에서의 동작 테스트가 필요하다.
2. UX를 고려했을 때 경고 모달을 띄우는 것보다 이런 이벤트가 일어났을 때 별도로 데이터를 저장하는 게 낫다.
3. 모달을 2개 이상 띄울 수 있는 것 혹은 모달 위에 alert을 띄우는 것을 허용할지에 대한 논의가 필요하다.

- [beforeunolad 이벤트](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event)