### PR TITLE
[FE] feat : 이미지 스켈레톤 적용

### DIFF
--- a/frontend/src/components/index.tsx
+++ b/frontend/src/components/index.tsx
@@ -3,3 +3,4 @@ export * from './common';
 export * from './error';
 export * from './highlight/components';
 export * from './login';
+export * from './skeleton';

--- a/frontend/src/components/skeleton/ImgWithSkeleton/index.tsx
+++ b/frontend/src/components/skeleton/ImgWithSkeleton/index.tsx
@@ -23,7 +23,7 @@ const ImgWithSkeleton = ({ children, imgWidth, imgHeight }: ImgWithSkeletonProps
       {!isLoaded && <S.ImgSkeleton />}
       <S.ImgWrapper $isLoaded={isLoaded}>
         {React.cloneElement(children, {
-          onLoad: (event) => handleImgLoad(event),
+          onLoad: (event: React.SyntheticEvent<HTMLImageElement, Event>) => handleImgLoad(event),
         })}
       </S.ImgWrapper>
     </S.Container>

--- a/frontend/src/components/skeleton/ImgWithSkeleton/index.tsx
+++ b/frontend/src/components/skeleton/ImgWithSkeleton/index.tsx
@@ -11,7 +11,10 @@ interface ImgWithSkeletonProps {
 const ImgWithSkeleton = ({ children, imgWidth, imgHeight }: ImgWithSkeletonProps) => {
   const [isLoaded, setIsLoaded] = useState(false);
 
-  const handleImgLoad = () => {
+  const handleImgLoad = (event: React.SyntheticEvent<HTMLImageElement, Event>) => {
+    if (children.props.onLoad) {
+      children.props.onLoad(event);
+    }
     setIsLoaded(true);
   };
 
@@ -20,7 +23,7 @@ const ImgWithSkeleton = ({ children, imgWidth, imgHeight }: ImgWithSkeletonProps
       {!isLoaded && <S.ImgSkeleton />}
       <S.ImgWrapper $isLoaded={isLoaded}>
         {React.cloneElement(children, {
-          onLoad: handleImgLoad,
+          onLoad: (event) => handleImgLoad(event),
         })}
       </S.ImgWrapper>
     </S.Container>

--- a/frontend/src/components/skeleton/ImgWithSkeleton/index.tsx
+++ b/frontend/src/components/skeleton/ImgWithSkeleton/index.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+
+import * as S from './style';
+
+interface ImgWithSkeletonProps {
+  children: React.ReactElement<React.ImgHTMLAttributes<HTMLImageElement>>;
+  imgWidth: string;
+  imgHeight: string;
+}
+
+const ImgWithSkeleton = ({ children, imgWidth, imgHeight }: ImgWithSkeletonProps) => {
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  const handleImgLoad = () => {
+    setIsLoaded(true);
+  };
+
+  return (
+    <S.Container $width={imgWidth} $height={imgHeight}>
+      {!isLoaded && <S.ImgSkeleton />}
+      <S.ImgWrapper $isLoaded={isLoaded}>
+        {React.cloneElement(children, {
+          onLoad: handleImgLoad,
+        })}
+      </S.ImgWrapper>
+    </S.Container>
+  );
+};
+
+export default ImgWithSkeleton;

--- a/frontend/src/components/skeleton/ImgWithSkeleton/style.ts
+++ b/frontend/src/components/skeleton/ImgWithSkeleton/style.ts
@@ -10,7 +10,7 @@ export const Container = styled.div<ContainerProps>`
   height: ${(props) => props.$height};
 `;
 export const ImgWrapper = styled.div<{ $isLoaded: boolean }>`
-  position: 'absolute';
+  position: absolute;
   top: 0;
   left: 0;
 
@@ -28,7 +28,7 @@ export const ImgSkeleton = styled.div`
   background-image: linear-gradient(
     135deg,
     ${({ theme }) => theme.colors.lightGray} 40%,
-    rgba(246, 246, 246, 0.76) 50%,
+    rgba(246, 246, 246, 0.89) 50%,
     ${({ theme }) => theme.colors.lightGray} 85%
   );
   background-size: 200% 100%;

--- a/frontend/src/components/skeleton/ImgWithSkeleton/style.ts
+++ b/frontend/src/components/skeleton/ImgWithSkeleton/style.ts
@@ -1,0 +1,47 @@
+import styled from '@emotion/styled';
+
+interface ContainerProps {
+  $width: string;
+  $height: string;
+}
+export const Container = styled.div<ContainerProps>`
+  position: relative;
+  width: ${(props) => props.$width};
+  height: ${(props) => props.$height};
+`;
+export const ImgWrapper = styled.div<{ $isLoaded: boolean }>`
+  position: 'absolute';
+  top: 0;
+  left: 0;
+
+  width: 100%;
+  height: 100%;
+
+  opacity: ${(props) => (props.$isLoaded ? 1 : 0)};
+
+  transition: opacity 300ms;
+`;
+export const ImgSkeleton = styled.div`
+  width: 100%;
+  height: 100%;
+
+  background-image: linear-gradient(
+    135deg,
+    ${({ theme }) => theme.colors.lightGray} 40%,
+    rgba(246, 246, 246, 0.76) 50%,
+    ${({ theme }) => theme.colors.lightGray} 85%
+  );
+  background-size: 200% 100%;
+  border-radius: ${({ theme }) => theme.borderRadius.basic};
+
+  animation: skeleton-animation 1.5s infinite linear;
+
+  @keyframes skeleton-animation {
+    0% {
+      background-position: 200% 0;
+    }
+    100% {
+      background-position: -200% 0;
+    }
+  }
+`;

--- a/frontend/src/components/skeleton/index.tsx
+++ b/frontend/src/components/skeleton/index.tsx
@@ -1,0 +1,1 @@
+export { default as ImgWithSkeleton } from './ImgWithSkeleton';

--- a/frontend/src/pages/HomePage/components/InfinityCarousel/index.tsx
+++ b/frontend/src/pages/HomePage/components/InfinityCarousel/index.tsx
@@ -2,7 +2,10 @@ import { useRef, useState, useEffect } from 'react';
 
 import nextArrowIcon from '@/assets/nextArrow.svg';
 import prevArrowIcon from '@/assets/prevArrow.svg';
+import { ImgWithSkeleton } from '@/components';
 import { breakpoints } from '@/styles/theme';
+
+import useSlideImgSize from '../../hooks/useSlideImgSize';
 
 import * as S from './styles';
 
@@ -37,6 +40,7 @@ const InfinityCarousel = ({ slideList }: InfinityCarouselProps) => {
   const [deltaX, setDeltaX] = useState(0); // 현재 드래그 중인 위치와 시작 위치 사이의 차이
 
   const slideRef = useRef<HTMLDivElement>(null);
+  const { imgSize } = useSlideImgSize({ slideRef });
 
   const slideLength = slideList.length;
   // 첫 슬라이드와 마지막 슬라이드의 복제본을 각각 맨 뒤, 맨 처음에 추가
@@ -151,7 +155,9 @@ const InfinityCarousel = ({ slideList }: InfinityCarouselProps) => {
         {clonedSlideList.map((slide, index) => (
           <S.SlideItem key={index}>
             <S.SlideContent>
-              <img src={slide.imageSrc} alt={slide.alt} />
+              <ImgWithSkeleton imgHeight={imgSize.height} imgWidth={imgSize.width}>
+                <S.SlideContentImg src={slide.imageSrc} alt={slide.alt} />
+              </ImgWithSkeleton>
             </S.SlideContent>
           </S.SlideItem>
         ))}

--- a/frontend/src/pages/HomePage/components/InfinityCarousel/styles.ts
+++ b/frontend/src/pages/HomePage/components/InfinityCarousel/styles.ts
@@ -46,10 +46,10 @@ export const SlideContent = styled.div`
   justify-content: space-between;
 
   width: 100%;
+`;
 
-  img {
-    width: 80%;
-  }
+export const SlideContentImg = styled.img`
+  width: 100%;
 `;
 
 export const PrevButton = styled.button`

--- a/frontend/src/pages/HomePage/hooks/useSlideImgSize.tsx
+++ b/frontend/src/pages/HomePage/hooks/useSlideImgSize.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+
+import { debounce } from '@/utils';
+
+const DEBOUNCE_TIME = 300;
+
+interface UseSlideImgSizeProps {
+  slideRef: React.RefObject<HTMLDivElement>;
+}
+const useSlideImgSize = ({ slideRef }: UseSlideImgSizeProps) => {
+  interface ImgSize {
+    width: string;
+    height: string;
+  }
+  const [imgSize, setImgSize] = useState<ImgSize>({ width: '', height: '' });
+
+  const updateImgSize = () => {
+    if (!slideRef.current) return;
+    const slideDomRect = slideRef.current.getBoundingClientRect();
+    const width = Math.ceil(slideDomRect.width * 0.8 * 0.1);
+    const height = width * 0.61;
+    setImgSize({ width: `${width}rem`, height: `${height}rem` });
+  };
+  const debouncedUpdateImgSize = debounce(updateImgSize, DEBOUNCE_TIME);
+
+  useEffect(() => {
+    updateImgSize();
+    document.addEventListener('resize', debouncedUpdateImgSize);
+
+    return () => {
+      document.removeEventListener('resize', debouncedUpdateImgSize);
+    };
+  }, [slideRef]);
+
+  return { imgSize };
+};
+
+export default useSlideImgSize;

--- a/frontend/src/pages/HomePage/hooks/useSlideImgSize.tsx
+++ b/frontend/src/pages/HomePage/hooks/useSlideImgSize.tsx
@@ -16,15 +16,19 @@ const useSlideImgSize = ({ slideRef }: UseSlideImgSizeProps) => {
 
   const updateImgSize = () => {
     if (!slideRef.current) return;
+
     const slideDomRect = slideRef.current.getBoundingClientRect();
     const width = Math.ceil(slideDomRect.width * 0.8 * 0.1);
     const height = width * 0.61;
+
     setImgSize({ width: `${width}rem`, height: `${height}rem` });
   };
+
   const debouncedUpdateImgSize = debounce(updateImgSize, DEBOUNCE_TIME);
 
   useEffect(() => {
     updateImgSize();
+
     document.addEventListener('resize', debouncedUpdateImgSize);
 
     return () => {

--- a/frontend/src/pages/ReviewZonePage/index.tsx
+++ b/frontend/src/pages/ReviewZonePage/index.tsx
@@ -4,8 +4,7 @@ import { useRecoilState } from 'recoil';
 
 import ReviewZoneIcon from '@/assets/reviewZone.svg';
 import { Button, ImgWithSkeleton } from '@/components';
-// TODO: ROUTE 상수명을 단수로 고치기
-import { ROUTE } from '@/constants/route';
+import { ROUTE } from '@/constants';
 import { useGetReviewGroupData, useSearchParamAndQuery, useModals } from '@/hooks';
 import { reviewRequestCodeAtom } from '@/recoil';
 import { calculateParticle } from '@/utils';

--- a/frontend/src/pages/ReviewZonePage/index.tsx
+++ b/frontend/src/pages/ReviewZonePage/index.tsx
@@ -3,7 +3,8 @@ import { useNavigate } from 'react-router';
 import { useRecoilState } from 'recoil';
 
 import ReviewZoneIcon from '@/assets/reviewZone.svg';
-import { Button } from '@/components';
+import { Button, ImgWithSkeleton } from '@/components';
+// TODO: ROUTE 상수명을 단수로 고치기
 import { ROUTE } from '@/constants/route';
 import { useGetReviewGroupData, useSearchParamAndQuery, useModals } from '@/hooks';
 import { reviewRequestCodeAtom } from '@/recoil';
@@ -15,6 +16,11 @@ import * as S from './styles';
 const MODAL_KEYS = {
   content: 'CONTENT_MODAL',
 };
+const BUTTON_SIZE = {
+  width: '28rem',
+  height: '8.5rem',
+};
+const IMG_HEIGHT = '15rem';
 
 const ReviewZonePage = () => {
   const { isOpen, openModal, closeModal } = useModals();
@@ -46,29 +52,21 @@ const ReviewZonePage = () => {
 
   return (
     <S.ReviewZonePage>
-      <S.ReviewZoneMainImg src={ReviewZoneIcon} alt="" />
+      <ImgWithSkeleton imgWidth={BUTTON_SIZE.width} imgHeight={IMG_HEIGHT}>
+        <S.ReviewZoneMainImg src={ReviewZoneIcon} alt="" $height={IMG_HEIGHT} />
+      </ImgWithSkeleton>
       <S.ReviewGuideContainer>
         <S.ReviewGuide>{`${reviewGroupData.projectName}${calculateParticle({ target: reviewGroupData.projectName, particles: { withFinalConsonant: '을', withoutFinalConsonant: '를' } })} 함께한`}</S.ReviewGuide>
         <S.ReviewGuide>{`${reviewGroupData.revieweeName}의 리뷰 공간이에요`}</S.ReviewGuide>
       </S.ReviewGuideContainer>
       <S.ButtonContainer>
-        <Button
-          styleType="primary"
-          type="button"
-          onClick={handleReviewWritingButtonClick}
-          style={{ width: '28rem', height: '8.5rem' }}
-        >
+        <Button styleType="primary" type="button" onClick={handleReviewWritingButtonClick} style={BUTTON_SIZE}>
           <S.ButtonTextContainer>
             <S.ButtonText>리뷰 쓰기</S.ButtonText>
             <S.ButtonDescription>작성한 리뷰는 익명으로 제출돼요</S.ButtonDescription>
           </S.ButtonTextContainer>
         </Button>
-        <Button
-          styleType="secondary"
-          type="button"
-          onClick={handleReviewListButtonClick}
-          style={{ width: '28rem', height: '8.5rem' }}
-        >
+        <Button styleType="secondary" type="button" onClick={handleReviewListButtonClick} style={BUTTON_SIZE}>
           <S.ButtonTextContainer>
             <S.ButtonText>리뷰 확인하기</S.ButtonText>
             <S.ButtonDescription>비밀번호로 내가 받은 리뷰를 확인할 수 있어요</S.ButtonDescription>

--- a/frontend/src/pages/ReviewZonePage/styles.ts
+++ b/frontend/src/pages/ReviewZonePage/styles.ts
@@ -14,9 +14,9 @@ export const ReviewZonePage = styled.div`
   justify-content: center;
 `;
 
-export const ReviewZoneMainImg = styled.img`
+export const ReviewZoneMainImg = styled.img<{ $height: string }>`
   width: 43rem;
-  height: 23rem;
+  height: ${(props) => props.$height};
 `;
 
 export const ReviewGuideContainer = styled.div`
@@ -25,6 +25,7 @@ export const ReviewGuideContainer = styled.div`
   align-items: center;
   justify-content: center;
 
+  margin-top: 3rem;
   padding-left: 0.2rem;
 `;
 


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #1054

---

### 🚀 어떤 기능을 구현했나요 ?
- 이미지를 children으로 받아서, 해당 이미지 로드하는 동안 스켈레톤을 띄우는 컴포넌트를 구현했어요.
- 구현한 컴포넌트를 이미지 로딩 시간이 걸리는 홈 페이지 캐러셀, 리뷰 연결 페이지 이미지에 모두 적용했어요. 

#### 이미지 사이즈
이미지에 대한 자유로운 스타일링과 기존에 사용된 이미지에 적용을 위해, children으로 이미지를 받아오도록 했어요. 

다만, 스켈레톤이 화면에 제대로 표시되기 위해 이미지 로드되기 전부터 해당 이미지 사이즈가 필요했어요. 그래서 width, height를 사이즈로 받아오도록 했어요. 

### 🔥 어떻게 해결했나요 ?
- 로컬에서 작업하면 이미지 로딩 속도가 빨라서 임의로 setTimeout으로 로드 속도를 지연시켜서 테스트했어요. 
#### 홈 페이지 캐러셀에 스켈레톤 적용 화면

https://github.com/user-attachments/assets/db5d9327-1849-48b6-bde9-3633b2dc52fd

#### 리뷰 연결 페이지에 스켈레톤 적용 화면

https://github.com/user-attachments/assets/1eb2318d-d870-41e0-8e4c-8d512fb0d89d

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
#### 스켈레톤 디자인
사전에 디자인 회의가 없어서, 제가 임의로 스타일링 했어요. 이에 대한 팀원들 의견이 궁금해요. 
 
- 스켈레톤에 많이 사용하는 회색톤(기존에 theme에 설정된 lightGray)를 사용했어요. 
- 단색으로 했다가, 애니메이션을 추가해서 이미지 로드될 동안 덜 지루하게/무언가가 진행되고 있다라는 느낌을 주었어요. 

### 📚 참고 자료, 할 말
