### PR TITLE
[FE] fix: 모든 아코디언을 기본적으로 닫힌 상태로 두기

### DIFF
--- a/frontend/src/pages/ReviewCollectionPage/components/ReviewCollectionPageContents/index.tsx
+++ b/frontend/src/pages/ReviewCollectionPage/components/ReviewCollectionPageContents/index.tsx
@@ -68,11 +68,7 @@ const ReviewCollectionPageContents = () => {
           });
 
           return (
-            <Accordion
-              title={parsedQuestionName}
-              key={`${selectedSection.value}-${index}`}
-              isInitiallyOpened={index === 0}
-            >
+            <Accordion title={parsedQuestionName} key={`${selectedSection.value}-${index}`} isInitiallyOpened={false}>
               {renderContent(review)}
             </Accordion>
           );


### PR DESCRIPTION
- resolves #935 

---

### 🚀 어떤 기능을 구현했나요 ?
- 모아보기 페이지의 아코디언을 처음부터 닫힌 상태로 두었습니다.

### 🔥 어떻게 해결했나요 ?
- 인덱스 상관없이 항상 닫힌 상태로 두었습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
아코디언은 더 이상 처음부터 입을 벌리지 않을 것입니다.