### PR TITLE
[BE] refactor: DTO에서 Enum 사용하도록 수정

### DIFF
--- a/backend/src/main/java/reviewme/template/domain/OptionType.java
+++ b/backend/src/main/java/reviewme/template/domain/OptionType.java
@@ -1,6 +1,8 @@
 package reviewme.template.domain;
 
 public enum OptionType {
+
     CATEGORY,
     KEYWORD,
+    ;
 }

--- a/backend/src/main/java/reviewme/template/domain/QuestionType.java
+++ b/backend/src/main/java/reviewme/template/domain/QuestionType.java
@@ -1,8 +1,8 @@
 package reviewme.template.domain;
 
 public enum QuestionType {
+
     CHECKBOX,
     TEXT,
     ;
-
 }

--- a/backend/src/main/java/reviewme/template/service/dto/response/QuestionResponse.java
+++ b/backend/src/main/java/reviewme/template/service/dto/response/QuestionResponse.java
@@ -1,12 +1,13 @@
 package reviewme.template.service.dto.response;
 
 import jakarta.annotation.Nullable;
+import reviewme.template.domain.QuestionType;
 
 public record QuestionResponse(
         long questionId,
         boolean required,
         String content,
-        String questionType,
+        QuestionType questionType,
         @Nullable OptionGroupResponse optionGroup,
         boolean hasGuideline,
         @Nullable String guideline

--- a/backend/src/main/java/reviewme/template/service/dto/response/SectionResponse.java
+++ b/backend/src/main/java/reviewme/template/service/dto/response/SectionResponse.java
@@ -2,11 +2,12 @@ package reviewme.template.service.dto.response;
 
 import jakarta.annotation.Nullable;
 import java.util.List;
+import reviewme.template.domain.VisibleType;
 
 public record SectionResponse(
         long sectionId,
         String sectionName,
-        String visible,
+        VisibleType visible,
         @Nullable Long onSelectedOptionId,
         String header,
         List<QuestionResponse> questions

--- a/backend/src/main/java/reviewme/template/service/mapper/TemplateMapper.java
+++ b/backend/src/main/java/reviewme/template/service/mapper/TemplateMapper.java
@@ -70,7 +70,7 @@ public class TemplateMapper {
         return new SectionResponse(
                 section.getId(),
                 section.getSectionName(),
-                section.getVisibleType().name(),
+                section.getVisibleType(),
                 section.getOnSelectedOptionId(),
                 section.getHeader(),
                 questionResponses
@@ -90,7 +90,7 @@ public class TemplateMapper {
                 question.getId(),
                 question.isRequired(),
                 question.getContent(),
-                question.getQuestionType().name(),
+                question.getQuestionType(),
                 optionGroupResponse,
                 question.hasGuideline(),
                 question.getGuideline()

--- a/backend/src/test/java/reviewme/api/TemplateFixture.java
+++ b/backend/src/test/java/reviewme/api/TemplateFixture.java
@@ -29,14 +29,14 @@ class TemplateFixture {
                         1,
                         true,
                         "프로젝트 기간 동안, 아루의 강점이 드러났던 순간을 선택해주세요.",
-                        QuestionType.CHECKBOX.name(),
+                        QuestionType.CHECKBOX,
                         new OptionGroupResponse(1, 1, 2, firstSectionOptions),
                         false,
                         null
                 )
         );
         SectionResponse firstSection = new SectionResponse(
-                1, "카테고리 선택", VisibleType.ALWAYS.name(), null, "아루와 함께 한 기억을 떠올려볼게요.", firstSectionQuestions
+                1, "카테고리 선택", VisibleType.ALWAYS, null, "아루와 함께 한 기억을 떠올려볼게요.", firstSectionQuestions
         );
 
         // Section 2
@@ -50,7 +50,7 @@ class TemplateFixture {
                         2,
                         true,
                         "커뮤니케이션, 협업 능력에서 어떤 부분이 인상 깊었는지 선택해주세요.",
-                        QuestionType.CHECKBOX.name(),
+                        QuestionType.CHECKBOX,
                         new OptionGroupResponse(2, 1, 3, secondSectionOptions),
                         false,
                         null
@@ -59,14 +59,14 @@ class TemplateFixture {
                         3,
                         true,
                         "위에서 선택한 사항에 대해 조금 더 자세히 설명해주세요.",
-                        QuestionType.TEXT.name(),
+                        QuestionType.TEXT,
                         null,
                         true,
                         "상황을 자세하게 기록할수록 아루에게 도움이 돼요. 아루 덕분에 팀이 원활한 소통을 이뤘거나, 함께 일하면서 배울 점이 있었는지 떠올려 보세요."
                 )
         );
         SectionResponse secondSection = new SectionResponse(
-                2, "커뮤니케이션 능력", VisibleType.ALWAYS.name(), 1L, "아루의 커뮤니케이션, 협업 능력을 평가해주세요.", secondSectionQuestions
+                2, "커뮤니케이션 능력", VisibleType.ALWAYS, 1L, "아루의 커뮤니케이션, 협업 능력을 평가해주세요.", secondSectionQuestions
         );
 
         return new TemplateResponse(1, "아루", "리뷰미", List.of(firstSection, secondSection));


### PR DESCRIPTION
### 🚀 어떤 기능을 구현했나요 ?
- 기존 DTO에서는 Enum을 직접 사용했었는데, 몇몇 부분에서 String으로 사용하면서 `.name()`를 불필요하게 부르고 있는 것을 확인했어요. 이를 Enum을 직접 사용하도록 수정했습니다. 통일감도 지키고요!

### 🔥 어떻게 해결했나요 ?
- 기능 상 변화는 없습니다 !
- Dto에서 String을 Enum 타입으로 바꾸기

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 문자열은 실수할 여지가 있다고 생각했어요. 자유롭게 생각 나눠주세요~

### 📚 참고 자료, 할 말
