### PR TITLE
[BE] chore: 기존 환경변수를 유지하며 sh 실행하도록 변경

### DIFF
--- a/.github/workflows/zero-downtime-deploy-test-cd.yml
+++ b/.github/workflows/zero-downtime-deploy-test-cd.yml
@@ -77,6 +77,6 @@ jobs:
           PROFILE_VAR: "dev"
         run: |
           chmod +x ./deploy.sh
-          sudo ./deploy.sh
+          sudo -E ./deploy.sh
 
         working-directory: ${{ env.APPLICATION_DIRECTORY }}/app


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #885 

---

### 🚀 어떤 기능을 구현했나요 ?
- cd 파일에서 설정한 환경변수고 shell 스크립트로도 전달되게 했습니다.

### 🔥 어떻게 해결했나요 ?
- 일반적으로 cd 파일의 환경변수는 그 하위에서 run 하는 shell script 에도 반영이 됩니다.
- 하지만 우리가 `sudo` 로 스크립트를 실행하고 있어서 문제가 발생했습니다.
- sudo는 보안상의 이유로 대부분의 환경 변수를 제거하고 새로운 환경에서 명령을 실행합니다. 
- 따라서 `-E` 옵션을 사용해서 현재 사용자의 환경 변수를 그대로 유지한 채 명령을 실행하도록 바꿔주었습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
