### PR TITLE
[BE] refactor: `TemplateMapper`에서 `ReviewGroup` 의존성 제거

### DIFF
--- a/backend/src/main/java/reviewme/template/service/TemplateService.java
+++ b/backend/src/main/java/reviewme/template/service/TemplateService.java
@@ -1,10 +1,12 @@
 package reviewme.template.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import reviewme.reviewgroup.domain.ReviewGroup;
 import reviewme.reviewgroup.service.ReviewGroupService;
+import reviewme.template.service.dto.response.SectionResponse;
 import reviewme.template.service.dto.response.TemplateResponse;
 import reviewme.template.service.mapper.TemplateMapper;
 
@@ -18,6 +20,11 @@ public class TemplateService {
     @Transactional(readOnly = true)
     public TemplateResponse generateReviewForm(String reviewRequestCode) {
         ReviewGroup reviewGroup = reviewGroupService.getReviewGroupByReviewRequestCode(reviewRequestCode);
-        return templateMapper.mapToTemplateResponse(reviewGroup);
+        List<SectionResponse> sectionResponses = templateMapper.mapSectionResponses(
+                reviewGroup.getId(), reviewGroup.getTemplateId()
+        );
+        return new TemplateResponse(
+                reviewGroup.getTemplateId(), reviewGroup.getReviewee(), reviewGroup.getProjectName(), sectionResponses
+        );
     }
 }

--- a/backend/src/main/java/reviewme/template/service/mapper/TemplateMapper.java
+++ b/backend/src/main/java/reviewme/template/service/mapper/TemplateMapper.java
@@ -3,7 +3,6 @@ package reviewme.template.service.mapper;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import reviewme.reviewgroup.domain.ReviewGroup;
 import reviewme.template.domain.OptionGroup;
 import reviewme.template.domain.OptionItem;
 import reviewme.template.domain.Question;
@@ -20,7 +19,6 @@ import reviewme.template.service.dto.response.OptionGroupResponse;
 import reviewme.template.service.dto.response.OptionItemResponse;
 import reviewme.template.service.dto.response.QuestionResponse;
 import reviewme.template.service.dto.response.SectionResponse;
-import reviewme.template.service.dto.response.TemplateResponse;
 import reviewme.template.service.exception.MissingOptionItemsInOptionGroupException;
 import reviewme.template.service.exception.QuestionInSectionNotFoundException;
 import reviewme.template.service.exception.SectionInTemplateNotFoundException;
@@ -38,23 +36,14 @@ public class TemplateMapper {
     private final OptionGroupRepository optionGroupRepository;
     private final OptionItemRepository optionItemRepository;
 
-    public TemplateResponse mapToTemplateResponse(ReviewGroup reviewGroup) {
-        Template template = templateRepository.findById(reviewGroup.getTemplateId())
-                .orElseThrow(() -> new TemplateNotFoundByReviewGroupException(
-                        reviewGroup.getId(), reviewGroup.getTemplateId()
-                ));
+    public List<SectionResponse> mapSectionResponses(long templateId, long reviewGroupId) {
+        Template template = templateRepository.findById(templateId)
+                .orElseThrow(() -> new TemplateNotFoundByReviewGroupException(reviewGroupId, templateId));
 
-        List<SectionResponse> sectionResponses = template.getSectionIds()
+        return template.getSectionIds()
                 .stream()
                 .map(this::mapToSectionResponse)
                 .toList();
-
-        return new TemplateResponse(
-                template.getId(),
-                reviewGroup.getReviewee(),
-                reviewGroup.getProjectName(),
-                sectionResponses
-        );
     }
 
     private SectionResponse mapToSectionResponse(TemplateSection templateSection) {


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->
- resolves #970 

---

### 문제 상황
- 현재 `TemplateResponse`를 위해 매핑 로직을 태우는데, 이때 불필요한 `ReviewGroup`까지 파라미터에 들어가 강결합되는 문제가 있었습니다. 의존성은 최대한 빼주는 게 좋으니 최종 매핑을 서비스단에서 진행하도록 수정했어요. 사용하고 있지 않더라도, `ReviewGroup`을 가지는 것만으로도 추후에 더 얽힐 가능성이 있습니다 (이전 캐시 코드에서도 해당 리뷰그룹의 값을 활용한 것으로 알고 있어요)

### 🔥 어떻게 해결했나요 ?
- 더 이상 `TemplateMapper`에서 `ReviewGroup`을 알지 못합니다.
- 이와 같이 수정함으로써 `List<SectionResponse>`를 캐싱하면 #1003 도 어느정도 해결될 것으로 보입니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 가볍게 확인해주셔도 좋겠습니다 😋

### 📚 참고 자료, 할 말
