### PR TITLE
[BE] feat: 하이라이트 정보 함께 조회

### DIFF
--- a/backend/src/main/java/reviewme/highlight/repository/HighlightRepository.java
+++ b/backend/src/main/java/reviewme/highlight/repository/HighlightRepository.java
@@ -20,6 +20,7 @@ public interface HighlightRepository extends JpaRepository<Highlight, Long> {
             SELECT h
             FROM Highlight h
             WHERE h.answerId IN :answerIds
+            ORDER BY h.lineIndex, h.highlightRange.startIndex ASC
             """)
-    List<Highlight> findAllByAnswerIds(Collection<Long> answerIds);
+    List<Highlight> findAllByAnswerIdsOrderedAsc(Collection<Long> answerIds);
 }

--- a/backend/src/main/java/reviewme/highlight/repository/HighlightRepository.java
+++ b/backend/src/main/java/reviewme/highlight/repository/HighlightRepository.java
@@ -1,6 +1,7 @@
 package reviewme.highlight.repository;
 
 import java.util.Collection;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -14,4 +15,11 @@ public interface HighlightRepository extends JpaRepository<Highlight, Long> {
             WHERE h.answerId IN :answerIds
             """)
     void deleteAllByAnswerIds(Collection<Long> answerIds);
+
+    @Query("""
+            SELECT h
+            FROM Highlight h
+            WHERE h.answerId IN :answerIds
+            """)
+    List<Highlight> findAllByAnswerIds(Collection<Long> answerIds);
 }

