### PR TITLE
[BE] refactor: TooManyRequest 로깅에 사용되는 IP 추출 로직 변경

### DIFF
--- a/backend/src/main/java/reviewme/config/requestlimit/RequestLimitInterceptor.java
+++ b/backend/src/main/java/reviewme/config/requestlimit/RequestLimitInterceptor.java
@@ -4,8 +4,8 @@ import static org.springframework.http.HttpHeaders.USER_AGENT;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
 import java.util.Objects;
-import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -19,7 +19,7 @@ import org.springframework.web.servlet.HandlerInterceptor;
 @RequiredArgsConstructor
 public class RequestLimitInterceptor implements HandlerInterceptor {
 
-    private static final Stream<String> PROXY_HEADERS = Stream.of("X-FORWARDED-FOR", "X-REAL-IP");
+    private static final List<String> PROXY_HEADERS = List.of("X-FORWARDED-FOR", "X-REAL-IP");
 
     private final RedisTemplate<String, Long> redisTemplate;
     private final RequestLimitProperties requestLimitProperties;
@@ -45,7 +45,8 @@ public class RequestLimitInterceptor implements HandlerInterceptor {
     private String generateRequestKey(HttpServletRequest request) {
         String requestURI = request.getRequestURI();
         String userAgent = request.getHeader(USER_AGENT);
-        String ip = PROXY_HEADERS.map(request::getHeader)
+        String ip = PROXY_HEADERS.stream()
+                .map(request::getHeader)
                 .filter(Objects::nonNull)
                 .findFirst()
                 .orElse(request.getRemoteAddr());

--- a/backend/src/main/java/reviewme/config/requestlimit/RequestLimitInterceptor.java
+++ b/backend/src/main/java/reviewme/config/requestlimit/RequestLimitInterceptor.java
@@ -1,7 +1,5 @@
 package reviewme.config.requestlimit;
 
-import static org.springframework.http.HttpHeaders.USER_AGENT;
-
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
@@ -44,13 +42,12 @@ public class RequestLimitInterceptor implements HandlerInterceptor {
 
     private String generateRequestKey(HttpServletRequest request) {
         String requestURI = request.getRequestURI();
-        String userAgent = request.getHeader(USER_AGENT);
-        String ip = PROXY_HEADERS.stream()
+        String remoteAddress = PROXY_HEADERS.stream()
                 .map(request::getHeader)
                 .filter(Objects::nonNull)
                 .findFirst()
                 .orElse(request.getRemoteAddr());
 
-        return String.format("RequestURI: %s, IP: %s, UserAgent: %s", requestURI, ip, userAgent);
+        return String.format("RequestURI: %s, RemoteAddress: %s", requestURI, remoteAddress);
     }
 }

--- a/backend/src/main/java/reviewme/config/requestlimit/RequestLimitInterceptor.java
+++ b/backend/src/main/java/reviewme/config/requestlimit/RequestLimitInterceptor.java
@@ -18,6 +18,7 @@ import org.springframework.web.servlet.HandlerInterceptor;
 public class RequestLimitInterceptor implements HandlerInterceptor {
 
     private static final String X_FORWARDED_FOR = "X-FORWARDED-FOR";
+    private static final String X_REAL_IP = "X-REAL-IP";
 
     private final RedisTemplate<String, Long> redisTemplate;
     private final RequestLimitProperties requestLimitProperties;
@@ -42,9 +43,18 @@ public class RequestLimitInterceptor implements HandlerInterceptor {
 
     private String generateRequestKey(HttpServletRequest request) {
         String requestURI = request.getRequestURI();
-        String forwardedIp = request.getHeader(X_FORWARDED_FOR);
         String userAgent = request.getHeader(USER_AGENT);
+        String ip = extractIp(request);
 
-        return String.format("RequestURI: %s, IP: %s, UserAgent: %s", requestURI, forwardedIp, userAgent);
+        return String.format("RequestURI: %s, IP: %s, UserAgent: %s", requestURI, ip, userAgent);
+    }
+
+    private String extractIp(HttpServletRequest request) {
+        String xForwardedForIP = request.getHeader(X_FORWARDED_FOR);
+        String xRealIp = request.getHeader(X_REAL_IP);
+        if (xForwardedForIP == null) {
+            return xRealIp;
+        }
+        return xForwardedForIP;
     }
 }

--- a/backend/src/main/java/reviewme/config/requestlimit/RequestLimitInterceptor.java
+++ b/backend/src/main/java/reviewme/config/requestlimit/RequestLimitInterceptor.java
@@ -45,15 +45,11 @@ public class RequestLimitInterceptor implements HandlerInterceptor {
     private String generateRequestKey(HttpServletRequest request) {
         String requestURI = request.getRequestURI();
         String userAgent = request.getHeader(USER_AGENT);
-        String ip = extractIpAddress(request);
-
-        return String.format("RequestURI: %s, IP: %s, UserAgent: %s", requestURI, ip, userAgent);
-    }
-
-    private String extractIpAddress(HttpServletRequest request) {
-        return PROXY_HEADERS.map(request::getHeader)
+        String ip = PROXY_HEADERS.map(request::getHeader)
                 .filter(Objects::nonNull)
                 .findFirst()
                 .orElse(request.getRemoteAddr());
+
+        return String.format("RequestURI: %s, IP: %s, UserAgent: %s", requestURI, ip, userAgent);
     }
 }

--- a/backend/src/main/java/reviewme/config/requestlimit/RequestLimitInterceptor.java
+++ b/backend/src/main/java/reviewme/config/requestlimit/RequestLimitInterceptor.java
@@ -17,6 +17,8 @@ import org.springframework.web.servlet.HandlerInterceptor;
 @RequiredArgsConstructor
 public class RequestLimitInterceptor implements HandlerInterceptor {
 
+    private static final String X_FORWARDED_FOR = "X-FORWARDED-FOR";
+
     private final RedisTemplate<String, Long> redisTemplate;
     private final RequestLimitProperties requestLimitProperties;
 
@@ -40,9 +42,9 @@ public class RequestLimitInterceptor implements HandlerInterceptor {
 
     private String generateRequestKey(HttpServletRequest request) {
         String requestURI = request.getRequestURI();
-        String remoteAddr = request.getRemoteAddr();
+        String forwardedIp = request.getHeader(X_FORWARDED_FOR);
         String userAgent = request.getHeader(USER_AGENT);
 
-        return String.format("RequestURI: %s, RemoteAddr: %s, UserAgent: %s", requestURI, remoteAddr, userAgent);
+        return String.format("RequestURI: %s, IP: %s, UserAgent: %s", requestURI, forwardedIp, userAgent);
     }
 }

--- a/backend/src/main/java/reviewme/config/requestlimit/RequestLimitInterceptor.java
+++ b/backend/src/main/java/reviewme/config/requestlimit/RequestLimitInterceptor.java
@@ -4,6 +4,8 @@ import static org.springframework.http.HttpHeaders.USER_AGENT;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Objects;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -17,8 +19,7 @@ import org.springframework.web.servlet.HandlerInterceptor;
 @RequiredArgsConstructor
 public class RequestLimitInterceptor implements HandlerInterceptor {
 
-    private static final String X_FORWARDED_FOR = "X-FORWARDED-FOR";
-    private static final String X_REAL_IP = "X-REAL-IP";
+    private static final Stream<String> PROXY_HEADERS = Stream.of("X-FORWARDED-FOR", "X-REAL-IP");
 
     private final RedisTemplate<String, Long> redisTemplate;
     private final RequestLimitProperties requestLimitProperties;
@@ -44,17 +45,15 @@ public class RequestLimitInterceptor implements HandlerInterceptor {
     private String generateRequestKey(HttpServletRequest request) {
         String requestURI = request.getRequestURI();
         String userAgent = request.getHeader(USER_AGENT);
-        String ip = extractIp(request);
+        String ip = extractIpAddress(request);
 
         return String.format("RequestURI: %s, IP: %s, UserAgent: %s", requestURI, ip, userAgent);
     }
 
-    private String extractIp(HttpServletRequest request) {
-        String xForwardedForIP = request.getHeader(X_FORWARDED_FOR);
-        String xRealIp = request.getHeader(X_REAL_IP);
-        if (xForwardedForIP == null) {
-            return xRealIp;
-        }
-        return xForwardedForIP;
+    private String extractIpAddress(HttpServletRequest request) {
+        return PROXY_HEADERS.map(request::getHeader)
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(request.getRemoteAddr());
     }
 }

--- a/backend/src/test/java/reviewme/config/requestlimit/RequestLimitInterceptorTest.java
+++ b/backend/src/test/java/reviewme/config/requestlimit/RequestLimitInterceptorTest.java
@@ -22,7 +22,7 @@ class RequestLimitInterceptorTest {
     private final ValueOperations<String, Long> valueOperations = mock(ValueOperations.class);
     private final RequestLimitProperties requestLimitProperties = mock(RequestLimitProperties.class);
     private final RequestLimitInterceptor interceptor = new RequestLimitInterceptor(redisTemplate, requestLimitProperties);
-    private final String requestKey = "RequestURI: /api/v2/reviews, RemoteAddr: localhost, UserAgent: Postman";
+    private final String requestKey = "RequestURI: /api/v2/reviews, IP: localhost, UserAgent: Postman";
 
     @BeforeEach
     void setUp() {

--- a/backend/src/test/java/reviewme/config/requestlimit/RequestLimitInterceptorTest.java
+++ b/backend/src/test/java/reviewme/config/requestlimit/RequestLimitInterceptorTest.java
@@ -22,7 +22,7 @@ class RequestLimitInterceptorTest {
     private final ValueOperations<String, Long> valueOperations = mock(ValueOperations.class);
     private final RequestLimitProperties requestLimitProperties = mock(RequestLimitProperties.class);
     private final RequestLimitInterceptor interceptor = new RequestLimitInterceptor(redisTemplate, requestLimitProperties);
-    private final String requestKey = "RequestURI: /api/v2/reviews, IP: localhost, UserAgent: Postman";
+    private final String requestKey = "RequestURI: /api/v2/reviews, RemoteAddress: localhost";
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #943 

---

### 🚀 어떤 기능을 구현했나요 ?
- 현재는 로드벨런서의 IP 를 remoteAddress 로 로깅하고 있습니다. 이는 의미가 없습니다😅
- 따라서 '실제 요청 IP'를 추출할 수 있도록 로직을 수정했습니다.

### 🔥 어떻게 해결했나요 ?
- IP 를 추출하는 우리의 코드가 프록서 서버에 종속적이면 안된다고 생각했습니다.
- 그래서 aws LB 를 사용하는 경우의 헤더(X-FORWARDED-FOR)와 Nginx 를 사용할 때의 헤더(X-REAL-IP)를 대상으로 추출하고,
- 이들이 없다면 그제야 HttpRequest 의 remoteAddr를 추출하도록 작성했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 프록시 종류에 종속적이지 않게 짰는데 과하진 않겠죠?

### 📚 참고 자료, 할 말
