### PR TITLE
[FE] feat : ErrorSuspense에 fallback 수정

### DIFF
--- a/frontend/src/components/error/ErrorSuspenseContainer/index.tsx
+++ b/frontend/src/components/error/ErrorSuspenseContainer/index.tsx
@@ -1,5 +1,5 @@
 import { QueryErrorResetBoundary } from '@tanstack/react-query';
-import { lazy, Suspense } from 'react';
+import { lazy, ReactNode, Suspense } from 'react';
 
 import { EssentialPropsWithChildren } from '@/types';
 
@@ -9,18 +9,20 @@ import ErrorFallback from '../ErrorFallback';
 const LoadingPage = lazy(() => import('@/pages/LoadingPage'));
 
 interface ErrorSuspenseContainerProps {
-  fallback?: React.ComponentType<FallbackProps>;
+  errorFallback?: React.ComponentType<FallbackProps>;
+  suspenseFallback?: ReactNode;
 }
 
 const ErrorSuspenseContainer = ({
   children,
-  fallback = ErrorFallback,
+  errorFallback = ErrorFallback,
+  suspenseFallback = <LoadingPage />,
 }: EssentialPropsWithChildren<ErrorSuspenseContainerProps>) => {
   return (
     <QueryErrorResetBoundary>
       {({ reset }) => (
-        <ErrorBoundary fallback={fallback} resetQueryError={reset}>
-          <Suspense fallback={<LoadingPage />}>{children}</Suspense>
+        <ErrorBoundary fallback={errorFallback} resetQueryError={reset}>
+          <Suspense fallback={suspenseFallback}>{children}</Suspense>
         </ErrorBoundary>
       )}
     </QueryErrorResetBoundary>

--- a/frontend/src/pages/DetailedReviewPage/index.tsx
+++ b/frontend/src/pages/DetailedReviewPage/index.tsx
@@ -4,7 +4,7 @@ import { DetailedReviewPageContents } from './components';
 
 const DetailedReviewPage = () => {
   return (
-    <ErrorSuspenseContainer fallback={AuthAndServerErrorFallback}>
+    <ErrorSuspenseContainer errorFallback={AuthAndServerErrorFallback}>
       <DetailedReviewPageContents />
       <TopButton />
     </ErrorSuspenseContainer>

--- a/frontend/src/pages/ReviewCollectionPage/index.tsx
+++ b/frontend/src/pages/ReviewCollectionPage/index.tsx
@@ -5,7 +5,7 @@ import ReviewCollectionPageContents from './components/ReviewCollectionPageConte
 
 const ReviewCollectionPage = () => {
   return (
-    <ErrorSuspenseContainer fallback={AuthAndServerErrorFallback}>
+    <ErrorSuspenseContainer errorFallback={AuthAndServerErrorFallback}>
       <ReviewDisplayLayout isReviewList={false}>
         <ReviewCollectionPageContents />
         <TopButton />

--- a/frontend/src/pages/ReviewListPage/index.tsx
+++ b/frontend/src/pages/ReviewListPage/index.tsx
@@ -5,7 +5,7 @@ import ReviewListPageContents from './components/ReviewListPageContents';
 
 const ReviewListPage = () => {
   return (
-    <ErrorSuspenseContainer fallback={AuthAndServerErrorFallback}>
+    <ErrorSuspenseContainer errorFallback={AuthAndServerErrorFallback}>
       <ReviewDisplayLayout isReviewList={true}>
         <ReviewListPageContents />
         <TopButton />


### PR DESCRIPTION


<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #1026

---

### 🚀 어떤 기능을 구현했나요 ?
- ErrorSuspense 에 Suspense fallback을 props로 받을 수 있게 해서 Suspense 활용도를 높였습니다.
그 과정에서 기존의 ErrorBoundary fallback props명을 수정했습니다. 

### 🔥 어떻게 해결했나요 ?
- 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
-  리뷰 링크 생성폼 PR에 해당 PR 내용이 포함되어 있어서, 이 PR를 먼저 머지해주세요! 