--- a/backend/src/main/java/reviewme/review/service/ReviewGatheredLookupService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewGatheredLookupService.java
@@ -42,6 +42,7 @@ public class ReviewGatheredLookupService {
                 .stream()
                 .flatMap(List::stream)
                 .map(Answer::getId)
+                .distinct()
                 .toList();
         List<Highlight> highlights = highlightRepository.findAllByAnswerIdsOrderedAsc(answerIds);
 

--- a/backend/src/main/java/reviewme/review/service/ReviewGatheredLookupService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewGatheredLookupService.java
@@ -7,6 +7,8 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import reviewme.highlight.domain.Highlight;
+import reviewme.highlight.repository.HighlightRepository;
 import reviewme.question.domain.Question;
 import reviewme.question.repository.QuestionRepository;
 import reviewme.review.domain.Answer;
@@ -27,6 +29,7 @@ public class ReviewGatheredLookupService {
     private final QuestionRepository questionRepository;
     private final AnswerRepository answerRepository;
     private final SectionRepository sectionRepository;
+    private final HighlightRepository highlightRepository;
 
     private final ReviewGatherMapper reviewGatherMapper;
 
@@ -35,7 +38,14 @@ public class ReviewGatheredLookupService {
         Section section = getSectionOrThrow(sectionId, reviewGroup);
         Map<Question, List<Answer>> questionAnswers = getQuestionAnswers(section, reviewGroup);
 
-        return reviewGatherMapper.mapToReviewsGatheredBySection(questionAnswers);
+        List<Long> answerIds = questionAnswers.values()
+                .stream()
+                .flatMap(List::stream)
+                .map(Answer::getId)
+                .toList();
+        List<Highlight> highlights = highlightRepository.findAllByAnswerIds(answerIds);
+
+        return reviewGatherMapper.mapToReviewsGatheredBySection(questionAnswers, highlights);
     }
 
     private Section getSectionOrThrow(long sectionId, ReviewGroup reviewGroup) {

--- a/backend/src/main/java/reviewme/review/service/ReviewGatheredLookupService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewGatheredLookupService.java
@@ -43,7 +43,7 @@ public class ReviewGatheredLookupService {
                 .flatMap(List::stream)
                 .map(Answer::getId)
                 .toList();
-        List<Highlight> highlights = highlightRepository.findAllByAnswerIds(answerIds);
+        List<Highlight> highlights = highlightRepository.findAllByAnswerIdsOrderedAsc(answerIds);
 
         return reviewGatherMapper.mapToReviewsGatheredBySection(questionAnswers, highlights);
     }

--- a/backend/src/main/java/reviewme/review/service/dto/response/gathered/RangeResponse.java
+++ b/backend/src/main/java/reviewme/review/service/dto/response/gathered/RangeResponse.java
@@ -6,6 +6,7 @@ public record RangeResponse(
         long startIndex,
         long endIndex
 ) {
+
     public static RangeResponse from(HighlightRange range) {
         return new RangeResponse(range.getStartIndex(), range.getEndIndex());
     }

--- a/backend/src/main/java/reviewme/review/service/dto/response/gathered/RangeResponse.java
+++ b/backend/src/main/java/reviewme/review/service/dto/response/gathered/RangeResponse.java
@@ -1,7 +1,12 @@
 package reviewme.review.service.dto.response.gathered;
 
+import reviewme.highlight.domain.HighlightRange;
+
 public record RangeResponse(
         long startIndex,
         long endIndex
 ) {
+    public static RangeResponse from(HighlightRange range) {
+        return new RangeResponse(range.getStartIndex(), range.getEndIndex());
+    }
 }

--- a/backend/src/main/java/reviewme/review/service/mapper/ReviewGatherMapper.java
+++ b/backend/src/main/java/reviewme/review/service/mapper/ReviewGatherMapper.java
@@ -3,12 +3,10 @@ package reviewme.review.service.mapper;
 import jakarta.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import reviewme.highlight.domain.Highlight;
-import reviewme.highlight.repository.HighlightRepository;
 import reviewme.question.domain.OptionItem;
 import reviewme.question.domain.Question;
 import reviewme.question.repository.QuestionRepository;
@@ -69,12 +67,14 @@ public class ReviewGatherMapper {
 
     private List<HighlightResponse> mapToHighlightResponse(List<Highlight> highlights) {
         // Line index를 기준으로 묶되, 묶은 것들은 mapping 함수를 통해 List로 변환
-        Collector<Highlight, ?, Map<Integer, List<RangeResponse>>> highlightMapCollector = Collectors.groupingBy(
-                Highlight::getLineIndex,
-                Collectors.mapping(highlight -> RangeResponse.from(highlight.getHighlightRange()), Collectors.toList())
-        );
         Map<Integer, List<RangeResponse>> lineIndexRangeResponses = highlights.stream()
-                .collect(highlightMapCollector);
+                .collect(Collectors.groupingBy(
+                        Highlight::getLineIndex,
+                        Collectors.mapping(
+                                highlight -> RangeResponse.from(highlight.getHighlightRange()),
+                                Collectors.toList()
+                        )
+                ));
 
         return lineIndexRangeResponses.entrySet()
                 .stream()

--- a/backend/src/main/java/reviewme/review/service/mapper/ReviewGatherMapper.java
+++ b/backend/src/main/java/reviewme/review/service/mapper/ReviewGatherMapper.java
@@ -3,9 +3,12 @@ package reviewme.review.service.mapper;
 import jakarta.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import reviewme.highlight.domain.Highlight;
+import reviewme.highlight.repository.HighlightRepository;
 import reviewme.question.domain.OptionItem;
 import reviewme.question.domain.Question;
 import reviewme.question.repository.QuestionRepository;
@@ -13,6 +16,8 @@ import reviewme.review.domain.Answer;
 import reviewme.review.domain.CheckboxAnswer;
 import reviewme.review.domain.CheckboxAnswerSelectedOption;
 import reviewme.review.domain.TextAnswer;
+import reviewme.review.service.dto.response.gathered.HighlightResponse;
+import reviewme.review.service.dto.response.gathered.RangeResponse;
 import reviewme.review.service.dto.response.gathered.ReviewsGatheredByQuestionResponse;
 import reviewme.review.service.dto.response.gathered.ReviewsGatheredBySectionResponse;
 import reviewme.review.service.dto.response.gathered.SimpleQuestionResponse;
@@ -25,33 +30,56 @@ import reviewme.review.service.exception.GatheredAnswersTypeNonUniformException;
 public class ReviewGatherMapper {
 
     private final QuestionRepository questionRepository;
+    private final HighlightRepository highlightRepository;
 
-    public ReviewsGatheredBySectionResponse mapToReviewsGatheredBySection(Map<Question, List<Answer>> questionAnswers) {
+    public ReviewsGatheredBySectionResponse mapToReviewsGatheredBySection(Map<Question, List<Answer>> questionAnswers,
+                                                                          List<Highlight> highlights) {
         List<ReviewsGatheredByQuestionResponse> reviews = questionAnswers.entrySet()
                 .stream()
-                .map(entry -> mapToReviewsGatheredByQuestion(entry.getKey(), entry.getValue()))
+                .map(entry -> mapToReviewsGatheredByQuestion(entry.getKey(), entry.getValue(), highlights))
                 .toList();
 
         return new ReviewsGatheredBySectionResponse(reviews);
     }
 
-    private ReviewsGatheredByQuestionResponse mapToReviewsGatheredByQuestion(Question question, List<Answer> answers) {
+    private ReviewsGatheredByQuestionResponse mapToReviewsGatheredByQuestion(Question question, List<Answer> answers,
+                                                                             List<Highlight> highlights) {
         return new ReviewsGatheredByQuestionResponse(
                 new SimpleQuestionResponse(question.getId(), question.getContent(), question.getQuestionType()),
-                mapToTextResponse(question, answers),
+                mapToTextResponse(question, answers, highlights),
                 mapToVoteResponse(question, answers)
         );
     }
 
     @Nullable
-    private List<TextResponse> mapToTextResponse(Question question, List<Answer> answers) {
+    private List<TextResponse> mapToTextResponse(Question question, List<Answer> answers,
+                                                 List<Highlight> highlights) {
         if (question.isSelectable()) {
             return null;
         }
+        Map<Long, List<Highlight>> answerIdHighlights = highlights.stream()
+                .collect(Collectors.groupingBy(Highlight::getAnswerId));
 
         List<TextAnswer> textAnswers = castAllOrThrow(answers, TextAnswer.class);
         return textAnswers.stream()
-                .map(textAnswer -> new TextResponse(textAnswer.getId(), textAnswer.getContent(), List.of()))
+                .map(textAnswer -> new TextResponse(
+                        textAnswer.getId(), textAnswer.getContent(),
+                        mapToHighlightResponse(answerIdHighlights.getOrDefault(textAnswer.getId(), List.of())))
+                ).toList();
+    }
+
+    private List<HighlightResponse> mapToHighlightResponse(List<Highlight> highlights) {
+        // Line index를 기준으로 묶되, 묶은 것들은 mapping 함수를 통해 List로 변환
+        Collector<Highlight, ?, Map<Integer, List<RangeResponse>>> highlightMapCollector = Collectors.groupingBy(
+                Highlight::getLineIndex,
+                Collectors.mapping(highlight -> RangeResponse.from(highlight.getHighlightRange()), Collectors.toList())
+        );
+        Map<Integer, List<RangeResponse>> lineIndexRangeResponses = highlights.stream()
+                .collect(highlightMapCollector);
+
+        return lineIndexRangeResponses.entrySet()
+                .stream()
+                .map(entry -> new HighlightResponse(entry.getKey(), entry.getValue()))
                 .toList();
     }
 

--- a/backend/src/main/java/reviewme/review/service/mapper/ReviewGatherMapper.java
+++ b/backend/src/main/java/reviewme/review/service/mapper/ReviewGatherMapper.java
@@ -30,7 +30,6 @@ import reviewme.review.service.exception.GatheredAnswersTypeNonUniformException;
 public class ReviewGatherMapper {
 
     private final QuestionRepository questionRepository;
-    private final HighlightRepository highlightRepository;
 
     public ReviewsGatheredBySectionResponse mapToReviewsGatheredBySection(Map<Question, List<Answer>> questionAnswers,
                                                                           List<Highlight> highlights) {

--- a/backend/src/test/java/reviewme/highlight/repository/HighlightRepositoryTest.java
+++ b/backend/src/test/java/reviewme/highlight/repository/HighlightRepositoryTest.java
@@ -1,0 +1,47 @@
+package reviewme.highlight.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import reviewme.highlight.domain.Highlight;
+import reviewme.highlight.domain.HighlightRange;
+
+@DataJpaTest
+class HighlightRepositoryTest {
+
+    @Autowired
+    private HighlightRepository highlightRepository;
+
+    @Test
+    void 하이라이트를_줄번호_시작_인덱스_순서대로_정렬해서_가져온다() {
+        // given
+        highlightRepository.saveAll(
+                List.of(
+                        new Highlight(1L, 1, new HighlightRange(1, 2)),
+                        new Highlight(1L, 2, new HighlightRange(6, 7)),
+                        new Highlight(1L, 2, new HighlightRange(2, 3)),
+                        new Highlight(1L, 3, new HighlightRange(3, 4)),
+                        new Highlight(1L, 1, new HighlightRange(4, 5)),
+                        new Highlight(2L, 3, new HighlightRange(7, 8))
+                )
+        );
+        // 1: (1, 2), (4, 5) 2: (2, 3), (6, 7) 3: (3, 4) -> 1 4 2 6 3
+
+        // when
+        List<Highlight> actual = highlightRepository.findAllByAnswerIdsOrderedAsc(List.of(1L));
+
+        // then
+        assertAll(
+                () -> assertThat(actual).extracting(Highlight::getLineIndex)
+                        .containsExactly(1, 1, 2, 2, 3),
+                () -> assertThat(actual)
+                        .extracting(Highlight::getHighlightRange)
+                        .extracting(HighlightRange::getStartIndex)
+                        .containsExactly(1, 4, 2, 6, 3)
+        );
+    }
+}

--- a/backend/src/test/java/reviewme/review/service/mapper/ReviewGatherMapperTest.java
+++ b/backend/src/test/java/reviewme/review/service/mapper/ReviewGatherMapperTest.java
@@ -69,8 +69,10 @@ class ReviewGatherMapperTest {
 
         // when
         ReviewsGatheredBySectionResponse actual = reviewGatherMapper.mapToReviewsGatheredBySection(Map.of(
-                question1, List.of(textAnswer1, textAnswer2),
-                question2, List.of(checkboxAnswer)));
+                        question1, List.of(textAnswer1, textAnswer2),
+                        question2, List.of(checkboxAnswer)),
+                List.of()
+        );
 
         // then
         assertAll(
@@ -90,9 +92,13 @@ class ReviewGatherMapperTest {
         Question question2 = questionRepository.save(서술형_옵션_질문(2));
 
         // when
-        ReviewsGatheredBySectionResponse actual = reviewGatherMapper.mapToReviewsGatheredBySection(Map.of(
-                question1, List.of(),
-                question2, List.of()));
+        ReviewsGatheredBySectionResponse actual = reviewGatherMapper.mapToReviewsGatheredBySection(
+                Map.of(
+                        question1, List.of(),
+                        question2, List.of()
+                ),
+                List.of()
+        );
 
         // then
         assertAll(


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #875 

---

### 🚀 어떤 기능을 구현했나요 ?
- 리뷰 모아보기에서 하이라이트를 내려주도록 구현합니다.

### 🔥 어떻게 해결했나요 ?
- 기존 코드에 덧대었습니다. 구조를 만지고 싶지만.. 이건 지금 할 일은 아닌 듯하네요.
- 최대한 코드 수정을 안 했어요. 변경 사항이 눈에 확 들어왔으면 좋겠습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 이해하기 쉬운가요? 제 생각에는 ReviewLookupService가 다른 LookupService에게서 도메인을 받아 와서 조합하는 게 좋을까.. 계속 고민됩니다. 각각의 LookupService에서 Dto를 반환해도 되나.. 싶은 생각이 들기도 하고요.
- `Collector.groupingBy` 메서드가 참 야무집니다. 묶어서 매핑해주는 친군데 이번에 활용해 보았어요. 좀 길어진다 싶은 한 군데에 주석으로 표기해 두었습니다.