### PR TITLE
[FE] feat: 커스텀한 ErrorBoudary 생성 및 react-error-boundary 삭제

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,6 @@
     "dotenv-webpack": "^8.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-error-boundary": "^4.0.13",
     "react-router": "^6.24.1",
     "react-router-dom": "^6.24.1",
     "recoil": "^0.7.7"

--- a/frontend/src/components/error/AuthAndServerErrorFallback/index.tsx
+++ b/frontend/src/components/error/AuthAndServerErrorFallback/index.tsx
@@ -1,10 +1,10 @@
-import { FallbackProps } from 'react-error-boundary';
 import { useNavigate } from 'react-router';
 
 import { ROUTE } from '@/constants/route';
 import { useSearchParamAndQuery } from '@/hooks';
 
 import AuthAndServerErrorSection from '../AuthAndServerErrorSection';
+import { FallbackProps } from '../ErrorBoundary';
 
 const AuthAndServerErrorFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
   const navigate = useNavigate();

--- a/frontend/src/components/error/ErrorBoundary.tsx
+++ b/frontend/src/components/error/ErrorBoundary.tsx
@@ -25,12 +25,12 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   }
 
   static getDerivedStateFromError(error: Error): ErrorBoundaryState {
-    // 에러가 발생하면 상태를 업데이트하여 fallback을 표시하게 함
+    // 에러가 발생하면 상태를 업데이트하여 fallback을 표시
     return { hasError: true, error };
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-    // 에러를 로깅하거나 다른 작업을 수행할 수 있음
+    // 에러를 로깅
     console.error('ErrorBoundary caught an error', error, errorInfo);
   }
 

--- a/frontend/src/components/error/ErrorBoundary.tsx
+++ b/frontend/src/components/error/ErrorBoundary.tsx
@@ -43,13 +43,11 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
     const { hasError, error } = this.state;
     const { children, fallback: FallbackComponent } = this.props;
 
-    // 에러가 IgnoredError를 포함하면 children을 그대로 보여줌
-    if (error?.message.includes(ERROR_BOUNDARY_IGNORE_ERROR)) {
-      return children;
-    }
+    // 에러 메세지에 IgnoredError를 포함하면 fallback 대상에서 제외
+    const isHandleError = !error?.message.includes(ERROR_BOUNDARY_IGNORE_ERROR);
 
     // 에러가 발생했을 때 fallback 컴포넌트로 대체
