### PR TITLE
[BE] refactor: 테스트 환경에서 캐싱을 사용하도록 하여 환경 통일

### DIFF
--- a/backend/src/test/java/reviewme/config/TestConfig.java
+++ b/backend/src/test/java/reviewme/config/TestConfig.java
@@ -1,7 +1,9 @@
 package reviewme.config;
 
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
+import reviewme.support.CacheCleaner;
 import reviewme.support.DatabaseCleaner;
 
 @TestConfiguration
@@ -10,5 +12,10 @@ public class TestConfig {
     @Bean
     public DatabaseCleaner databaseCleaner() {
         return new DatabaseCleaner();
+    }
+
+    @Bean
+    public CacheCleaner cacheCleaner(CacheManager cacheManager) {
+        return new CacheCleaner(cacheManager);
     }
 }

--- a/backend/src/test/java/reviewme/support/CacheCleaner.java
+++ b/backend/src/test/java/reviewme/support/CacheCleaner.java
@@ -1,0 +1,22 @@
+package reviewme.support;
+
+import java.util.Objects;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+
+public class CacheCleaner {
+
+    private final CacheManager cacheManager;
+
+    public CacheCleaner(CacheManager cacheManager) {
+        this.cacheManager = cacheManager;
+    }
+
+    public void execute() {
+        cacheManager.getCacheNames()
+                .stream()
+                .map(cacheManager::getCache)
+                .filter(Objects::nonNull)
+                .forEach(Cache::clear);
+    }
+}

--- a/backend/src/test/java/reviewme/support/CacheCleanerExtension.java
+++ b/backend/src/test/java/reviewme/support/CacheCleanerExtension.java
@@ -1,0 +1,15 @@
+package reviewme.support;
+
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+public class CacheCleanerExtension implements BeforeEachCallback {
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) {
+        SpringExtension.getApplicationContext(extensionContext)
+                .getBean(CacheCleaner.class)
+                .execute();
+    }
+}

--- a/backend/src/test/java/reviewme/support/ServiceTest.java
+++ b/backend/src/test/java/reviewme/support/ServiceTest.java
@@ -12,6 +12,6 @@ import reviewme.config.TestConfig;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @SpringBootTest(webEnvironment = WebEnvironment.NONE, classes = TestConfig.class)
-@ExtendWith(DatabaseCleanerExtension.class)
+@ExtendWith({DatabaseCleanerExtension.class, CacheCleanerExtension.class})
 public @interface ServiceTest {
 }

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -14,7 +14,7 @@ spring:
   flyway:
     enabled: false
   cache:
-    type: none
+    type: simple
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #1006 

---

### 🚀 어떤 기능을 구현했나요 ?
- 프로덕션 환경에서의 변화는 없습니다.
- 테스트 코드가 추가되지 않았고, 환경 일치만 진행했습니다.
- 테스트 환경에서의 Cache를 활성화했습니다. 이로써 테스트로 캐싱을 확인할 수 있습니다.

### 🔥 어떻게 해결했나요 ?
- `CacheCleanerExtension`을 만들었습니다. 앞으로 `@ServiceTest`가 붙은 친구들은 데이터베이스 격리와 더불어 캐싱 격리가 진행됩니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 보다 나은 방식이 있다면 추천해주세요~