### PR TITLE
[BE] refactor: 기존 api가 리뷰 그룹 정보를 포함하도록 수정

### DIFF
--- a/backend/src/main/java/reviewme/highlight/controller/HighlightController.java
+++ b/backend/src/main/java/reviewme/highlight/controller/HighlightController.java
@@ -3,6 +3,7 @@ package reviewme.highlight.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,8 +18,9 @@ public class HighlightController {
 
     private final HighlightService highlightService;
 
-    @PostMapping("/v2/highlight")
+    @PostMapping("/v2/groups/{reviewGroupId}/highlight")
     public ResponseEntity<Void> highlight(
+            @PathVariable long reviewGroupId,
             @Valid @RequestBody HighlightsRequest request,
             @ReviewGroupSession ReviewGroup reviewGroup
     ) {

--- a/backend/src/main/java/reviewme/review/controller/ReviewController.java
+++ b/backend/src/main/java/reviewme/review/controller/ReviewController.java
@@ -39,8 +39,9 @@ public class ReviewController {
         return ResponseEntity.created(URI.create("/reviews/" + savedReviewId)).build();
     }
 
-    @GetMapping("/v2/reviews")
+    @GetMapping("/v2/groups/{reviewGroupId}/reviews")
     public ResponseEntity<ReceivedReviewsResponse> findReceivedReviews(
+            @PathVariable long reviewGroupId,
             @RequestParam(required = false) Long lastReviewId,
             @RequestParam(required = false) Integer size,
             @ReviewGroupSession ReviewGroup reviewGroup
@@ -58,16 +59,18 @@ public class ReviewController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/v2/reviews/summary")
+    @GetMapping("/v2/groups/{reviewGroupId}/reviews/summary")
     public ResponseEntity<ReceivedReviewsSummaryResponse> findReceivedReviewOverview(
+            @PathVariable long reviewGroupId,
             @ReviewGroupSession ReviewGroup reviewGroup
     ) {
         ReceivedReviewsSummaryResponse response = reviewSummaryService.getReviewSummary(reviewGroup);
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/v2/reviews/gather")
+    @GetMapping("/v2/groups/{reviewGroupId}/reviews/gather")
     public ResponseEntity<ReviewsGatheredBySectionResponse> getReceivedReviewsBySectionId(
+            @PathVariable long reviewGroupId,
             @RequestParam("sectionId") long sectionId,
             @ReviewGroupSession ReviewGroup reviewGroup
     ) {

--- a/backend/src/main/java/reviewme/reviewgroup/controller/ReviewGroupController.java
+++ b/backend/src/main/java/reviewme/reviewgroup/controller/ReviewGroupController.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -24,8 +25,10 @@ public class ReviewGroupController {
     private final ReviewGroupService reviewGroupService;
     private final ReviewGroupLookupService reviewGroupLookupService;
 
-    @GetMapping("/v2/groups")
-    public ResponseEntity<ReviewGroupResponse> getReviewGroupSummary(@RequestParam String reviewRequestCode) {
+    @GetMapping("/v2/groups/{reviewGroupId}")
+    public ResponseEntity<ReviewGroupResponse> getReviewGroupSummary(
+            @PathVariable long reviewGroupId,
+            @RequestParam String reviewRequestCode) {
         ReviewGroupResponse response = reviewGroupLookupService.getReviewGroupSummary(reviewRequestCode);
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/reviewme/template/controller/SectionController.java
+++ b/backend/src/main/java/reviewme/template/controller/SectionController.java
@@ -3,6 +3,7 @@ package reviewme.template.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 import reviewme.reviewgroup.controller.ReviewGroupSession;
 import reviewme.reviewgroup.domain.ReviewGroup;
@@ -15,8 +16,9 @@ public class SectionController {
 
     private final SectionService sectionService;
 
-    @GetMapping("/v2/sections")
+    @GetMapping("/v2/groups/{reviewGroupId}/sections")
     public ResponseEntity<SectionNamesResponse> getSectionNames(
+            @PathVariable long reviewGroupId,
             @ReviewGroupSession ReviewGroup reviewGroup
     ) {
         SectionNamesResponse sectionNames = sectionService.getSectionNames(reviewGroup);

--- a/backend/src/test/java/reviewme/api/HighlightApiTest.java
+++ b/backend/src/test/java/reviewme/api/HighlightApiTest.java
@@ -54,7 +54,7 @@ class HighlightApiTest extends ApiTest {
         givenWithSpec().log().all()
                 .cookie("JSESSIONID", "AVEBNKLCL13TNVZ")
                 .body(request)
-                .when().post("/v2/highlight")
+                .when().post("/v2/groups/1/highlight")
                 .then().log().all()
                 .apply(handler)
                 .status(HttpStatus.OK);

--- a/backend/src/test/java/reviewme/api/ReviewApiTest.java
+++ b/backend/src/test/java/reviewme/api/ReviewApiTest.java
@@ -216,7 +216,7 @@ class ReviewApiTest extends ApiTest {
                 .queryParam("reviewRequestCode", "hello!!")
                 .queryParam("lastReviewId", "2")
                 .queryParam("size", "5")
-                .when().get("/v2/reviews")
+                .when().get("/v2/groups/1/reviews")
                 .then().log().all()
                 .apply(handler)
                 .statusCode(200);
@@ -245,7 +245,7 @@ class ReviewApiTest extends ApiTest {
 
         givenWithSpec().log().all()
                 .cookie("JSESSIONID", "ABCDEFGHI1234")
-                .when().get("/v2/reviews/summary")
+                .when().get("/v2/groups/1/reviews/summary")
                 .then().log().all()
                 .apply(handler)
                 .statusCode(200);
@@ -309,7 +309,7 @@ class ReviewApiTest extends ApiTest {
         givenWithSpec().log().all()
                 .cookie("JSESSIONID", "ABCDEFGHI1234")
                 .queryParam("sectionId", 1)
-                .when().get("/v2/reviews/gather")
+                .when().get("/v2/groups/1/reviews/gather")
                 .then().log().all()
                 .apply(handler)
                 .statusCode(200);

--- a/backend/src/test/java/reviewme/api/ReviewGroupApiTest.java
+++ b/backend/src/test/java/reviewme/api/ReviewGroupApiTest.java
@@ -83,7 +83,7 @@ class ReviewGroupApiTest extends ApiTest {
 
         givenWithSpec().log().all()
                 .queryParam("reviewRequestCode", "ABCD1234")
-                .when().get("/v2/groups")
+                .when().get("/v2/groups/1")
                 .then().log().all()
                 .apply(handler)
                 .statusCode(200);

--- a/backend/src/test/java/reviewme/api/TemplateApiTest.java
+++ b/backend/src/test/java/reviewme/api/TemplateApiTest.java
@@ -122,7 +122,7 @@ class TemplateApiTest extends ApiTest {
         );
         givenWithSpec().log().all()
                 .cookie("JSESSIONID", "ABCDEFGHI1234")
-                .when().get("/v2/sections")
+                .when().get("/v2/groups/1/sections")
                 .then().log().all()
                 .apply(handler)
                 .statusCode(200);


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #1048 

---

### 🚀 어떤 기능을 구현했나요 ?
- 로그인 체계를 구상하다가 우리가 아주 중요한 것을 놓치고 있다는 것을 알게되었습니다💀
- 이전까지는 세션으로 ReviewGroup이 식별되었으나, 회원이 도입되면서 세션 : 리뷰그룹 이 1:1대응이 되지 않게 되었습니다.
그래서 몇가지 api 에 ❗️리뷰 그룹에 대한 정보를 추가해야 합니다❗️
예를 들어 하이라이트를 추가하는 POST /highlight의 경우,
회원이 이를 호출한다고 하면 "**어떤 리뷰 그룹(프로젝트)에 대한 하이라이트 추가인지**"를 전달해줄 정보가 필요합니다.
변경이 필요한 uri 들은 아래와 같습니다. 
    - 형광펜 하이라이트 : POST /highlight → `/groups/{id}/highlight`
    - 받은 리뷰 목록 조회 : GET /reviews → `/groups/{id}/reviews`
    - 받은 리뷰 요약 조회 : GET /reviews/summary → `/groups/{id}/reviews/summary`
    - 받은 리뷰 섹션 별 모아보기 : GET /reviews/gather → `/groups/{id}/reviews/gather`
    - 리뷰 그룹 요약 조회 : GET /groups → `/groups/{id}`
    - 섹션 이름 조회 : GET /sections → `/groups/{id}/sections`

### 🔥 어떻게 해결했나요 ?
- 어떻게 group에 대한 정보를 전달하게 할지 고민을 많이 했습니다. 시도해봤던 것들은 아래와 같습니다.
1. PathVariable : 가장 먼저 떠올린 방법입니다. 형광펜, 리뷰, 섹션 모두 리뷰그룹의 하위에 있다고 생각해서, 계층적인 uri 를 잘 나타낸다고 생각했습니다. 막상 적용해보니 `/groups/1/sections` 처럼 다소 uri 가 길어지는 단점이 있었으나, 이정도는 넘어갈만 하다 생각합니다. 그리고 위 6개의 api 들에 모두 적용될 수 있다는 점도 장점입니다. 통일감은 중요한 요소이니깐요.
2. RequestBody : 하이라이트 요청같은 경우, 정말 적합하다 생각했는데, GET에 사용할 수 없어서 소거했습니다.
3. RequestParam : ?groupId=1  과 같이 직접 붙여서 확인해보니 다소 어색한 감이 있었습니다.. RequestParam은 원래 필터링이나 페이징에 사용된다고 생각해서 그랬었고, 예를 들어 받은 리뷰 조회의 경우 GET /reviews?groupId=1 보다 GET groups/1/reviews 가 더 적절해보였습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- uri 가 적절한지 확인해주세요.

### 📚 참고 자료, 할 말
- 바뀐 비지니스 로직도 적용해야 하니 할 일이 산더미입니다.. 🏔️🌋🗻
간단한 PR이니 이번 코드리뷰는 속도감 있게 갔으면 좋겠습니다.
- `리뷰 그룹 요약 조회 : GET /groups` 부분이 커,테가 작업한 부분이랑 겹칩니다. 아마 테스트 코드에서 컨틀릭 날거예요.
뭘 먼저 머지하던지 리베이스한 다음 해소하고 머지해야 합니다.