### PR TITLE
[FE] design: 리뷰 작성 페이지 모달 글자 가운데 정렬

### DIFF
--- a/frontend/src/pages/ReviewWritingPage/modals/components/NavigateBlockerModal/style.ts
+++ b/frontend/src/pages/ReviewWritingPage/modals/components/NavigateBlockerModal/style.ts
@@ -6,9 +6,9 @@ export const ConfirmModalMessage = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.8rem;
+  align-items: center;
 
   p {
-    width: 100%;
     margin: 0;
     text-align: center;
   }

--- a/frontend/src/pages/ReviewWritingPage/modals/components/NavigateBlockerModal/style.ts
+++ b/frontend/src/pages/ReviewWritingPage/modals/components/NavigateBlockerModal/style.ts
@@ -6,19 +6,15 @@ export const ConfirmModalMessage = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.8rem;
-  align-items: start;
 
   p {
-    width: max-content;
+    width: 100%;
     margin: 0;
+    text-align: center;
   }
 
   ${media.xSmall} {
     width: 100%;
     min-width: 70vw;
-
-    p {
-      width: inherit;
-    }
   }
 `;

--- a/frontend/src/pages/ReviewWritingPage/modals/components/StrengthUnCheckModal/style.ts
+++ b/frontend/src/pages/ReviewWritingPage/modals/components/StrengthUnCheckModal/style.ts
@@ -8,11 +8,13 @@ export const Contents = styled.div`
   gap: 1rem;
   width: max-content;
 
+  p {
+    width: 100%;
+    text-align: center;
+  }
+
   ${media.xSmall} {
-    min-width: ${({ theme }) => {
-      const { maxWidth, padding } = theme.confirmModalSize;
-      return `calc(${maxWidth} - (${padding} * 2))`;
-    }};
+    width: 23rem;
   }
 `;
 

--- a/frontend/src/pages/ReviewWritingPage/modals/components/StrengthUnCheckModal/style.ts
+++ b/frontend/src/pages/ReviewWritingPage/modals/components/StrengthUnCheckModal/style.ts
@@ -6,10 +6,11 @@ export const Contents = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  width: max-content;
+  align-items: center;
 
+  width: max-content;
   p {
-    width: 100%;
+    width: fit-content;
     text-align: center;
   }
 

--- a/frontend/src/pages/ReviewWritingPage/modals/components/SubmitCheckModal/style.ts
+++ b/frontend/src/pages/ReviewWritingPage/modals/components/SubmitCheckModal/style.ts
@@ -19,7 +19,7 @@ export const Message = styled.div`
     min-width: 27rem;
   }
 
-  ${media.xxSmall} {
+  @media screen and (max-width: 375px) {
     min-width: 60vw;
   }
 `;

--- a/frontend/src/pages/ReviewWritingPage/modals/components/SubmitCheckModal/style.ts
+++ b/frontend/src/pages/ReviewWritingPage/modals/components/SubmitCheckModal/style.ts
@@ -6,12 +6,11 @@ export const Message = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.8rem;
-  align-items: start;
+  align-items: center;
 
   min-width: 30rem;
 
   p {
-    width: inherit;
     margin: 0;
   }
 

--- a/frontend/src/pages/ReviewWritingPage/modals/components/SubmitCheckModal/style.ts
+++ b/frontend/src/pages/ReviewWritingPage/modals/components/SubmitCheckModal/style.ts
@@ -12,9 +12,14 @@ export const Message = styled.div`
 
   p {
     margin: 0;
+    text-align: center;
   }
 
   ${media.xSmall} {
     min-width: 27rem;
+  }
+
+  ${media.xxSmall} {
+    min-width: 60vw;
   }
 `;

--- a/frontend/src/pages/ReviewWritingPage/modals/components/SubmitErrorModal/style.ts
+++ b/frontend/src/pages/ReviewWritingPage/modals/components/SubmitErrorModal/style.ts
@@ -4,11 +4,10 @@ export const Message = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.8rem;
-  align-items: start;
+  align-items: center;
 
   width: fit-content;
   p {
-    width: max-content;
     margin: 0;
   }
 `;

--- a/frontend/src/pages/ReviewWritingPage/modals/components/SubmitErrorModal/style.ts
+++ b/frontend/src/pages/ReviewWritingPage/modals/components/SubmitErrorModal/style.ts
@@ -9,5 +9,6 @@ export const Message = styled.div`
   width: fit-content;
   p {
     margin: 0;
+    text-align: center;
   }
 `;


### PR DESCRIPTION
- resolves #855

---

### 🚀 어떤 기능을 구현했나요 ?
- 리뷰 작성 페이지 모달을 웹, 모바일에서 사용해 보니 왼쪽 정렬을 택했을 때 빈 공간이 걸려서, 리뷰 작성 페이지 모달의 글자가 가운데 정렬되게 수정했습니다  

### 🔥 어떻게 해결했나요 ?
#### 강점 선택 해제 시
- 모바일 
![스크린샷 2024-10-14 135454](https://github.com/user-attachments/assets/d3e0a03c-a648-44d7-80b8-bd8864eb077e)
- 웹
![image](https://github.com/user-attachments/assets/306c335e-cd99-45d1-9e7e-a67ca28d2c55)

#### 리뷰  제출
- 모바일 
![스크린샷 2024-10-14 135440](https://github.com/user-attachments/assets/1bf67bd0-494e-4908-85e7-548fb43c1084)
- 웹
![image](https://github.com/user-attachments/assets/0a20f48d-9531-4000-87de-d5033b0cd608)

#### 경로 이탈 시 
- 모바일 
![스크린샷 2024-10-14 135250](https://github.com/user-attachments/assets/ee36f01f-4b33-4d03-aa47-33b4f54a161b)
- 웹 
![스크린샷 2024-10-14 135255](https://github.com/user-attachments/assets/7bfcbb51-2be9-4f6d-8ec7-6953516f70f9)

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 가운데 정렬을 했지만, 반응형을 하다보면 문장이 어색하게 끊기는 경우가 있습니다. 최대한 잡으려고 했지만, 어색한 부분이 있다면 말씀해주세요! 

### 📚 참고 자료, 할 말
- ErrorBounday와 하이라이트 관련 충돌이 예상되어서, 제가 올린 pr 중 이 pr 먼저 머지하고 다른 pr 머지하겠습니다