### PR TITLE
[FE] fix : 질문 섹션 변경 시, 변경된 형광펜 상태 적용되지 않는 오류 수정 및 리뷰 모아보기 목  핸들러,목 데이터 변경

### DIFF
--- a/frontend/src/apis/endpoints.ts
+++ b/frontend/src/apis/endpoints.ts
@@ -48,10 +48,17 @@ export const REVIEW_GROUP_DATA_API_PARAMS = {
   },
 };
 
+export const REVIEW_GROUP_API_PARAMS = {
+  queryString: {
+    sectionId: 'sectionId',
+  },
+};
+
 export const REVIEW_WRITING_API_URL = `${serverUrl}/${VERSION2}/${REVIEW_WRITING_API_PARAMS.resource}`;
 export const REVIEW_LIST_API_URL = `${serverUrl}/${VERSION2}/${REVIEW_LIST_API_PARAMS.resource}`;
 export const DETAILED_REVIEW_API_URL = `${serverUrl}/${VERSION2}/${DETAILED_REVIEW_API_PARAMS.resource}`;
 export const REVIEW_GROUP_DATA_API_URL = `${serverUrl}/${VERSION2}/${REVIEW_GROUP_DATA_API_PARAMS.resource}`;
+export const REVIEW_GROUP_API_URL = `${serverUrl}/${VERSION2}/reviews/gather`;
 
 const endPoint = {
   postingReview: `${serverUrl}/${VERSION2}/reviews`,
@@ -70,7 +77,8 @@ const endPoint = {
   gettingReviewGroupData: (reviewRequestCode: string) =>
     `${REVIEW_GROUP_DATA_API_URL}?${REVIEW_GROUP_DATA_API_PARAMS.queryString.reviewRequestCode}=${reviewRequestCode}`,
   gettingSectionList: `${serverUrl}/${VERSION2}/sections`,
-  gettingGroupedReviews: (sectionId: number) => `${serverUrl}/${VERSION2}/reviews/gather?sectionId=${sectionId}`,
+  gettingGroupedReviews: (sectionId: number) =>
+    `${REVIEW_GROUP_API_URL}?${REVIEW_GROUP_API_PARAMS.queryString.sectionId}=${sectionId}`,
   postingHighlight: `${serverUrl}/${VERSION2}/highlight`,
 };
 

--- a/frontend/src/components/highlight/components/HighlightEditor/hooks/useHighlight.ts
+++ b/frontend/src/components/highlight/components/HighlightEditor/hooks/useHighlight.ts
@@ -1,6 +1,11 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
-import { EDITOR_ANSWER_CLASS_NAME, HIGHLIGHT_EVENT_NAME, HIGHLIGHT_SPAN_CLASS_NAME } from '@/constants';
+import {
+  EDITOR_ANSWER_CLASS_NAME,
+  HIGHLIGHT_EVENT_NAME,
+  HIGHLIGHT_SPAN_CLASS_NAME,
+  SESSION_STORAGE_KEY,
+} from '@/constants';
 import { EditorAnswerMap, EditorLine, HighlightResponseData, ReviewAnswerResponseData } from '@/types';
 import {
   getEndLineOffset,
@@ -71,13 +76,25 @@ const useHighlight = ({
   handleModalMessage,
 }: UseHighlightProps) => {
   const [editorAnswerMap, setEditorAnswerMap] = useState<EditorAnswerMap>(makeInitialEditorAnswerMap(answerList));
+  const storageKey = `${SESSION_STORAGE_KEY.editorAnswerMap}-${questionId}`;
+
+  useEffect(() => {
+    const item = localStorage.getItem(storageKey);
+    if (item) {
+      setEditorAnswerMap(new Map(JSON.parse(item)) as EditorAnswerMap);
+    }
+  }, []);
 
   // span 클릭 시, 제공되는 형광펜 삭제 기능 타겟
   const [longPressRemovalTarget, setLongPressRemovalTarget] = useState<RemovalTarget | null>(null);
 
   const resetLongPressRemovalTarget = () => setLongPressRemovalTarget(null);
 
-  const updateEditorAnswerMap = (newEditorAnswerMap: EditorAnswerMap) => setEditorAnswerMap(newEditorAnswerMap);
+  const updateEditorAnswerMap = (newEditorAnswerMap: EditorAnswerMap) => {
+    setEditorAnswerMap(newEditorAnswerMap);
+    // editorAnswerMap이 변경될 때 새로운 값을 로컬 스토리지에 저장
+    localStorage.setItem(storageKey, JSON.stringify(Array.from(newEditorAnswerMap)));
+  };
 
   const resetHighlightMenu = () => {
     removeSelection();

--- a/frontend/src/components/highlight/components/HighlightEditorContainer/index.tsx
+++ b/frontend/src/components/highlight/components/HighlightEditorContainer/index.tsx
@@ -8,7 +8,9 @@ import { ErrorBoundary } from '../../../error';
 import ErrorFallback from '../../../error/ErrorFallback';
 import HighlightEditor, { HighlightEditorProps } from '../HighlightEditor';
 
-const HighlightEditorContainer = (props: Omit<HighlightEditorProps, 'handleErrorModal'>) => {
+interface HighlightEditorContainerProps extends Omit<HighlightEditorProps, 'handleErrorModal' | 'handleModalMessage'> {}
+
+const HighlightEditorContainer = (props: HighlightEditorContainerProps) => {
   const [isOpenErrorModal, setIsOpenErrorModal] = useState(false);
   const [modalMessage, setModalMessage] = useState('');
 

--- a/frontend/src/constants/storageKey.ts
+++ b/frontend/src/constants/storageKey.ts
@@ -2,3 +2,7 @@ export const LOCAL_STORAGE_KEY = {
   isHighlightEditable: 'isHighlightEditable',
   isHighlightError: 'isHighlightError',
 };
+
+export const SESSION_STORAGE_KEY = {
+  editorAnswerMap: 'editorAnswerMap-question',
+};

--- a/frontend/src/mocks/handlers/review.ts
+++ b/frontend/src/mocks/handlers/review.ts
@@ -3,6 +3,8 @@ import { http, HttpResponse } from 'msw';
 import endPoint, {
   DETAILED_REVIEW_API_PARAMS,
   DETAILED_REVIEW_API_URL,
+  REVIEW_GROUP_API_PARAMS,
+  REVIEW_GROUP_API_URL,
   REVIEW_WRITING_API_PARAMS,
   REVIEW_WRITING_API_URL,
   VERSION2,
@@ -104,17 +106,23 @@ const getSectionList = () =>
     return authorizeWithCookie(cookies, () => HttpResponse.json(GROUPED_SECTION_MOCK_DATA));
   });
 
-const getGroupedReviews = (sectionId: number) =>
-  http.get(endPoint.gettingGroupedReviews(sectionId), ({ cookies }) => {
-    return authorizeWithCookie(cookies, () => HttpResponse.json(GROUPED_REVIEWS_MOCK_DATA));
+const getGroupedReviews = () => {
+  return http.get(new RegExp(`^${REVIEW_GROUP_API_URL}`), ({ request, cookies }) => {
+    const url = new URL(request.url);
+    const sectionId = url.searchParams.get(REVIEW_GROUP_API_PARAMS.queryString.sectionId);
+    const { length } = GROUPED_REVIEWS_MOCK_DATA;
+    const index = (Number(sectionId) + length) % length;
+
+    return authorizeWithCookie(cookies, () => HttpResponse.json(GROUPED_REVIEWS_MOCK_DATA[index]));
   });
+};
 
 const reviewHandler = [
   getDetailedReview(),
   getReviewList(null, 10),
   getDataToWriteReview(),
   getSectionList(),
-  getGroupedReviews(1),
+  getGroupedReviews(),
   getReviewInfoData(),
   postReview(),
 ];

--- a/frontend/src/mocks/mockData/reviewCollection.ts
+++ b/frontend/src/mocks/mockData/reviewCollection.ts
@@ -13,69 +13,203 @@ export const GROUPED_SECTION_MOCK_DATA: GroupedSection = {
   ],
 };
 
-export const GROUPED_REVIEWS_MOCK_DATA: GroupedReviews = {
-  reviews: [
-    {
-      question: {
-        id: 1,
-        name: '커뮤니케이션, 협업 능력에서 어떤 부분이 인상 깊었는지 선택해주세요',
-        type: 'CHECKBOX',
-      },
-      answers: null,
-      votes: [
-        { content: '반대 의견을 내더라도 듣는 사람이 기분 나쁘지 않게 이야기해요', count: 13 },
-        { content: '팀원들의 의견을 잘 모아서 회의가 매끄럽게 진행되도록 해요', count: 0 },
-        { content: '팀의 분위기를 주도해요', count: 5 },
-        { content: '주장을 이야기할 때에는 합당한 근거가 뒤따라요', count: 3 },
-        { content: '팀에게 필요한 것과 그렇지 않은 것을 잘 구분해요', count: 0 },
-        { content: '팀 내 주어진 요구사항에 우선순위를 잘 매겨요', count: 1 },
-        { content: '서로 다른 분야간의 소통도 중요하게 생각해요', count: 1 },
-      ],
-    },
-    {
-      question: {
-        id: 2,
-        name: '위에서 선택한 사항에 대해 조금 더 자세히 설명해주세요',
-        type: 'TEXT',
-      },
-      answers: [
-        {
+export const GROUPED_REVIEWS_MOCK_DATA: GroupedReviews[] = [
+  {
+    reviews: [
+      {
+        question: {
           id: 1,
-          content:
-            '장의 시작부분은 짧고 직접적이며, 뒤따라 나올 복잡한 정보를 어떻게 해석해야 할 것인지 프레임을 짜주는 역할을 해야 한다. 그러면 아무리 긴 문장이라도 쉽게 읽힌다.\n\n프레임을 짜주는 역할을 해야 한다.\n    \n그러면 아무리 긴 문장이라도 쉽게 읽힌다.\n프레임을 짜주는 역할을 해야 한다. 그러면 아무리 긴 문장이라도 쉽게 읽힌다.',
-          highlights: [{ lineIndex: 0, ranges: [{ startIndex: 0, endIndex: 0 }] }],
+          name: '커뮤니케이션, 협업 능력에서 어떤 부분이 인상 깊었는지 선택해주세요',
+          type: 'CHECKBOX',
         },
-        {
+        answers: null,
+        votes: [
+          { content: '반대 의견을 내더라도 듣는 사람이 기분 나쁘지 않게 이야기해요', count: 13 },
+          { content: '팀원들의 의견을 잘 모아서 회의가 매끄럽게 진행되도록 해요', count: 0 },
+          { content: '팀의 분위기를 주도해요', count: 5 },
+          { content: '주장을 이야기할 때에는 합당한 근거가 뒤따라요', count: 3 },
+          { content: '팀에게 필요한 것과 그렇지 않은 것을 잘 구분해요', count: 0 },
+          { content: '팀 내 주어진 요구사항에 우선순위를 잘 매겨요', count: 1 },
+          { content: '서로 다른 분야간의 소통도 중요하게 생각해요', count: 1 },
+        ],
+      },
+      {
+        question: {
           id: 2,
-          content:
-            'http://localhost:3000/user/review-zone/5WkYQLqW1http://localhost:3000/user/review-zone/5WkYQLqW2http://localhost:3000/user/review-zone/5WkYQLqW3http://localhost:3000/user/review-zone/5WkYQLqW4http://localhost:3000/user/review-zone/5WkYQLqW5http://localhost:3000/user/review-zone/5WkYQLqW6http://localhost:3000/user/review-zone/5WkYQLqW7http://localhost:3000/user/review-zone/5WkYQLqW8http://localhost:3000/user/review-zone/5WkYQLqW9http://localhost:3000/user/review-zone/5WkYQLqW10',
-          highlights: [
-            {
-              lineIndex: 0,
-              ranges: [
-                { startIndex: 17, endIndex: 20 },
-                { startIndex: 64, endIndex: 67 },
-                { startIndex: 205, endIndex: 208 },
-                { startIndex: 252, endIndex: 255 },
-                { startIndex: 346, endIndex: 349 },
-              ],
-            },
-          ],
+          name: '위에서 선택한 사항에 대해 조금 더 자세히 설명해주세요',
+          type: 'TEXT',
         },
-        {
+        answers: [
+          {
+            id: 1,
+            content:
+              '커뮤니은 짧고 직접적이며, 뒤따라 나올 복잡한 정보를 어떻게 해석해야 할 것인지 프레임을 짜주는 역할을 해야 한다. 그러면 아무리 긴 문장이라도 쉽게 읽힌다.\n\n프레임을 짜주는 역할을 해야 한다.\n    \n그러면 아무리 긴 문장이라도 쉽게 읽힌다.\n프레임을 짜주는 역할을 해야 한다. 그러면 아무리 긴 문장이라도 쉽게 읽힌다.',
+            highlights: [{ lineIndex: 0, ranges: [{ startIndex: 0, endIndex: 0 }] }],
+          },
+          {
+            id: 2,
+            content:
+              'http://localhost:3000/user/review-zone/5WkYQLqW1http://localhost:3000/user/review-zone/5WkYQLqW2http://localhost:3000/user/review-zone/5WkYQLqW3http://localhost:3000/user/review-zone/5WkYQLqW4http://localhost:3000/user/review-zone/5WkYQLqW5http://localhost:3000/user/review-zone/5WkYQLqW6http://localhost:3000/user/review-zone/5WkYQLqW7http://localhost:3000/user/review-zone/5WkYQLqW8http://localhost:3000/user/review-zone/5WkYQLqW9http://localhost:3000/user/review-zone/5WkYQLqW10',
+            highlights: [
+              {
+                lineIndex: 0,
+                ranges: [
+                  { startIndex: 17, endIndex: 20 },
+                  { startIndex: 64, endIndex: 67 },
+                  { startIndex: 205, endIndex: 208 },
+                  { startIndex: 252, endIndex: 255 },
+                  { startIndex: 346, endIndex: 349 },
+                ],
+              },
+            ],
+          },
+          {
+            id: 3,
+            content:
+              '장의 시작부분은 짧고 직접적이며, 뒤따라 나올 복잡한 정보를 어떻게 해석해야 할 것인지 프레임을 짜주는 역할을 해야 한다. 그러면 아무리 긴 문장이라도 쉽게 읽힌다.',
+            highlights: [],
+          },
+          {
+            id: 4,
+            content:
+              '고액공제건강보험과 건강저축계좌를 만들어 노동자와 고용주가 세금공제를 받을 수 있도록 하면 결과적으로 노동자의 의료보험 부담이 커진다. 세금공제를 받을 수 있도록 하면------------------------------------------- 결과적으로 노동자의 의료보험 부담이 커진다.',
+            highlights: [],
+          },
+        ],
+        votes: null,
+      },
+    ],
+  },
+  {
+    reviews: [
+      {
+        question: {
           id: 3,
-          content:
-            '장의 시작부분은 짧고 직접적이며, 뒤따라 나올 복잡한 정보를 어떻게 해석해야 할 것인지 프레임을 짜주는 역할을 해야 한다. 그러면 아무리 긴 문장이라도 쉽게 읽힌다.',
-          highlights: [],
+          name: '문제 능력에서 어떤 부분이 인상 깊었는지 선택해주세요',
+          type: 'CHECKBOX',
         },
-        {
+        answers: null,
+        votes: [
+          { content: '반대 의견을 내더라도 듣는 사람이 기분 나쁘지 않게 이야기해요', count: 13 },
+          { content: '팀원들의 의견을 잘 모아서 회의가 매끄럽게 진행되도록 해요', count: 0 },
+          { content: '팀의 분위기를 주도해요', count: 5 },
+          { content: '주장을 이야기할 때에는 합당한 근거가 뒤따라요', count: 3 },
+          { content: '팀에게 필요한 것과 그렇지 않은 것을 잘 구분해요', count: 0 },
+          { content: '팀 내 주어진 요구사항에 우선순위를 잘 매겨요', count: 1 },
+          { content: '서로 다른 분야간의 소통도 중요하게 생각해요', count: 1 },
+        ],
+      },
+      {
+        question: {
           id: 4,
-          content:
-            '고액공제건강보험과 건강저축계좌를 만들어 노동자와 고용주가 세금공제를 받을 수 있도록 하면 결과적으로 노동자의 의료보험 부담이 커진다. 세금공제를 받을 수 있도록 하면------------------------------------------- 결과적으로 노동자의 의료보험 부담이 커진다.',
-          highlights: [],
+          name: '위에서 선택한 사항에 대해 조금 더 자세히 설명해주세요',
+          type: 'TEXT',
         },
-      ],
-      votes: null,
-    },
-  ],
-};
+        answers: [
+          {
+            id: 1,
+            content:
+              '문제 능력 장의 시작부분은 짧고 직접적이며, 뒤따라 나올 복잡한 정보를 어떻게 해석해야 할 것인지 프레임을 짜주는 역할을 해야 한다. 그러면 아무리 긴 문장이라도 쉽게 읽힌다.\n\n프레임을 짜주는 역할을 해야 한다.\n    \n그러면 아무리 긴 문장이라도 쉽게 읽힌다.\n프레임을 짜주는 역할을 해야 한다. 그러면 아무리 긴 문장이라도 쉽게 읽힌다.',
+            highlights: [{ lineIndex: 0, ranges: [{ startIndex: 0, endIndex: 0 }] }],
+          },
+          {
+            id: 2,
+            content:
+              'http://localhost:3000/user/review-zone/5WkYQLqW1http://localhost:3000/user/review-zone/5WkYQLqW2http://localhost:3000/user/review-zone/5WkYQLqW3http://localhost:3000/user/review-zone/5WkYQLqW4http://localhost:3000/user/review-zone/5WkYQLqW5http://localhost:3000/user/review-zone/5WkYQLqW6http://localhost:3000/user/review-zone/5WkYQLqW7http://localhost:3000/user/review-zone/5WkYQLqW8http://localhost:3000/user/review-zone/5WkYQLqW9http://localhost:3000/user/review-zone/5WkYQLqW10',
+            highlights: [
+              {
+                lineIndex: 0,
+                ranges: [
+                  { startIndex: 17, endIndex: 20 },
+                  { startIndex: 64, endIndex: 67 },
+                  { startIndex: 205, endIndex: 208 },
+                  { startIndex: 252, endIndex: 255 },
+                  { startIndex: 346, endIndex: 349 },
+                ],
+              },
+            ],
+          },
+          {
+            id: 3,
+            content:
+              '장의 시작부분은 짧고 직접적이며, 뒤따라 나올 복잡한 정보를 어떻게 해석해야 할 것인지 프레임을 짜주는 역할을 해야 한다. 그러면 아무리 긴 문장이라도 쉽게 읽힌다.',
+            highlights: [],
+          },
+          {
+            id: 4,
+            content:
+              '고액공제건강보험과 건강저축계좌를 만들어 노동자와 고용주가 세금공제를 받을 수 있도록 하면 결과적으로 노동자의 의료보험 부담이 커진다. 세금공제를 받을 수 있도록 하면------------------------------------------- 결과적으로 노동자의 의료보험 부담이 커진다.',
+            highlights: [],
+          },
+        ],
+        votes: null,
+      },
+    ],
+  },
+  {
+    reviews: [
+      {
+        question: {
+          id: 5,
+          name: '시간 능력에서 어떤 부분이 인상 깊었는지 선택해주세요',
+          type: 'CHECKBOX',
+        },
+        answers: null,
+        votes: [
+          { content: '반대 의견을 내더라도 듣는 사람이 기분 나쁘지 않게 이야기해요', count: 13 },
+          { content: '팀원들의 의견을 잘 모아서 회의가 매끄럽게 진행되도록 해요', count: 0 },
+          { content: '팀의 분위기를 주도해요', count: 5 },
+          { content: '주장을 이야기할 때에는 합당한 근거가 뒤따라요', count: 3 },
+          { content: '팀에게 필요한 것과 그렇지 않은 것을 잘 구분해요', count: 0 },
+          { content: '팀 내 주어진 요구사항에 우선순위를 잘 매겨요', count: 1 },
+          { content: '서로 다른 분야간의 소통도 중요하게 생각해요', count: 1 },
+        ],
+      },
+      {
+        question: {
+          id: 6,
+          name: '위에서 선택한 사항에 대해 조금 더 자세히 설명해주세요',
+          type: 'TEXT',
+        },
+        answers: [
+          {
+            id: 1,
+            content:
+              '시간 능력 장의 시작부분은 짧고 직접적이며, 뒤따라 나올 복잡한 정보를 어떻게 해석해야 할 것인지 프레임을 짜주는 역할을 해야 한다. 그러면 아무리 긴 문장이라도 쉽게 읽힌다.\n\n프레임을 짜주는 역할을 해야 한다.\n    \n그러면 아무리 긴 문장이라도 쉽게 읽힌다.\n프레임을 짜주는 역할을 해야 한다. 그러면 아무리 긴 문장이라도 쉽게 읽힌다.',
+            highlights: [{ lineIndex: 0, ranges: [{ startIndex: 0, endIndex: 0 }] }],
+          },
+          {
+            id: 2,
+            content:
+              'http://localhost:3000/user/review-zone/5WkYQLqW1http://localhost:3000/user/review-zone/5WkYQLqW2http://localhost:3000/user/review-zone/5WkYQLqW3http://localhost:3000/user/review-zone/5WkYQLqW4http://localhost:3000/user/review-zone/5WkYQLqW5http://localhost:3000/user/review-zone/5WkYQLqW6http://localhost:3000/user/review-zone/5WkYQLqW7http://localhost:3000/user/review-zone/5WkYQLqW8http://localhost:3000/user/review-zone/5WkYQLqW9http://localhost:3000/user/review-zone/5WkYQLqW10',
+            highlights: [
+              {
+                lineIndex: 0,
+                ranges: [
+                  { startIndex: 17, endIndex: 20 },
+                  { startIndex: 64, endIndex: 67 },
+                  { startIndex: 205, endIndex: 208 },
+                  { startIndex: 252, endIndex: 255 },
+                  { startIndex: 346, endIndex: 349 },
+                ],
+              },
+            ],
+          },
+          {
+            id: 3,
+            content:
+              '장의 시작부분은 짧고 직접적이며, 뒤따라 나올 복잡한 정보를 어떻게 해석해야 할 것인지 프레임을 짜주는 역할을 해야 한다. 그러면 아무리 긴 문장이라도 쉽게 읽힌다.',
+            highlights: [],
+          },
+          {
+            id: 4,
+            content:
+              '고액공제건강보험과 건강저축계좌를 만들어 노동자와 고용주가 세금공제를 받을 수 있도록 하면 결과적으로 노동자의 의료보험 부담이 커진다. 세금공제를 받을 수 있도록 하면------------------------------------------- 결과적으로 노동자의 의료보험 부담이 커진다.',
+            highlights: [],
+          },
+        ],
+        votes: null,
+      },
+    ],
+  },
+];

--- a/frontend/src/pages/ReviewCollectionPage/index.tsx
+++ b/frontend/src/pages/ReviewCollectionPage/index.tsx
@@ -1,9 +1,30 @@
+import { useEffect } from 'react';
+
 import { AuthAndServerErrorFallback, ErrorSuspenseContainer, TopButton } from '@/components';
 import ReviewDisplayLayout from '@/components/layouts/ReviewDisplayLayout';
+import { SESSION_STORAGE_KEY } from '@/constants';
 
 import ReviewCollectionPageContents from './components/ReviewCollectionPageContents';
 
 const ReviewCollectionPage = () => {
+  const clearEditorAnswerMapStorage = () => {
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+
+      // 키에 특정 문자열이 포함되어 있는지 확인
+      if (key?.includes(SESSION_STORAGE_KEY.editorAnswerMap)) {
+        localStorage.removeItem(key); // 해당 키 삭제
+        i--; // removeItem 후에 인덱스가 변경되므로 i를 감소시켜야 함
+      }
+    }
+  };
+
+  useEffect(() => {
+    return () => {
+      clearEditorAnswerMapStorage();
+    };
+  }, []);
+
   return (
     <ErrorSuspenseContainer fallback={AuthAndServerErrorFallback}>
       <ReviewDisplayLayout isReviewList={false}>


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #930

---

### 🚀 어떤 기능을 구현했나요 ?
- 형광펜 API 성공 시, 세션 스토리지에 (해당 질문 id를 key에 포함해서) 새로운 editorAnswerMap을 배열로 저장합니다. HighlightEditor 마운트 시, 세션 스토지에 해당 질문에 대한 editorAnswerMap 데이터가 있으면 해당 값을 사용해 editroAnswerMap 상태를 업데이트합니다.

### 🔥 어떻게 해결했나요 ?
- 기존의 리뷰 모아보기 목 핸들러는 질문 섹션이 변경되어도 동일한 데이터를 내려줬습니다. 리뷰 모아보기 목 데이터에 리뷰를 추가했고 이제는 sectionId 쿼리 값을 사용해 섹션별로 리뷰 모아보기 목 데이터 속 배열을 순차적으로 돌면서 다른 리뷰를 내려주도록 했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- dev에서 실행해서, 맞는 지 봐야 안심할 것 같네요

### 📚 참고 자료, 할 말
- 세션 스토리지는 사용자가 데이터를 변경할 수 있고 해당 데이터는 DB에 저장되기 때문에 안전한 방법은 아닙니다. 제일 좋은 것은 groupReviews 상태를 새로운 형광펜 정보를 담도록 업데이트하는 거에요. 시도해봤지만, 현재 형광펜에 대해 서버에서 내려주는 타입과 서버에 보내는 타입이 달라서 상태를 업데이트하는게 쉽지 않습니다. (이게 안되면, 형광펜 정보는 전역 상태로 관리해야할 수도?) 데모데이가 내일이라서 가장 빠르게 할 수 있는 방법으로 버그를 잡았습니다. 이 오류를 어떻게 관리할 지 데모데이 끝나고 논의해보죠!! 
