### PR TITLE
[FE] feat: 뒤로 가기 버튼 구현

### DIFF
--- a/frontend/src/assets/backButton.svg
+++ b/frontend/src/assets/backButton.svg
@@ -1,0 +1,3 @@
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M38 24H10M10 24L24 10M10 24L24 38" stroke="#7F7F7F" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/components/common/BackButton/index.tsx
+++ b/frontend/src/components/common/BackButton/index.tsx
@@ -8,10 +8,11 @@ import * as S from './styles';
 interface BackButtonProps {
   prevPath: string;
   options?: NavigateOptions;
-  style?: React.CSSProperties;
+  buttonStyle?: React.CSSProperties;
+  wrapperStyle?: React.CSSProperties;
 }
 
-const BackButton = ({ prevPath, options, style }: BackButtonProps) => {
+const BackButton = ({ prevPath, options, buttonStyle, wrapperStyle }: BackButtonProps) => {
   const navigate = useNavigate();
 
   const handleBackButtonClick = () => {
@@ -19,9 +20,11 @@ const BackButton = ({ prevPath, options, style }: BackButtonProps) => {
   };
 
   return (
-    <S.BackButton onClick={handleBackButtonClick} $style={style}>
-      <S.BackButtonImage src={BackButtonIcon} alt="뒤로가기 버튼" />
-    </S.BackButton>
+    <S.BackButtonWrapper $style={wrapperStyle}>
+      <S.BackButton onClick={handleBackButtonClick} $style={buttonStyle}>
+        <img src={BackButtonIcon} alt="뒤로가기 버튼" />
+      </S.BackButton>
+    </S.BackButtonWrapper>
   );
 };
 

--- a/frontend/src/components/common/BackButton/index.tsx
+++ b/frontend/src/components/common/BackButton/index.tsx
@@ -21,7 +21,7 @@ const BackButton = ({ prevPath, navigateOptions, buttonStyle, wrapperStyle }: Ba
 
   return (
     <S.BackButtonWrapper $style={wrapperStyle}>
-      <S.BackButton onClick={handleBackButtonClick} $style={buttonStyle}>
+      <S.BackButton onClick={handleBackButtonClick} $style={buttonStyle} type="button">
         <img src={BackButtonIcon} alt="뒤로가기 버튼" />
       </S.BackButton>
     </S.BackButtonWrapper>

--- a/frontend/src/components/common/BackButton/index.tsx
+++ b/frontend/src/components/common/BackButton/index.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { NavigateOptions, useNavigate } from 'react-router';
+
+import BackButtonIcon from '@/assets/backButton.svg';
+
+import * as S from './styles';
+
+interface BackButtonProps {
+  prevPath: string;
+  options?: NavigateOptions;
+  style?: React.CSSProperties;
+}
+
+const BackButton = ({ prevPath, options, style }: BackButtonProps) => {
+  const navigate = useNavigate();
+
+  const handleBackButtonClick = () => {
+    navigate(prevPath, options);
+  };
+
+  return (
+    <S.BackButton onClick={handleBackButtonClick} $style={style}>
+      <S.BackButtonImage src={BackButtonIcon} alt="뒤로가기 버튼" />
+    </S.BackButton>
+  );
+};
+
+export default BackButton;

--- a/frontend/src/components/common/BackButton/index.tsx
+++ b/frontend/src/components/common/BackButton/index.tsx
@@ -7,16 +7,16 @@ import * as S from './styles';
 
 interface BackButtonProps {
   prevPath: string;
-  options?: NavigateOptions;
+  navigateOptions?: NavigateOptions;
   buttonStyle?: React.CSSProperties;
   wrapperStyle?: React.CSSProperties;
 }
 
-const BackButton = ({ prevPath, options, buttonStyle, wrapperStyle }: BackButtonProps) => {
+const BackButton = ({ prevPath, navigateOptions, buttonStyle, wrapperStyle }: BackButtonProps) => {
   const navigate = useNavigate();
 
   const handleBackButtonClick = () => {
-    navigate(prevPath, options);
+    navigate(prevPath, navigateOptions);
   };
 
   return (

--- a/frontend/src/components/common/BackButton/styles.ts
+++ b/frontend/src/components/common/BackButton/styles.ts
@@ -1,0 +1,14 @@
+import styled from '@emotion/styled';
+
+interface BackButtonStyleProps {
+  $style?: React.CSSProperties;
+}
+
+export const BackButton = styled.button<BackButtonStyleProps>`
+  width: 3.5rem;
+  height: 3.5rem;
+
+  ${({ $style }) => $style && { ...$style }}
+`;
+
+export const BackButtonImage = styled.img``;

--- a/frontend/src/components/common/BackButton/styles.ts
+++ b/frontend/src/components/common/BackButton/styles.ts
@@ -4,11 +4,17 @@ interface BackButtonStyleProps {
   $style?: React.CSSProperties;
 }
 
+export const BackButtonWrapper = styled.div<BackButtonStyleProps>`
+  display: flex;
+  justify-content: flex-start;
+  width: 100%;
+
+  ${({ $style }) => $style && { ...$style }}
+`;
+
 export const BackButton = styled.button<BackButtonStyleProps>`
   width: 3.5rem;
   height: 3.5rem;
 
   ${({ $style }) => $style && { ...$style }}
 `;
-
-export const BackButtonImage = styled.img``;

--- a/frontend/src/pages/DetailedReviewPage/components/DetailedReviewPageContents/index.tsx
+++ b/frontend/src/pages/DetailedReviewPage/components/DetailedReviewPageContents/index.tsx
@@ -46,7 +46,6 @@ const DetailedReviewPageContents = () => {
     };
   }, [detailedReview]);
 
-  // TODO: 리뷰 공개/비공개 토글 버튼 기능
   return (
     <S.DetailedReviewPageContents>
       <ReviewDescription

--- a/frontend/src/pages/ReviewCollectionPage/index.tsx
+++ b/frontend/src/pages/ReviewCollectionPage/index.tsx
@@ -1,4 +1,4 @@
-import { AuthAndServerErrorFallback, ErrorSuspenseContainer, TopButton } from '@/components';
+import { AuthAndServerErrorFallback, ErrorSuspenseContainer } from '@/components';
 import ReviewDisplayLayout from '@/components/layouts/ReviewDisplayLayout';
 
 import ReviewCollectionPageContents from './components/ReviewCollectionPageContents';
@@ -8,7 +8,6 @@ const ReviewCollectionPage = () => {
     <ErrorSuspenseContainer fallback={AuthAndServerErrorFallback}>
       <ReviewDisplayLayout isReviewList={false}>
         <ReviewCollectionPageContents />
-        <TopButton />
       </ReviewDisplayLayout>
     </ErrorSuspenseContainer>
   );

--- a/frontend/src/pages/ReviewListPage/index.tsx
+++ b/frontend/src/pages/ReviewListPage/index.tsx
@@ -1,4 +1,4 @@
-import { ErrorSuspenseContainer, AuthAndServerErrorFallback, TopButton } from '@/components';
+import { ErrorSuspenseContainer, AuthAndServerErrorFallback } from '@/components';
 import ReviewDisplayLayout from '@/components/layouts/ReviewDisplayLayout';
 
 import ReviewListPageContents from './components/ReviewListPageContents';
@@ -8,7 +8,6 @@ const ReviewListPage = () => {
     <ErrorSuspenseContainer fallback={AuthAndServerErrorFallback}>
       <ReviewDisplayLayout isReviewList={true}>
         <ReviewListPageContents />
-        <TopButton />
       </ReviewDisplayLayout>
     </ErrorSuspenseContainer>
   );


### PR DESCRIPTION
- resolves #1021 

---

### 🚀 어떤 기능을 구현했나요 ?
- 뒤로 가기 버튼 공통 컴포넌트(`BackButton`)를 구현했습니다.
- **기존 목표였던 뒤로 가기 버튼을 포함한 레이아웃은 만들지 않았습니다.** 현재는 뒤로 가기 버튼이 필요한 페이지에서 직접 버튼을 배치하면 됩니다.

### 🔥 어떻게 해결했나요 ?
#### 기대했던 뒤로 가기 레이아웃
![image](https://github.com/user-attachments/assets/07d56b10-5bbe-4f7e-9514-550ac9eac77c)
- `BackButtonLayout`은 children으로 페이지를 받습니다.
- `BackButton`은 children과 flex-start 정렬되어야 합니다. (시작 라인에 위치)
- `BackButton`과 children은 화면 중앙에 배치되어야 합니다.

#### 문제점
- children으로 오는 페이지들은 width가 화면 전체를 기준으로 한 상대 크기로 지정되어 있습니다. 상세 리뷰 페이지의 경우, 반응형으로 구현되어 있어 화면 크기에 따라 70%, 80%, 92% 등으로 크기가 가변적입니다. 다른 페이지들도 모두 다른 width가 설정되어 있습니다.
- `BackButton`과 children을 flex-start 정렬하기 위해 필요한 `InnerContainer`를 children과 같은 width로 설정하면 요구 사항을 만족할 수 있습니다. 이를 위해 `width: auto` 또는 `width: fit-content` 등으로 설정하면, children의 상대 크기와 맞물려 순환 참조가 발생하게 됩니다.
  1. children은 부모의 부모인 `BackButtonLayoutContainer`(화면 전체)를 기준으로 70%, 80% 등을 적용하고 싶고
  2. 부모인 `InnerContainer`는 1번에서 계산된 children과 같게 두고 싶은 상태
  - 즉, 자식이 조부모(?)를 기준으로 크기 계산을 한 다음에 부모가 자식의 크기를 따라야 하기 때문에 CSS의 width 계산 순서와 맞지 않게 됩니다. 

- CSS는 순환 참조가 발생하는 경우, 부모는 최초의 자식 width로 fit-content가 결정되고, 그 후 자식은 부모의 width를 기준으로 다시 상대 크기를 갖게 됩니다. 따라서 부모는 화면 전체의 80%, 자식은 화면 전체의 80%의 80%로 설정됩니다. (원래 크기보다 줄어드는 문제)
  - 이렇게 되면 `InnerContainer`가 children보다 커지기 때문에 flex-start를 적용할 경우 아래 그림과 같이 화면 중앙에 정렬되지 않습니다.
![image](https://github.com/user-attachments/assets/d05c3efd-55c5-46b6-98a9-3ac74e715e53)


#### 시도해본 방법(대안)
1. `InnerContainer`의 width를 자식 크기와 같게가 아닌 100%로 지정하면 children의 width는 잘 설정되지만 **BackButton이 children의 시작 위치에 배치되지 않습니다.** 이 경우 디자인적으로 만족스럽지 않습니다.

2. `BackButtonLayout`의 children으로 오는 모든 페이지는 `width: 100%`로 두고, `BackButtonLayout`을 반응형으로 구현하는 방법.
- 부모를 반응형으로 구현하면 하위 페이지들은 일관적인 UI를 가질 수 있겠지만, 현재는 페이지마다 UI가 다르기 때문에 논의가 필요합니다.

3. `getBoundingClientRect`을 사용해서 children의 시작 위치를 TypeScript로 계산해서 `BackButton`에 left 속성으로 설정하는 방법
- children을 감싼 Wrapper에 ref를 설정하여 레이아웃 위치를 계산해야 하는데요, 이 경우 Wrapper는 children의 width와 같게 설정되어야 정확한 위치를 계산할 수 있습니다. 하지만 위의 문제점과 동일한 이유로 실제 children의 시작 위치와 Wrapper의 시작 위치가 달라지게 되어 원하는 결과를 얻을 수 없었습니다.
![image](https://github.com/user-attachments/assets/736d8237-5443-4edd-b5e9-8d7e6aded4c0)

4. (채택) `BackButton`이 필요한 페이지에서 버튼만 갖다 쓰는 방법
- 공통 레이아웃을 만들지 않고, 필요한 곳에서 버튼 컴포넌트만 가져다 사용하는 방법입니다.
- 유연한 스타일링이 가능하고, 위의 문제점 등을 고민할 필요가 없게 됩니다. 

**재사용성에 관한 제 생각**
- 리뷰 목록/모아보기 페이지의 경우, 이미 `ReviewDisplayLayout`이 적용되어 있고, 공통으로 사용되는 `ReviewDescription`을 처리하기 위해 useContext를 사용하는 등 로직이 복잡하게 얽혀있습니다. 기존의 레이아웃을 그대로 사용하고, BackButton만 가져와 쓰는 것이 더 낫다고 생각합니다. 
- 결국 남는 것은 리뷰 상세 페이지인데, 당장은 하나의 페이지를 위해 공통 레이아웃을 만들 필요는 없다고 생각합니다.
- 만약 추후에 `BackButton`을 사용하는 모든 페이지가 일관된 UI를 가지는 것으로 합의된다면 위의 2번 방법을 적용해볼 수 있지 않을까 생각합니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 위 문제점과 구현 방법에 대한 여러분들의 생각이 궁금합니다. 추가적인 아이디어가 있다면 알려주세요!

### 📚 참고 자료, 할 말
