### PR TITLE
[FE] design: 아코디언 header의 모든 영역을 클릭 가능하도록 수정

### DIFF
--- a/frontend/src/components/common/Accordion/styles.ts
+++ b/frontend/src/components/common/Accordion/styles.ts
@@ -24,7 +24,6 @@ export const AccordionContainer = styled.div<AccordionStyleProps>`
 
 export const AccordionHeader = styled.div<AccordionStyleProps>`
   display: flex;
-  padding: 1rem;
   border-bottom: ${({ $isOpened, theme }) => $isOpened && `0.1rem solid ${theme.colors.placeholder}`};
 `;
 
@@ -36,7 +35,8 @@ export const AccordionButton = styled.button`
 
   width: 100%;
   height: fit-content;
-  min-height: 3rem;
+  min-height: 5rem;
+  padding: 1rem;
 `;
 
 export const AccordionTitle = styled.p`


### PR DESCRIPTION
- resolves #938 

---

### 🚀 어떤 기능을 구현했나요 ?
- 아코디언 header의 모든 영역을 클릭 가능하도록 수정했습니다. 이전에는 button의 부모 요소에 padding이 들어가 있어서 아코디언 가장자리가 클릭되지 않는 문제가 있었어요.

### 🔥 어떻게 해결했나요 ?
- button의 min-height를 높이고, padding을 부모 요소가 아닌 button이 직접 갖도록 했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
![image](https://github.com/user-attachments/assets/afc58f60-ff0b-48b7-8e4c-e31be8751b8e)
