### PR TITLE
[BE] refactor: 2차 정렬 기준 추가

### DIFF
--- a/backend/src/main/java/reviewme/review/repository/AnswerRepository.java
+++ b/backend/src/main/java/reviewme/review/repository/AnswerRepository.java
@@ -15,7 +15,7 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
             SELECT a FROM Answer a
             JOIN Review r ON a.reviewId = r.id
             WHERE r.reviewGroupId = :reviewGroupId AND a.questionId IN :questionIds
-            ORDER BY r.createdAt DESC
+            ORDER BY r.createdAt DESC, r.id DESC
             LIMIT :limit
             """)
     List<Answer> findReceivedAnswersByQuestionIds(long reviewGroupId, Collection<Long> questionIds, int limit);

--- a/backend/src/main/java/reviewme/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/reviewme/review/repository/ReviewRepository.java
@@ -12,7 +12,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query("""
             SELECT r FROM Review r
             WHERE r.reviewGroupId = :reviewGroupId
-            ORDER BY r.createdAt DESC
+            ORDER BY r.createdAt DESC, r.id DESC
             """)
     List<Review> findAllByGroupId(long reviewGroupId);
 


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #971 

---
![image](https://github.com/user-attachments/assets/ad002c46-e6c7-4281-920b-0ba35476a80b)


### 🚀 어떤 기능을 구현했나요 ?
- 생성일이 겹치면 가끔 테스트가 실패합니다
- 운영 환경에서는 일어날 일이 거의 없겠지만, 생성일이 겹칠 수 있는 조건이기에 2차 정렬 기준을 id로 추가합니다.

### 🔥 어떻게 해결했나요 ?
- 생성일이 동일하면, id 기준 내림차순

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 더 없겠죠?

### 📚 참고 자료, 할 말
