### PR TITLE
[FE] feat: URL 모달이 떠있는 동안 뒤로가기, 새로고침 방지

### DIFF
--- a/frontend/src/pages/HomePage/components/ReviewZoneURLModal/index.tsx
+++ b/frontend/src/pages/HomePage/components/ReviewZoneURLModal/index.tsx
@@ -37,7 +37,6 @@ const ReviewZoneURLModal = ({ reviewZoneURL, closeModal }: ReviewZoneURLModalPro
 
   useEffect(() => {
     window.addEventListener('beforeunload', handleBeforeUnload); // 새로고침 방지
-    window.history.pushState(null, '', window.location.href); // 뒤로가기 방지 설정
     window.addEventListener('popstate', handlePopState); // 뒤로가기 이벤트(history change) 감지
 
     return () => {

--- a/frontend/src/pages/HomePage/components/ReviewZoneURLModal/index.tsx
+++ b/frontend/src/pages/HomePage/components/ReviewZoneURLModal/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { AlertModal } from '@/components';
 import Checkbox from '@/components/common/Checkbox';
@@ -21,6 +21,30 @@ const ReviewZoneURLModal = ({ reviewZoneURL, closeModal }: ReviewZoneURLModalPro
   const handleCloseButtonClick = () => {
     if (isChecked) closeModal();
   };
+
+  const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+    event.preventDefault();
+  };
+
+  const handlePopState = () => {
+    if (window.confirm('링크가 사라질 수 있어요. 계속하시겠어요?')) {
+      closeModal();
+    } else {
+      // 히스토리를 다시 추가해 뒤로가기 취소
+      window.history.pushState(null, '', window.location.href);
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener('beforeunload', handleBeforeUnload); // 새로고침 방지
+    window.history.pushState(null, '', window.location.href); // 뒤로가기 방지 설정
+    window.addEventListener('popstate', handlePopState); // 뒤로가기 이벤트(history change) 감지
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, []);
 
   return (
     <AlertModal


### PR DESCRIPTION
- resolves #911 

---

### 🚀 어떤 기능을 구현했나요 ?
- 홈페이지에서 리뷰 URL 생성 모달이 열려있을 때 뒤로가기 및 새로고침 시 confirm을 띄웁니다. URL 복사를 안 해뒀는데 뒤로 가거나 새로고침해서 사라진다면 슬프겠죠?

### 🔥 어떻게 해결했나요 ?
- beforeunload 이벤트를 감지해서 페이지를 나갈 때나 새로고침할 때 confirm을 띄웁니다.
- window.history를 사용하고 popstate 이벤트를 감지해서 뒤로가기할 때 confirm을 띄웁니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
