### PR TITLE
[BE] fix: 잘못된 캐시 키 정정

### DIFF
--- a/backend/src/main/java/reviewme/template/service/mapper/TemplateMapper.java
+++ b/backend/src/main/java/reviewme/template/service/mapper/TemplateMapper.java
@@ -39,7 +39,7 @@ public class TemplateMapper {
     private final OptionGroupRepository optionGroupRepository;
     private final OptionItemRepository optionItemRepository;
 
-    @Cacheable(value = "template_response", key = "#reviewGroup.reviewRequestCode")
+    @Cacheable(value = "template_response", key = "#reviewGroup.id")
     public TemplateResponse mapToTemplateResponse(ReviewGroup reviewGroup) {
         Template template = templateRepository.findById(reviewGroup.getTemplateId())
                 .orElseThrow(() -> new TemplateNotFoundByReviewGroupException(

--- a/backend/src/main/java/reviewme/template/service/mapper/TemplateMapper.java
+++ b/backend/src/main/java/reviewme/template/service/mapper/TemplateMapper.java
@@ -39,7 +39,7 @@ public class TemplateMapper {
     private final OptionGroupRepository optionGroupRepository;
     private final OptionItemRepository optionItemRepository;
 
-    @Cacheable(value = "template_response", key = "#reviewGroup.templateId")
+    @Cacheable(value = "template_response", key = "#reviewGroup.reviewRequestCode")
     public TemplateResponse mapToTemplateResponse(ReviewGroup reviewGroup) {
         Template template = templateRepository.findById(reviewGroup.getTemplateId())
                 .orElseThrow(() -> new TemplateNotFoundByReviewGroupException(

--- a/backend/src/main/java/reviewme/template/service/mapper/TemplateMapper.java
+++ b/backend/src/main/java/reviewme/template/service/mapper/TemplateMapper.java
@@ -2,19 +2,18 @@ package reviewme.template.service.mapper;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
+import reviewme.reviewgroup.domain.ReviewGroup;
 import reviewme.template.domain.OptionGroup;
 import reviewme.template.domain.OptionItem;
 import reviewme.template.domain.Question;
-import reviewme.template.repository.OptionGroupRepository;
-import reviewme.template.repository.OptionItemRepository;
-import reviewme.template.repository.QuestionRepository;
-import reviewme.reviewgroup.domain.ReviewGroup;
 import reviewme.template.domain.Section;
 import reviewme.template.domain.SectionQuestion;
 import reviewme.template.domain.Template;
 import reviewme.template.domain.TemplateSection;
+import reviewme.template.repository.OptionGroupRepository;
+import reviewme.template.repository.OptionItemRepository;
+import reviewme.template.repository.QuestionRepository;
 import reviewme.template.repository.SectionRepository;
 import reviewme.template.repository.TemplateRepository;
 import reviewme.template.service.dto.response.OptionGroupResponse;
@@ -39,7 +38,6 @@ public class TemplateMapper {
     private final OptionGroupRepository optionGroupRepository;
     private final OptionItemRepository optionItemRepository;
 
-    @Cacheable(value = "template_response", key = "#reviewGroup.id")
     public TemplateResponse mapToTemplateResponse(ReviewGroup reviewGroup) {
         Template template = templateRepository.findById(reviewGroup.getTemplateId())
                 .orElseThrow(() -> new TemplateNotFoundByReviewGroupException(


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- related to #1002

---

### 🚀 어떤 기능을 구현했나요 ?
- 캐시가 잘못되는 부분을 수정했습니다.


### 🔥 어떻게 해결했나요 ?
- AS-IS : **templateId를 기준으로 리뷰 그룹에 대한 정보를 포함한 응답을 캐싱함**
 templateId가 대부분 1로 통일되어있는 지금, 리뷰 그룹이 다르더라도 캐싱된 리뷰 그룹 정보가 포함되어 응답됨
- TO-BE : reviewGroupId 를 캐시의 키로 설정

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 또 놓치는 부분이 있을까요?

### 📚 참고 자료, 할 말
