### PR TITLE
[BE] refactor: fetchtype을 `Lazy`로 변경한 후 `EntityGraph`를 사용해 최적화

### DIFF
--- a/backend/src/main/java/reviewme/review/domain/CheckboxAnswer.java
+++ b/backend/src/main/java/reviewme/review/domain/CheckboxAnswer.java
@@ -20,7 +20,7 @@ import reviewme.review.domain.exception.QuestionNotAnsweredException;
 @Getter
 public class CheckboxAnswer extends Answer {
 
-    @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "checkbox_answer_id", nullable = false, updatable = false)
     private List<CheckboxAnswerSelectedOption> selectedOptionIds;
 

--- a/backend/src/main/java/reviewme/review/domain/Review.java
+++ b/backend/src/main/java/reviewme/review/domain/Review.java
@@ -37,7 +37,7 @@ public class Review {
     @Column(name = "review_group_id", nullable = false)
     private long reviewGroupId;
 
-    @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.PERSIST)
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "review_id", nullable = false, updatable = false)
     private List<Answer> answers;
 
@@ -61,6 +61,7 @@ public class Review {
         return getAnsweredQuestionIds().contains(questionId);
     }
 
+    // 하위 타입의 구체적인 정보를 알지 못하므로, fetch join할 수 없다..?
     public <T extends Answer> List<T> getAnswersByType(Class<T> clazz) {
         return answers.stream()
                 .filter(clazz::isInstance)

--- a/backend/src/main/java/reviewme/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/reviewme/review/repository/ReviewRepository.java
@@ -3,12 +3,14 @@ package reviewme.review.repository;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import reviewme.review.domain.Review;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
+    @EntityGraph(attributePaths = {"answers"})
     @Query("""
             SELECT r FROM Review r
             WHERE r.reviewGroupId = :reviewGroupId
@@ -16,6 +18,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             """)
     List<Review> findAllByGroupId(long reviewGroupId);
 
+    @EntityGraph(attributePaths = {"answers"})
     @Query("""
             SELECT r FROM Review r
             WHERE r.reviewGroupId = :reviewGroupId
@@ -25,6 +28,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             """)
     List<Review> findByReviewGroupIdWithLimit(long reviewGroupId, Long lastReviewId, int limit);
 
+    @EntityGraph(attributePaths = {"answers"})
     Optional<Review> findByIdAndReviewGroupId(long reviewId, long reviewGroupId);
 
     @Query("""

--- a/backend/src/main/java/reviewme/template/domain/Section.java
+++ b/backend/src/main/java/reviewme/template/domain/Section.java
@@ -34,7 +34,7 @@ public class Section {
     @Enumerated(EnumType.STRING)
     private VisibleType visibleType;
 
-    @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "section_id", nullable = false, updatable = false)
     private List<SectionQuestion> questionIds;
 

--- a/backend/src/main/java/reviewme/template/domain/Template.java
+++ b/backend/src/main/java/reviewme/template/domain/Template.java
@@ -26,7 +26,7 @@ public class Template {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "template_id", nullable = false, updatable = false)
     private List<TemplateSection> sectionIds;
 

--- a/backend/src/main/java/reviewme/template/repository/SectionRepository.java
+++ b/backend/src/main/java/reviewme/template/repository/SectionRepository.java
@@ -2,6 +2,7 @@ package reviewme.template.repository;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -10,15 +11,16 @@ import reviewme.template.domain.Section;
 @Repository
 public interface SectionRepository extends JpaRepository<Section, Long> {
 
+    @EntityGraph(attributePaths = {"questionIds"})
     @Query("""
             SELECT s FROM Section s
-            JOIN TemplateSection ts
-            ON s.id = ts.sectionId
+            JOIN TemplateSection ts ON s.id = ts.sectionId
             WHERE ts.templateId = :templateId
             ORDER BY s.position ASC
             """)
     List<Section> findAllByTemplateId(long templateId);
 
+    @EntityGraph(attributePaths = {"questionIds"})
     @Query("""
             SELECT s FROM Section s
             JOIN TemplateSection ts ON s.id = ts.sectionId


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #977

---

### 🔥 어떻게 해결했나요 ?
- EntityGraph를 도입해 Fetch해오도록 했습니다.

### 문제 상황, 함께 이야기해보면 좋을 것

현재 추상화로 인해 아래와 같은 객체 구조를 가집니다:
```
Review
  | (1:N)
Answer (Abstract)
  | 
CheckboxAnswer (Subclass)
  | (1:N)
CheckboxAnswerSelectedOption
```

이 상황에서 ReviewRepository에서 Answer에 대한 LAZY 처리 + EntityGraph를 사용해 N+1 문제를 해결했습니다만, `CheckboxAnswer -> CheckboxAnswerSelectedOption`의 N+1 문제는 해결하지 못했습니다. `Review`에서 `Answer`를 fetch하기 때문에 하위 클래스에 대한 properties를 불러오지 않기 때문인데요...

이거 같이 해결하면 좋을 것 같아 우선 PR 올리고 대기합니다. 아이디어 바람...

결론 및 문제상황:
0. 해당 문제 상황을 확인하기 위해서는 `ReviewDetailLookupServiceTest.사용자가_작성한_리뷰를_확인한다`를 한 바퀴 돌려보면 됨.
1. EAGER로 인해서 N+1 문제가 발생하고 있었음.
2. LAZY 변경 + EntityGraph를 활용해 문제를 어느 정도 해결했음. (FETCH JOIN을 사용해도 되지만, JPQL에 불필요한 행이 추가되는 경우도 있고, 이슈에 적어 둔 것처럼 작동하지 않는 경우도 존재함, 공부 필요)
3. 추상 클래스를 fetch하면 추상 클래스의 속성은 fetch함. 하지만 TextAnswer나 CheckboxAnswer처럼 구체 클래스의 속성은 가져오지 않음.
4. 여기서 발생하는 N+1 문제가 있다. TextAnswer, CheckboxAnswer의 내부 값을 가져올 때 쿼리가 추가로 발생함... 이건 어떻게 해결할 수 있을까?

우선 1, 2는 해결했기 때문에 PR을 올립니다. 어떻게 해결하면 좋을지 의견 나눠주시면 감사하겠습니다~