### PR TITLE
[BE] chore: prod cd에 사용될 runner 변경

### DIFF
--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -52,10 +52,7 @@ jobs:
   deploy:
     name: Deploy via self-hosted runner
     needs: build
-    strategy:
-      matrix:
-        runner: [prod-a, prod-b]
-    runs-on: [ self-hosted, "${{ matrix.runner }}" ]
+    runs-on: [self-hosted, prod, oracle]
 
     steps:
       - name: Checkout to secret repository


### PR DESCRIPTION

### 🚀 어떤 기능을 구현했나요 ?
- prod cd 의 runner 설정을 변경했습니다.

### 🔥 어떻게 해결했나요 ?
- oracle runner 를 사용하도록 변경했습니다.
- 이걸 develop에 머지하는 이유는, 예상치 못한 문제로 인해서 release 브랜치에 핫픽스가 생기는 상황을 막기 위해서입니다.
- release 브랜치의 커밋을 깨끗하게 지키려는 전략은 아래와 같습니다.
  - 우선 이걸 develop 브랜치에 머지한 다음, actions 에서 수동으로 release workflow 에 돌립니다. 이때 develop 브랜치를 선택합니다.
  - release workflow 는 develop 브랜치에 체크아웃하고, oracle prod runner 를 사용해 배포를 진행합니다.
  - 배포가 무사히 되는 것을 확인하고, release 브랜치에 머지하여 마이그레이션을 마무리 합니다.

### 📚 참고 자료, 할 말
- 리뷰미 파이팅~~ 중간에 자문해주신 아루 감사합니다🌼