### PR TITLE
[FE] fix: Toast가 나타난 후 클릭 및 드래그 불가 이슈 해결

### DIFF
--- a/frontend/src/components/common/Portal/index.tsx
+++ b/frontend/src/components/common/Portal/index.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom';
 
 import * as S from './styles';
 
-interface PortalProps {
+export interface PortalProps {
   id?: string;
   disableScroll?: boolean;
 }
@@ -25,7 +25,12 @@ const Portal: React.FC<PropsWithChildren<PortalProps>> = ({ children: Modal, id,
     };
   });
 
-  return createPortal(<S.Portal id={id || 'portal'}>{Modal}</S.Portal>, document.body);
+  return createPortal(
+    <S.Portal id={id || 'portal'} disableScroll={disableScroll}>
+      {Modal}
+    </S.Portal>,
+    document.body,
+  );
 };
 
 export default Portal;

--- a/frontend/src/components/common/Portal/styles.ts
+++ b/frontend/src/components/common/Portal/styles.ts
@@ -3,6 +3,8 @@ import styled from '@emotion/styled';
 import { PortalProps } from '.';
 
 export const Portal = styled.div<PortalProps>`
+  pointer-events: ${({ disableScroll }) => (disableScroll ? 'auto' : 'none')};
+
   position: fixed;
   z-index: ${({ theme }) => theme.zIndex.modal};
   top: 0;
@@ -12,6 +14,4 @@ export const Portal = styled.div<PortalProps>`
 
   width: 100%;
   height: 100%;
-
-  pointer-events: ${({ disableScroll }) => (disableScroll ? 'auto' : 'none')};
 `;

--- a/frontend/src/components/common/Portal/styles.ts
+++ b/frontend/src/components/common/Portal/styles.ts
@@ -1,6 +1,8 @@
 import styled from '@emotion/styled';
 
-export const Portal = styled.div`
+import { PortalProps } from '.';
+
+export const Portal = styled.div<PortalProps>`
   position: fixed;
   z-index: ${({ theme }) => theme.zIndex.modal};
   top: 0;
@@ -10,4 +12,6 @@ export const Portal = styled.div`
 
   width: 100%;
   height: 100%;
+
+  pointer-events: ${({ disableScroll }) => (disableScroll ? 'auto' : 'none')};
 `;

--- a/frontend/src/components/common/Toast/styles.ts
+++ b/frontend/src/components/common/Toast/styles.ts
@@ -82,7 +82,9 @@ const getToastPositionStyles = (position: ToastPositionType, duration: number) =
 
 export const ToastModalContainer = styled.div<ToastModalProps>`
   background-color: #626262;
+
   color: white;
+
   display: flex;
   justify-content: center;
   align-items: center;
@@ -91,7 +93,6 @@ export const ToastModalContainer = styled.div<ToastModalProps>`
   position: fixed;
 
   ${({ position, duration }) => getToastPositionStyles(position, duration)}
-
   left: 50%;
   transform: translateX(-50%);
 
@@ -101,7 +102,6 @@ export const ToastModalContainer = styled.div<ToastModalProps>`
 
   border-radius: ${({ theme }) => theme.borderRadius.basic};
   box-shadow: 0.4rem 0.4rem 0.8rem rgba(0, 0, 0, 0.2);
-
   border: none;
 
   ${media.xxSmall} {

--- a/frontend/src/components/common/Toast/styles.ts
+++ b/frontend/src/components/common/Toast/styles.ts
@@ -88,8 +88,6 @@ export const ToastModalContainer = styled.div<ToastModalProps>`
   align-items: center;
   gap: 0.8rem;
 
-  z-index: ${({ theme }) => theme.zIndex.modal};
-
   position: fixed;
 
   ${({ position, duration }) => getToastPositionStyles(position, duration)}

--- a/frontend/src/components/highlight/components/HighlightEditor/hooks/useHighlight.ts
+++ b/frontend/src/components/highlight/components/HighlightEditor/hooks/useHighlight.ts
@@ -248,7 +248,11 @@ const useHighlight = ({
 
     if (!newEditorAnswerMap) return;
 
-    mutateHighlight(newEditorAnswerMap);
+    mutateHighlight(newEditorAnswerMap, {
+      onError: () => {
+        handleModalMessage(HIGHLIGHT_ERROR_MESSAGES.deleteFailure);
+      },
+    });
   };
 
   const removeSingleAnswerHighlight = (selectionInfo: SelectionInfo) => {

--- a/frontend/src/pages/ReviewCollectionPage/components/DoughnutChart/styles.ts
+++ b/frontend/src/pages/ReviewCollectionPage/components/DoughnutChart/styles.ts
@@ -4,10 +4,9 @@ import media from '@/utils/media';
 
 export const DoughnutChartContainer = styled.div`
   display: flex;
-  justify-content: center;
-  align-items: center;
-
   gap: 5rem;
+  align-items: center;
+  justify-content: center;
 
   ${media.small} {
     flex-direction: column;

--- a/frontend/src/pages/ReviewCollectionPage/components/DoughnutChartDetails/styles.ts
+++ b/frontend/src/pages/ReviewCollectionPage/components/DoughnutChartDetails/styles.ts
@@ -5,9 +5,7 @@ import media from '@/utils/media';
 export const DoughnutChartDetailList = styled.div`
   display: flex;
   flex-direction: column;
-
   gap: 2rem;
-
   margin: 2rem;
 
   ${media.small} {
@@ -17,27 +15,25 @@ export const DoughnutChartDetailList = styled.div`
 
 export const DetailItem = styled.div`
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-
   gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
 `;
 
 export const ContentContainer = styled.div`
   display: flex;
-  align-items: center;
-
   gap: 1rem;
+  align-items: center;
 `;
 
 export const ChartColor = styled.div<{ color: string }>`
-  background-color: ${({ color }) => color};
+  flex-shrink: 0;
 
   width: 2rem;
   height: 2rem;
 
+  background-color: ${({ color }) => color};
   border-radius: 0.5rem;
-  flex-shrink: 0;
 
   ${media.small} {
     width: 1.6rem;


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #903

---

### 🚀 어떤 기능을 구현했나요 ?

형광펜 api 요청이 실패하면 Toast가 나타나야 하며, 이때 형광펜 작업을 계속 진행할 수 있어야 합니다. 그러나 클릭이 전혀 불가능한 문제가 발생했습니다. 이를 해결하기 위해 클릭 이벤트가 정상적으로 작동하도록 수정하였습니다.

### 🚨 문제상황 🚨

https://github.com/user-attachments/assets/25a140d6-78aa-4dca-9488-101bd8d450e1



### 🔥 어떻게 해결했나요 ?

#### 해결방안
1안 - Portal을 사용하지 않고 toast는 따로 createPortal로 감싸서 분리.
2안 - Portal css 속성에 `pointer-events: none;`을 추가하여 모달과 토스트에 따라 클릭 이벤트를 조정 가능하도록 수정.

사실 첫 번째 방법으로 진행하고 싶었으나, Portal을 모달과 토스트에서 공통으로 사용하는 방향으로 의견이 모아졌습니다. 그래서 일단, 두 번째 방법으로 선택했습니다. disableScroll 값에 따라 pointer-events 속성을 다르게 설정하여 클릭 이벤트를 실행하거나 차단하는 방식으로 구현했습니다.

```css
export const Portal = styled.div<PortalProps>`
  pointer-events: ${({ disableScroll }) => (disableScroll ? 'auto' : 'none')};

  position: fixed;
  z-index: ${({ theme }) => theme.zIndex.modal};
  top: 0;
  left: 0;

  // ....
`;
```

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
