### PR TITLE
[BE] feat: 하이라이트 벌크 삽입 추가

### DIFF
--- a/backend/src/main/java/reviewme/highlight/repository/HighlightJdbcRepository.java
+++ b/backend/src/main/java/reviewme/highlight/repository/HighlightJdbcRepository.java
@@ -1,0 +1,9 @@
+package reviewme.highlight.repository;
+
+import java.util.Collection;
+import reviewme.highlight.domain.Highlight;
+
+public interface HighlightJdbcRepository {
+
+    void saveAll(Collection<Highlight> highlights);
+}

--- a/backend/src/main/java/reviewme/highlight/repository/HighlightJdbcRepositoryImpl.java
+++ b/backend/src/main/java/reviewme/highlight/repository/HighlightJdbcRepositoryImpl.java
@@ -3,10 +3,8 @@ package reviewme.highlight.repository;
 import java.util.Collection;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.stereotype.Repository;
 import reviewme.highlight.domain.Highlight;
 
-@Repository
 @RequiredArgsConstructor
 public class HighlightJdbcRepositoryImpl implements HighlightJdbcRepository {
 

--- a/backend/src/main/java/reviewme/highlight/repository/HighlightJdbcRepositoryImpl.java
+++ b/backend/src/main/java/reviewme/highlight/repository/HighlightJdbcRepositoryImpl.java
@@ -2,25 +2,23 @@ package reviewme.highlight.repository;
 
 import java.util.Collection;
 import lombok.RequiredArgsConstructor;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.jdbc.core.namedparam.SqlParameterSourceUtils;
 import reviewme.highlight.domain.Highlight;
 
 @RequiredArgsConstructor
 public class HighlightJdbcRepositoryImpl implements HighlightJdbcRepository {
 
-    private final JdbcTemplate jdbcTemplate;
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
     @Override
     public void saveAll(Collection<Highlight> highlights) {
-        jdbcTemplate.batchUpdate(
-                "INSERT INTO highlight (answer_id, line_index, start_index, end_index) VALUES (?, ?, ?, ?)",
-                highlights,
-                highlights.size(),
-                (ps, highlight) -> {
-                    ps.setLong(1, highlight.getAnswerId());
-                    ps.setInt(2, highlight.getLineIndex());
-                    ps.setInt(3, highlight.getHighlightRange().getStartIndex());
-                    ps.setInt(4, highlight.getHighlightRange().getEndIndex());
-                });
+        SqlParameterSource[] parameterSources = SqlParameterSourceUtils.createBatch(highlights.toArray());
+        String insertSql = """
+                INSERT INTO highlight (answer_id, line_index, start_index, end_index)
+                VALUES (:answerId, :lineIndex, :highlightRange.startIndex, :highlightRange.endIndex)
+                """;
+        namedParameterJdbcTemplate.batchUpdate(insertSql, parameterSources);
     }
 }

--- a/backend/src/main/java/reviewme/highlight/repository/HighlightJdbcRepositoryImpl.java
+++ b/backend/src/main/java/reviewme/highlight/repository/HighlightJdbcRepositoryImpl.java
@@ -1,0 +1,28 @@
+package reviewme.highlight.repository;
+
+import java.util.Collection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import reviewme.highlight.domain.Highlight;
+
+@Repository
+@RequiredArgsConstructor
+public class HighlightJdbcRepositoryImpl implements HighlightJdbcRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public void saveAll(Collection<Highlight> highlights) {
+        jdbcTemplate.batchUpdate(
+                "INSERT INTO highlight (answer_id, line_index, start_index, end_index) VALUES (?, ?, ?, ?)",
+                highlights,
+                highlights.size(),
+                (ps, highlight) -> {
+                    ps.setLong(1, highlight.getAnswerId());
+                    ps.setInt(2, highlight.getLineIndex());
+                    ps.setInt(3, highlight.getHighlightRange().getStartIndex());
+                    ps.setInt(4, highlight.getHighlightRange().getEndIndex());
+                });
+    }
+}

--- a/backend/src/main/java/reviewme/highlight/repository/HighlightRepository.java
+++ b/backend/src/main/java/reviewme/highlight/repository/HighlightRepository.java
@@ -2,12 +2,16 @@ package reviewme.highlight.repository;
 
 import java.util.Collection;
 import java.util.List;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
 import reviewme.highlight.domain.Highlight;
 
