### PR TITLE
[FE] fix: textarea가 없는 리뷰 작성 카드에서 tab키로 다른 리뷰 섹션에 접근할 수 있는 문제 수정

### DIFF
--- a/frontend/src/components/common/CheckboxItem/index.tsx
+++ b/frontend/src/components/common/CheckboxItem/index.tsx
@@ -26,13 +26,18 @@ const CheckboxItem = ({
         currentTarget: {
           id: id,
           checked: !isChecked,
-        } as Partial<HTMLInputElement>, 
-      } as ChangeEvent<HTMLInputElement>); 
+        } as Partial<HTMLInputElement>,
+      } as ChangeEvent<HTMLInputElement>);
     }
   };
 
   return (
-    <S.CheckboxItem tabIndex={$isReadonly ? -1 : 0} aria-label={isCheckedLabel} onKeyDown={handleKeyDown}>
+    <S.CheckboxItem
+      className="checkbox-item"
+      tabIndex={$isReadonly ? -1 : 0}
+      aria-label={isCheckedLabel}
+      onKeyDown={handleKeyDown}
+    >
       <S.CheckboxLabel>
         <UndraggableWrapper>
           <Checkbox

--- a/frontend/src/pages/ReviewWritingPage/slider/hooks/ally/useTabNavigationOnValidity.ts
+++ b/frontend/src/pages/ReviewWritingPage/slider/hooks/ally/useTabNavigationOnValidity.ts
@@ -23,13 +23,18 @@ const useTabNavigationOnValidity = ({ cardId }: UseTabNavigationOnValidityProps)
   const handleTabKeydown = (event: KeyboardEvent) => {
     if (event.code !== 'Tab') return;
     const currentCardElement = findCurrentCardElement();
-    const lastTabCandidateList = currentCardElement?.querySelectorAll('input, textarea, button:not([disabled])');
+
+    // 리뷰 작성 카드에서, tab으로 접근 가능한 요소들은
+    // 활성화된 버튼(이동 버튼, 프로그레스 바 버튼), CheckboxItem, textarea
+    const lastTabCandidateList = currentCardElement?.querySelectorAll(
+      'textarea, .checkbox-item, button:not([disabled])',
+    );
     if (!lastTabCandidateList || lastTabCandidateList.length === 0) return;
 
     const lastTabElementInCard = lastTabCandidateList[lastTabCandidateList.length - 1];
     if (document.activeElement !== lastTabElementInCard) return;
 
-    //카드 속에서 마지막 탭 요소에 focus되어있고, tab키 누를 경우
+    // 리뷰 작성 카드에서 tab 가능한 마지막 요소에 focus가 있을 때 tab키를 누를 경우
     event.preventDefault();
     (document.querySelector('footer a') as HTMLElement | null)?.focus();
   };


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #913 

---

### 🚀 어떤 기능을 구현했나요 ?
- tab키를 이용해 다른 리뷰 섹션에 접근할 수 있었던 문제를 해결했습니다.

### 🔥 어떻게 해결했나요 ?
- 기존 로직에서, tab으로 접근 가능한 요소들을 가져와서 마지막 요소에 도달했는지를 체크했었는데 가져오는 요소 중 input이 있었습니다.
- 그런데 리뷰 작성 페이지에서는 CheckboxItem만 사용하고 있고, CheckboxItem을 사용하는 경우 해당 Item이 사용하는 input에 포커스가 가지 않습니다.
- 따라서 가져오는 요소에서 input을 제거하고 CheckboxItem의 className을 추가했습니다.

- 버그가 발생했던 이유
  - input에 포커스가 갈 수 없음에도, textarea가 없는 섹션에서는 포커스할 수 있는 요소들의 마지막 요소로 항상 input이 선택돼서 다음 섹션 대신 footer로 포커스가 가게 하는 로직이 실행되지 않았습니다.
  - 제가 checkbox 접근성을 작업할 때 사용성을 위해 checkboxItem을 사용하는 경우 input에 추가로 포커스가 가지 않게 만들었는데, 훅 작업은 input을 기준으로 만들어져서 살짝 충돌이 있었읍니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 리뷰미 화이팅!!!!!!!

### 📚 참고 자료, 할 말