-    if (hasError && error) {
+    if (hasError && error && isHandleError) {
       return <FallbackComponent error={error} resetErrorBoundary={this.resetErrorBoundary} />;
     }
 

--- a/frontend/src/components/error/ErrorBoundary.tsx
+++ b/frontend/src/components/error/ErrorBoundary.tsx
@@ -10,7 +10,7 @@ export interface FallbackProps {
 interface ErrorBoundaryProps {
   fallback: React.ComponentType<FallbackProps>;
   children: ReactNode;
-  resetQueryError: () => void;
+  resetQueryError?: () => void;
 }
 
 interface ErrorBoundaryState {
@@ -35,7 +35,9 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   }
 
   resetErrorBoundary = () => {
-    this.props.resetQueryError();
+    const { resetQueryError } = this.props;
+    if (resetQueryError) resetQueryError();
+
     this.setState({ hasError: false, error: null });
   };
 

--- a/frontend/src/components/error/ErrorBoundary.tsx
+++ b/frontend/src/components/error/ErrorBoundary.tsx
@@ -1,0 +1,60 @@
+import React, { Component, ReactNode } from 'react';
+
+import { ERROR_BOUNDARY_IGNORE_ERROR } from '@/constants';
+
+export interface FallbackProps {
+  error: Error;
+  resetErrorBoundary: () => void;
+}
+
+interface ErrorBoundaryProps {
+  fallback: React.ComponentType<FallbackProps>;
+  children: ReactNode;
+  resetQueryError: () => void;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    // 에러가 발생하면 상태를 업데이트하여 fallback을 표시하게 함
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    // 에러를 로깅하거나 다른 작업을 수행할 수 있음
+    console.error('ErrorBoundary caught an error', error, errorInfo);
+  }
+
+  resetErrorBoundary = () => {
+    this.props.resetQueryError();
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    const { hasError, error } = this.state;
+    const { children, fallback: FallbackComponent } = this.props;
+
+    // 에러가 IgnoredError를 포함하면 children을 그대로 보여줌
+    if (error?.message.includes(ERROR_BOUNDARY_IGNORE_ERROR)) {
+      return children;
+    }
+
+    // 에러가 발생했을 때 fallback 컴포넌트로 대체
+    if (hasError && error) {
+      return <FallbackComponent error={error} resetErrorBoundary={this.resetErrorBoundary} />;
+    }
+
+    return children;
+  }
+}
+
+export default ErrorBoundary;

--- a/frontend/src/components/error/ErrorFallback/index.tsx
+++ b/frontend/src/components/error/ErrorFallback/index.tsx
@@ -1,6 +1,6 @@
-import { FallbackProps } from 'react-error-boundary';
 import { useNavigate } from 'react-router';
 
+import { FallbackProps } from '../ErrorBoundary';
 import ErrorSection from '../ErrorSection';
 
 const ErrorFallback = ({ error, resetErrorBoundary }: FallbackProps) => {

--- a/frontend/src/components/error/ErrorSuspenseContainer/index.tsx
+++ b/frontend/src/components/error/ErrorSuspenseContainer/index.tsx
@@ -1,9 +1,9 @@
 import { QueryErrorResetBoundary } from '@tanstack/react-query';
 import { lazy, Suspense } from 'react';
-import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
 
 import { EssentialPropsWithChildren } from '@/types';
 
+import ErrorBoundary, { FallbackProps } from '../ErrorBoundary';
 import ErrorFallback from '../ErrorFallback';
 
 const LoadingPage = lazy(() => import('@/pages/LoadingPage'));
@@ -19,7 +19,7 @@ const ErrorSuspenseContainer = ({
   return (
     <QueryErrorResetBoundary>
       {({ reset }) => (
-        <ErrorBoundary FallbackComponent={fallback} onReset={reset}>
+        <ErrorBoundary fallback={fallback} resetQueryError={reset}>
           <Suspense fallback={<LoadingPage />}>{children}</Suspense>
         </ErrorBoundary>
       )}

--- a/frontend/src/components/error/index.tsx
+++ b/frontend/src/components/error/index.tsx
@@ -2,3 +2,4 @@ export { default as ErrorSection } from './ErrorSection';
 export { default as ErrorSuspenseContainer } from './ErrorSuspenseContainer';
 export { default as AuthAndServerErrorFallback } from './AuthAndServerErrorFallback';
 export { default as AuthAndServerErrorSection } from './AuthAndServerErrorSection';
+export { default as ErrorBoundary } from './ErrorBoundary';

--- a/frontend/src/constants/errorMessage.ts
+++ b/frontend/src/constants/errorMessage.ts
@@ -17,3 +17,5 @@ export const SERVER_ERROR_REGEX = /^5\d{2}$/;
 export const ROUTE_ERROR_MESSAGE = '찾으시는 페이지가 없어요';
 
 export const INVALID_REVIEW_PASSWORD_MESSAGE = '올바르지 않은 비밀번호예요';
+
+export const ERROR_BOUNDARY_IGNORE_ERROR = 'IgnoredError';

--- a/frontend/src/pages/ReviewWritingPage/modals/components/CardFormModalContainer/index.tsx
+++ b/frontend/src/pages/ReviewWritingPage/modals/components/CardFormModalContainer/index.tsx
@@ -1,7 +1,7 @@
 import { QueryErrorResetBoundary } from '@tanstack/react-query';
-import { ErrorBoundary } from 'react-error-boundary';
 import { useRecoilValue } from 'recoil';
 
+import { ErrorBoundary } from '@/components';
 import { CARD_FORM_MODAL_KEY } from '@/pages/ReviewWritingPage/constants';
 import {
   AnswerListRecheckModal,
@@ -31,13 +31,13 @@ const CardFormModalContainer = ({
       <QueryErrorResetBoundary>
         {({ reset }) => (
           <ErrorBoundary
-            FallbackComponent={(fallbackProps) => (
+            fallback={(fallbackProps) => (
               <SubmitErrorModal
                 closeSubmitCheckModal={() => closeModal(CARD_FORM_MODAL_KEY.submitConfirm)}
                 {...fallbackProps}
               />
             )}
-            onReset={reset}
+            resetQueryError={reset}
           >
             {isOpen(CARD_FORM_MODAL_KEY.submitConfirm) && (
               <SubmitCheckModal

--- a/frontend/src/pages/ReviewWritingPage/modals/components/SubmitErrorModal/index.tsx
+++ b/frontend/src/pages/ReviewWritingPage/modals/components/SubmitErrorModal/index.tsx
@@ -1,7 +1,6 @@
-import { FallbackProps } from 'react-error-boundary';
-
 import { ErrorAlertModal } from '@/components';
 import { ErrorAlertModalCloseButton } from '@/components/common/modals/ErrorAlertModal';
+import { FallbackProps } from '@/components/error/ErrorBoundary';
 
 import * as S from './style';
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6816,13 +6816,6 @@ react-dom@^18.3.1:
     loose-envify "^1.1.0"
     scheduler "^0.23.2"
 
-react-error-boundary@^4.0.13:
-  version "4.0.13"
-  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-4.0.13.tgz#80386b7b27b1131c5fbb7368b8c0d983354c7947"
-  integrity sha512-b6PwbdSv8XeOSYvjt8LpgpKrZ0yGdtZokYwkwV2wlcZbxgopHX/hgPl5VgpnoVOWd868n1hktM8Qm4b+02MiLQ==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #852

---

### 🚀 어떤 기능을 구현했나요 ?
#### 현재 문제점
 `react-error-boundary`의 `ErrorBoundary`는 api요청 실패 시 throw, Promise.reject을 모두 에러 캐치하고 있습니다.
형광펜 기능에서 api 오류 시 토스트 모달을 띄워야하기 때문에,  `react-error-boundary`의 `ErrorBoundary`를 사용한 에러 처리의 한계점을 느꼈습니다

#### 해결 방법
기존의 사용하던 `react-error-boundary`의 `ErrorBoundary`의 사용과 유사하며 기존에 사용하던 `react-query`의 `QueryErrorResetBoundary`의rest을 여전히 사용할 수 있는 `ErrorBoundary`를 직접 만들었습니다. 

현재는  에러 메세지에 `ERROR_BOUNDARY_IGNORE_ERROR` 상수가 포함되면 fallback이 실행되지 않도록 했습니다.
다만 문제는 `ERROR_BOUNDARY_IGNORE_ERROR` 로 fallback을 실행하지 않지만, 에러 발생 시 `ErrorBoundary`가 렌더링 되어 chilren도 같이 렌더링 됩니다. 그래서 api 요청 실패가 일어났을 때 리렌더링 되어야하는, api 요청을 하는 핸들러/훅이 선언된 컴포넌트만 `ErrorSuspenseContainer` 로 감싸는 것을 권장합니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
-  기존에 ErrorBoundary를 사용하는 곳에서 에러 처리 모두 확인했지만, 혹시나 놓치는 부분이 있다면 알려주세요

### 📚 참고 자료, 할 말
