### PR TITLE
[FE] feat: Checkbox, CheckboxItem 컴포넌트 접근성 개선

### DIFF
--- a/frontend/src/components/common/Checkbox/index.tsx
+++ b/frontend/src/components/common/Checkbox/index.tsx
@@ -31,7 +31,14 @@ const Checkbox = ({ id, isChecked, handleChange, isDisabled, $style, $isReadonly
           onChange={handleChange}
           {...rest}
         />
-        <img src={isChecked ? CheckedIcon : UncheckedIcon} alt="체크박스" />
+        <img
+          src={isChecked ? CheckedIcon : UncheckedIcon}
+          role="checkbox"
+          aria-checked={isChecked}
+          aria-readonly={$isReadonly}
+          alt=""
+        />
+        {$isReadonly && <span className="sr-only">{isChecked ? '선택됨' : '선택 안 됨'}</span>}
       </S.CheckboxLabel>
     </S.CheckboxContainer>
   );

--- a/frontend/src/components/common/Checkbox/index.tsx
+++ b/frontend/src/components/common/Checkbox/index.tsx
@@ -13,12 +13,22 @@ export interface CheckboxStyleProps {
 export interface CheckboxProps extends CheckboxStyleProps {
   id: string;
   isChecked: boolean;
+  isTabAccessible?: boolean;
   handleChange?: (event: ChangeEvent<HTMLInputElement>, label?: string) => void;
   name?: string;
   isDisabled?: boolean;
 }
 
-const Checkbox = ({ id, isChecked, handleChange, isDisabled, $style, $isReadonly = false, ...rest }: CheckboxProps) => {
+const Checkbox = ({
+  id,
+  isChecked,
+  handleChange,
+  isDisabled,
+  isTabAccessible = true,
+  $style,
+  $isReadonly = false,
+  ...rest
+}: CheckboxProps) => {
   return (
     <S.CheckboxContainer $style={$style} $isReadonly={$isReadonly}>
       <S.CheckboxLabel>
@@ -29,10 +39,12 @@ const Checkbox = ({ id, isChecked, handleChange, isDisabled, $style, $isReadonly
           disabled={isDisabled}
           type="checkbox"
           onChange={handleChange}
+          tabIndex={-1}
           {...rest}
         />
         <img
           src={isChecked ? CheckedIcon : UncheckedIcon}
+          tabIndex={$isReadonly || isDisabled || !isTabAccessible ? -1 : 0}
           role="checkbox"
           aria-checked={isChecked}
           aria-readonly={$isReadonly}

--- a/frontend/src/components/common/CheckboxItem/index.tsx
+++ b/frontend/src/components/common/CheckboxItem/index.tsx
@@ -26,8 +26,8 @@ const CheckboxItem = ({
         currentTarget: {
           id: id,
           checked: !isChecked,
-        },
-      } as unknown as ChangeEvent<HTMLInputElement>);
+        } as Partial<HTMLInputElement>, 
+      } as ChangeEvent<HTMLInputElement>); 
     }
   };
 

--- a/frontend/src/components/common/CheckboxItem/index.tsx
+++ b/frontend/src/components/common/CheckboxItem/index.tsx
@@ -1,3 +1,5 @@
+import { ChangeEvent } from 'react';
+
 import Checkbox, { CheckboxProps } from '../Checkbox';
 import UndraggableWrapper from '../UndraggableWrapper';
 
@@ -7,12 +9,31 @@ interface CheckboxItemProps extends CheckboxProps {
   label: string;
 }
 
-const CheckboxItem = ({ label, ...rest }: CheckboxItemProps) => {
+const CheckboxItem = ({
+  id,
+  label,
+  isChecked,
+  handleChange,
+  $isReadonly,
+  isTabAccessible = false,
+  ...rest
+}: CheckboxItemProps) => {
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' && handleChange) {
+      handleChange({
+        currentTarget: {
+          id: id,
+          checked: !isChecked,
+        },
+      } as unknown as ChangeEvent<HTMLInputElement>);
+    }
+  };
+
   return (
-    <S.CheckboxItem>
+    <S.CheckboxItem tabIndex={$isReadonly ? -1 : 0} onKeyDown={handleKeyDown}>
       <S.CheckboxLabel>
         <UndraggableWrapper>
-          <Checkbox {...rest} />
+          <Checkbox id={id} isChecked={isChecked} isTabAccessible={isTabAccessible} handleChange={handleChange} {...rest} />
         </UndraggableWrapper>
         {label}
       </S.CheckboxLabel>

--- a/frontend/src/components/common/CheckboxItem/index.tsx
+++ b/frontend/src/components/common/CheckboxItem/index.tsx
@@ -18,6 +18,8 @@ const CheckboxItem = ({
   isTabAccessible = false,
   ...rest
 }: CheckboxItemProps) => {
+  const isCheckedLabel = `${label}, ${isChecked ? '선택됨' : '선택 안 됨'}`;
+
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.key === 'Enter' && handleChange) {
       handleChange({
@@ -30,10 +32,16 @@ const CheckboxItem = ({
   };
 
   return (
-    <S.CheckboxItem tabIndex={$isReadonly ? -1 : 0} onKeyDown={handleKeyDown}>
+    <S.CheckboxItem tabIndex={$isReadonly ? -1 : 0} aria-label={isCheckedLabel} onKeyDown={handleKeyDown}>
       <S.CheckboxLabel>
         <UndraggableWrapper>
-          <Checkbox id={id} isChecked={isChecked} isTabAccessible={isTabAccessible} handleChange={handleChange} {...rest} />
+          <Checkbox
+            id={id}
+            isChecked={isChecked}
+            isTabAccessible={isTabAccessible}
+            handleChange={handleChange}
+            {...rest}
+          />
         </UndraggableWrapper>
         {label}
       </S.CheckboxLabel>

--- a/frontend/src/components/common/CheckboxItem/styles.ts
+++ b/frontend/src/components/common/CheckboxItem/styles.ts
@@ -3,6 +3,10 @@ import styled from '@emotion/styled';
 export const CheckboxItem = styled.div`
   display: flex;
   margin-bottom: 1rem;
+
+  :focus-visible {
+    outline: 0.3rem solid ${({ theme }) => theme.colors.primary};
+  }
 `;
 
 export const CheckboxLabel = styled.label`


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #870 

---

### 🚀 어떤 기능을 구현했나요 ?
- `Checkbox `및 `CheckboxItem`의 tab 접근성 강화
  - `CheckboxItem`을 사용하는 경우, Item 전체에만 포커스가 가고, Item이 사용하고 있는 `Checkbox`에 추가적인 포커스가 가지 않음
  - `Checkbox`만을 사용하는 경우 `Checkbox`에 포커싱 가능 
- 선택된 `Checkbox`인지를 읽어주는 기능 추가
  - 선택 여부는 해당 `Checkbox`가 readonly일 때도 읽음 

### 🔥 어떻게 해결했나요 ?
#### 탭 접근성 강화
- `CheckboxItem`을 사용할 때, `Checkbox`에만 포커스가 가는 것보다 `CheckboxItem` 자체가 포커싱되는 것이 더 직관적이라고 생각해서 `CheckboxItem`에 `tabIndex`를 줬습니다.
    - 이때 엔터를 누르면 선택되게 하는 로직에서, 체크 상태를 바꾸기 위해 인위적으로 만든  `ChangeEvent<HTMLInputElement>` 객체를 사용하고 있습니다. 더 좋은 의견 환영합니다…🙃
    - 다만 기본적으로 Tab 키를 이용한 접근은 사용자와 상호작용 가능한 요소에 오는 게 일반적이라 `$isReadOnly`가 true인 경우에는 `tabIndex`를 -1로 설정했습니다.

- `CheckboxItem`에 `tabIndex`를 주니 `CheckboxItem` 포커스 → 그 안의 `Checkbox`에 포커스가 가서 같은 요소를 2번 탐색하는 문제가 있었습니다.
    - `Checkbox`를 아예 tab으로 접근 불가능하게 만들면 단독으로 `Checkbox`를 쓸 때 tab을 이용할 수 없으므로, `isTabAccessible`이라는 속성을 통해 탭 접근 가능성을 제어합니다.
        - `Checkbox`에서의 기본값은 true이고, `CheckboxItem`에서는 중첩을 막기 위해 기본값이 false입니다.
- `focus`상태에서의 `outline`을 primary 색상으로 줬는데, 이대로 쓰려면 다른 요소들에게도 적용해야 하므로 품이 커진다면 해당 코드는 삭제하겠습니당

#### sr-only 사용
- `Checkbox`가 `readonly`일 때, 스타일에서 `pointer`를 `none`으로 설정해 상호작용 불가능함을 나타내고 있었습니다.
- `readonly` 상태에서도 `Checkbox`가 선택되어 있는 상태인지는 읽어 줘야 한다고 생각했는데, `pointer`가 `none`으로 되어 있으니 스크린 리더가 상호작용 불가능한 요소로 간주하고 읽어주지 않았습니다.
- `pointer:none`을 없애는 건 시각 사용자의 ux를 저하시킨다고 생각해, 기존에 추가되어 있는 `sr-only` 클래스를 사용해 스크린 리더 환경 + 읽기 전용이 적용된 상태에서만 선택 여부를 추가로 읽도록 만들었습니다.


### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 접근성이 괜찮은지, 선택 이벤트를 트리거하는 더 좋은 방법이 있는지 궁금해요

### 📚 참고 자료, 할 말
