### PR TITLE
[FE] chore: 타입, 인터페이스의 이름을 PascalCase로 강제하는 eslint 규칙 추가

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -26,6 +26,17 @@ module.exports = {
   rules: {
     'react/react-in-jsx-scope': 'off',
     'react/no-unknown-property': ['error', { ignore: ['css'] }],
+    '@typescript-eslint/naming-convention': [
+      'error',
+      {
+        selector: 'interface',
+        format: ['PascalCase'],
+      },
+      {
+        selector: 'typeAlias',
+        format: ['PascalCase'],
+      },
+    ],
     'import/order': [
       'error',
       {


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #1033 

---

### 🚀 어떤 기능을 구현했나요 ?
- 타입, 인터페이스 이름을 PascalCase로 강제하는 규칙을 추가했습니다. 

### 🔥 어떻게 해결했나요 ?
- `@typescript-eslint/naming-convention`의 error 부분 추가

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
훗날 컨벤션 정할 때 eslint 규칙으로 추가할 만한 게 없는지 돌아보면 좋을 것 같네요! 그치만 나머지는 나중에 하는 것으로...