-public interface HighlightRepository extends JpaRepository<Highlight, Long> {
+public interface HighlightRepository extends Repository<Highlight, Long>, HighlightJdbcRepository {
+
+    Highlight save(Highlight highlight);
+
+    boolean existsById(long id);
 
     @Modifying
     @Query("""

--- a/backend/src/test/java/reviewme/highlight/repository/HighlightRepositoryTest.java
+++ b/backend/src/test/java/reviewme/highlight/repository/HighlightRepositoryTest.java
@@ -21,7 +21,7 @@ class HighlightRepositoryTest {
         // given
         List<Highlight> highlights = List.of(
                 new Highlight(1L, 1, new HighlightRange(1, 2)),
-                new Highlight(1L, 2, new HighlightRange(2, 3))
+                new Highlight(1L, 1, new HighlightRange(3, 5))
         );
 
         // when
@@ -29,7 +29,9 @@ class HighlightRepositoryTest {
 
         // then
         List<Highlight> actual = highlightRepository.findAllByAnswerIdsOrderedAsc(List.of(1L));
-        assertThat(actual).containsExactlyElementsOf(highlights);
+        assertThat(actual)
+                .extracting(Highlight::getHighlightRange)
+                .containsExactly(new HighlightRange(1, 2), new HighlightRange(3, 5));
     }
 
     @Test

--- a/backend/src/test/java/reviewme/highlight/repository/HighlightRepositoryTest.java
+++ b/backend/src/test/java/reviewme/highlight/repository/HighlightRepositoryTest.java
@@ -17,6 +17,22 @@ class HighlightRepositoryTest {
     private HighlightRepository highlightRepository;
 
     @Test
+    void 한_번에_여러_하이라이트를_벌크_삽입한다() {
+        // given
+        List<Highlight> highlights = List.of(
+                new Highlight(1L, 1, new HighlightRange(1, 2)),
+                new Highlight(1L, 2, new HighlightRange(2, 3))
+        );
+
+        // when
+        highlightRepository.saveAll(highlights);
+
+        // then
+        List<Highlight> actual = highlightRepository.findAllByAnswerIdsOrderedAsc(List.of(1L));
+        assertThat(actual).containsExactlyElementsOf(highlights);
+    }
+
+    @Test
     void 하이라이트를_줄번호_시작_인덱스_순서대로_정렬해서_가져온다() {
         // given
         highlightRepository.saveAll(

--- a/backend/src/test/java/reviewme/highlight/service/HighlightServiceTest.java
+++ b/backend/src/test/java/reviewme/highlight/service/HighlightServiceTest.java
@@ -102,7 +102,7 @@ class HighlightServiceTest {
         highlightService.editHighlight(highlightsRequest, reviewGroup);
 
         // then
-        List<Highlight> highlights = highlightRepository.findAll();
+        List<Highlight> highlights = highlightRepository.findAllByAnswerIdsOrderedAsc(List.of(textAnswer.getId()));
         assertAll(
                 () -> assertThat(highlights.get(0).getAnswerId()).isEqualTo(textAnswer.getId()),
                 () -> assertThat(highlights.get(0).getHighlightRange()).isEqualTo(


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #878 

---

### 🚀 어떤 기능을 구현했나요 ?
- 하이라이트를 하나의 쿼리로 삽입하도록 수정합니다.

### 🔥 어떻게 해결했나요 ?
- JdbcTemplate의 `batchUpdate`를 사용했습니다. 자세한 사항은 이슈를 확인해주세요.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- `Impl`은 Spring에서 이렇게 적어야 한다고 해서.. 안 적으면 제대로 잡아오지를 못하더라고요. `JpaRepository`를 `Repository`로 변경하고, `saveAll` 메서드를 `JdbcTemplate`를 활용한 것을 사용하도록 했어요.

### 📚 참고 자료, 할 말
- #878 
- 테스트를 위한 프로덕션 코드 수정을 안 좋아할 텐데, `JpaRepository`의 `findAll` 메서드는 테스트에서만 사용되고 있었습니다. `JpaRepository`를 사용하는 것보다 `Repository`를 받아서 구현할 것만 메서드를 만드는 게 좋지 않을까요?
 
<img width="526" alt="image" src="https://github.com/user-attachments/assets/ec05254f-9a27-4b59-9849-53411d23e604">
