### PR TITLE
[BE] chore: release cd를 돌릴 수 있는 브랜치 한정

### DIFF
--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -7,6 +7,17 @@ env:
   APPLICATION_DIRECTORY: /home/ubuntu/review-me
 
 jobs:
+  check-branch:
+    name: Check branch name
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch name
+        if: ${{ github.ref_name != 'release' && !startsWith(github.ref_name, 'hotfix/') }}
+        run: |
+          echo "This workflow can only run on 'release' branch or branches starting with 'hotfix/'"
+          echo "Current branch: ${{ github.ref_name }}"
+          exit 1
+
   build:
     name: Build Dockerfile and push to DockerHub
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- related to #1002

---

### 🚀 어떤 기능을 구현했나요 ?
- release cd 를 돌릴 수 있는 브랜치를 'release'와 'hotfix/'로 시작하는 브랜치로 한정했습니다.
- 위 이슈를 반복하지 않기 위함입니다.

### 🔥 어떻게 해결했나요 ?
- 'release'가 아니거나 'hotfix/'로 시작하지 않으면 워크플로우를 즉시 중단하게 했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 브랜치 이름을 이렇게 workflow에 박아두면, 장단점이 있습니다.
  - 장점 : prod 서버가 이상한 브랜치에서 돌지 않게 지킬 수 있다.
  - 단점 : 브랜치 이름이 하드코딩으로 들어간다.
- 워크플로우 파일에 브랜치 이름이 들어가는 경우는 흔하니, 단점이 치명적이지 않다 생각해서 이렇게 PR 올립니다.

### 📚 참고 자료, 할 말
- dev cd 파일도 이렇게 수정해야 할까요? 아니면 dev cd 는 조금 더 자유도를 둘까요?