### PR TITLE
[FE] fix: 리뷰 작성 완료 페이지에 url로 직접 접근하는 행위 방지

### DIFF
--- a/frontend/src/components/common/Breadcrumb/index.tsx
+++ b/frontend/src/components/common/Breadcrumb/index.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
-import { useNavigate } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
+
+import { ROUTE } from '@/constants/route';
 
 import UndraggableWrapper from '../UndraggableWrapper';
 
 import * as S from './styles';
 
-type PathType = string | number;
-
 export interface Path {
   pageName: string;
-  path: PathType;
+  path: string;
 }
 
 interface BreadcrumbProps {
@@ -18,12 +18,13 @@ interface BreadcrumbProps {
 
 const Breadcrumb = ({ pathList }: BreadcrumbProps) => {
   const navigate = useNavigate();
+  const location = useLocation();
 
-  const handleNavigation = (path: PathType) => {
+  const handleNavigation = (path: string) => {
     if (typeof path === 'number') {
       navigate(path);
     } else {
-      navigate(path);
+      navigate(path, { replace: location.pathname.includes(`/${ROUTE.reviewWritingComplete}`) });
     }
   };
 

--- a/frontend/src/components/common/Breadcrumb/index.tsx
+++ b/frontend/src/components/common/Breadcrumb/index.tsx
@@ -21,11 +21,7 @@ const Breadcrumb = ({ pathList }: BreadcrumbProps) => {
   const location = useLocation();
 
   const handleNavigation = (path: string) => {
-    if (typeof path === 'number') {
-      navigate(path);
-    } else {
-      navigate(path, { replace: location.pathname.includes(`/${ROUTE.reviewWritingComplete}`) });
-    }
+    navigate(path, { replace: location.pathname.includes(`/${ROUTE.reviewWritingComplete}`) });
   };
 
   return (

--- a/frontend/src/components/error/ErrorSection/index.tsx
+++ b/frontend/src/components/error/ErrorSection/index.tsx
@@ -13,6 +13,7 @@ export interface ErrorSectionProps {
   errorMessage: string;
   handleReload: () => void;
   handleGoOtherPage: () => void;
+  errorType?: 'notFound' | 'invalidAccess';
 }
 
 export interface ErrorSectionButton {
@@ -25,27 +26,30 @@ export interface ErrorSectionButton {
   onClick: () => void;
 }
 
-const ErrorSection = ({ errorMessage, handleReload, handleGoOtherPage }: ErrorSectionProps) => {
+const ErrorSection = ({ errorMessage, handleReload, handleGoOtherPage, errorType = 'notFound' }: ErrorSectionProps) => {
   const isGoHomeButtonFirst = errorMessage === ROUTE_ERROR_MESSAGE;
   // errorMessage에 따른 커스텀
-  const buttonList: ErrorSectionButton[] = [
-    {
+  const buttonList: ErrorSectionButton[] = [];
+
+  if (errorType === 'notFound') {
+    buttonList.push({
       buttonType: isGoHomeButtonFirst ? 'secondary' : 'primary',
       key: 'refreshButton',
       text: '새로고침하기',
       imageSrc: isGoHomeButtonFirst ? PrimaryReloadIcon : WhiteReloadIcon,
       imageDescription: '새로고침 이미지',
       onClick: handleReload,
-    },
-    {
-      buttonType: isGoHomeButtonFirst ? 'primary' : 'secondary',
-      key: 'homeButton',
-      text: '홈으로 이동하기',
-      imageSrc: isGoHomeButtonFirst ? WhiteHomeIcon : PrimaryHomeIcon,
-      imageDescription: '홈 이미지',
-      onClick: handleGoOtherPage,
-    },
-  ];
+    });
+  }
+
+  buttonList.push({
+    buttonType: errorType === 'invalidAccess' ? 'primary' : isGoHomeButtonFirst ? 'primary' : 'secondary',
+    key: 'homeButton',
+    text: '홈으로 이동하기',
+    imageSrc: errorType === 'invalidAccess' ? WhiteHomeIcon : isGoHomeButtonFirst ? WhiteHomeIcon : PrimaryHomeIcon,
+    imageDescription: '홈 이미지',
+    onClick: handleGoOtherPage,
+  });
 
   const errorSectionButtonList = isGoHomeButtonFirst ? buttonList.reverse() : buttonList;
 

--- a/frontend/src/hooks/useBreadcrumbPaths.ts
+++ b/frontend/src/hooks/useBreadcrumbPaths.ts
@@ -34,7 +34,7 @@ const useBreadcrumbPaths = () => {
   if (pathname.includes(`/${ROUTE.reviewWritingComplete}`)) {
     breadcrumbPathList.push(
       { pageName: '리뷰 작성', path: `${ROUTE.reviewWriting}/${reviewRequestCode}` },
-      { pageName: '리뷰 작성 완료 페이지', path: pathname },
+      { pageName: '리뷰 작성 완료', path: pathname },
     );
   }
 

--- a/frontend/src/pages/ReviewWritingCompletePage/index.tsx
+++ b/frontend/src/pages/ReviewWritingCompletePage/index.tsx
@@ -1,4 +1,5 @@
-import { useNavigate } from 'react-router';
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router';
 
 import PrimaryHomeIcon from '@/assets/primaryHome.svg';
 import SmileIcon from '@/assets/smile.svg';
@@ -8,6 +9,13 @@ import * as S from './styles';
 
 const ReviewWritingCompletePage = () => {
   const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    if (!location.state || !location.state.isValidAccess) {
+      navigate('/');
+    }
+  }, [location, navigate]);
 
   const handleClickHomeButton = () => {
     navigate('/', { replace: true });

--- a/frontend/src/pages/ReviewWritingCompletePage/index.tsx
+++ b/frontend/src/pages/ReviewWritingCompletePage/index.tsx
@@ -1,25 +1,34 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 
 import PrimaryHomeIcon from '@/assets/primaryHome.svg';
 import SmileIcon from '@/assets/smile.svg';
-import { Button } from '@/components';
+import { Button, ErrorSection } from '@/components';
 
 import * as S from './styles';
 
 const ReviewWritingCompletePage = () => {
+  const [isValid, setIsValid] = useState(true);
   const navigate = useNavigate();
   const location = useLocation();
 
   useEffect(() => {
-    if (!location.state || !location.state.isValidAccess) {
-      navigate('/');
-    }
-  }, [location, navigate]);
+    if (!location.state || !location.state.isValidAccess) setIsValid(false);
+  }, [location]);
 
   const handleClickHomeButton = () => {
     navigate('/', { replace: true });
   };
+
+  if (!isValid) {
+    return (
+      <ErrorSection
+        errorMessage="유효하지 않은 접근이에요"
+        handleReload={() => navigate(0)}
+        handleGoOtherPage={() => navigate('/', { replace: true })}
+      />
+    );
+  }
 
   return (
     <S.Layout>

--- a/frontend/src/pages/ReviewWritingCompletePage/index.tsx
+++ b/frontend/src/pages/ReviewWritingCompletePage/index.tsx
@@ -26,6 +26,7 @@ const ReviewWritingCompletePage = () => {
         errorMessage="유효하지 않은 접근이에요"
         handleReload={() => navigate(0)}
         handleGoOtherPage={() => navigate('/', { replace: true })}
+        errorType="invalidAccess"
       />
     );
   }

--- a/frontend/src/pages/ReviewWritingPage/form/hooks/answers/useSubmitAnswers.ts
+++ b/frontend/src/pages/ReviewWritingPage/form/hooks/answers/useSubmitAnswers.ts
@@ -21,7 +21,7 @@ const useSubmitAnswers = ({ closeSubmitConfirmModal }: UseSubmitAnswersProps) =>
   const navigate = useNavigate();
 
   const executeAfterMutateSuccess = () => {
-    navigate(`/${ROUTE.reviewWritingComplete}/${reviewRequestCode}`);
+    navigate(`/${ROUTE.reviewWritingComplete}/${reviewRequestCode}`, { state: { isValidAccess: true } });
     closeSubmitConfirmModal();
   };
 

--- a/frontend/src/pages/ReviewZonePage/index.tsx
+++ b/frontend/src/pages/ReviewZonePage/index.tsx
@@ -49,7 +49,6 @@ const ReviewZonePage = () => {
     <S.ReviewZonePage>
       <S.ReviewZoneMainImg src={ReviewZoneIcon} alt="" />
       <S.ReviewGuideContainer>
-        {/* NOTE: 추후 API 연동되면 서버에서 받아온 이름들을 출력하도록 수정해야 함 */}
         <S.ReviewGuide>{`${reviewGroupData.projectName}${calculateParticle({ target: reviewGroupData.projectName, particles: { withFinalConsonant: '을', withoutFinalConsonant: '를' } })} 함께한`}</S.ReviewGuide>
         <S.ReviewGuide>{`${reviewGroupData.revieweeName}의 리뷰 공간이에요`}</S.ReviewGuide>
       </S.ReviewGuideContainer>


### PR DESCRIPTION
- resolves #864 

---

### 🚀 어떤 기능을 구현했나요 ?
- 리뷰 작성 완료 페이지에 url로 직접 접근하지 못하게 막았습니다.

### 🔥 어떻게 해결했나요 ?
- 리뷰 작성 페이지에서 제출 버튼을 누를 때 navigate와 함께 state로 `isValidAccess` 플래그를 전달합니다. 리뷰 작성 완료 페이지에서는 state가 비어있거나, `isValidAccess`가 false일 때 홈페이지로 리다이렉션합니다.
- PrivateRoute를 사용하는 방식도 있지만(https://velog.io/@somda/React-PrivateRoute-%EB%A7%8C%EB%93%A4%EA%B8%B0react-router-dom-v6), 이는 인증되지 않은 경우에 url 접근을 막는 것이라 다른 상황이라 판단했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
