### PR TITLE
[All] chore: CODEOWNERS 추가

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+* @chysis @BadaHertz52 @soosoo22 @ImxYJL @donghoony @Kimprodp @nayonsoso @skylar1220
+/frontend/ @chysis @BadaHertz52 @soosoo22 @ImxYJL
+/backend/ @donghoony @Kimprodp @nayonsoso @skylar1220


### PR DESCRIPTION
GitHub에는 CODEOWNER라는 시스템이 있어요, 코드의 주인(?)을 적어두는 건데요, 리뷰어 추가를 자동으로 할 수 있도록 기능을 제공합니다. 매번 PR 날릴 때 리뷰어를 찾아 추가하는 불편함이 있어서 이를 해결하고자 파일을 추가했어요.

`/frontend/` 하위 변동이 있는 경우 프론트엔드 크루가 리뷰어로 등록됩니다. 백엔드도 마찬가지입니다~ 
맨 윗줄 `*`는 기본적으로 `/backend/`, `/frontend/`가 아닌 경우 작동합니다.

진작 할 걸~

레퍼런스는 이곳입니다
https://docs.github.com/ko/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

ps. 웬만하면 지금 커밋한 것처럼 개개인을 하드코딩하지 않는 게 좋습니다. 원래라면 GitHub Organization에서 제공하는 Team을 적어두는 게 좋아요. 이 레포에서는 우테코에서 제공하는 팀을 사용하기 때문에 권한이 없어 모든 팀원을 하나하나 추가했어요. 팀에 사람을 추가/삭제하는 건 GitHub에서 가능하므로 더 유연합니다~
<p align=center><img width="343" alt="image" src="https://github.com/user-attachments/assets/c290acdb-8f0e-439f-8d24-16e079a07adc"></p>
