### PR TITLE
[BE] chore: 롬복 설정에서 불필요한 부분 제거

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.1'
-    id 'io.spring.dependency-management' version '1.1.5'
     id "org.asciidoctor.jvm.convert" version "3.3.2"
 }
 
@@ -15,9 +14,6 @@ java {
 }
 
 configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
-    }
     asciidoctorExt
 }
 
@@ -45,9 +41,10 @@ dependencies {
     testRuntimeOnly 'com.h2database:h2'
 
     // Lombok
+    compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.projectlombok:lombok'
 
     // RestDocs
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.1'
+    id 'io.spring.dependency-management' version '1.1.5'
     id "org.asciidoctor.jvm.convert" version "3.3.2"
 }
 


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #1066 

---

### 🚀 어떤 기능을 구현했나요 ?
- 롬복은 컴파일 환경에서 annotationProcessor에 의해 설정되므로, testImplementation은 불필요합니다.
-  추가로 compileOnly가 annotationProcessor를 상속받도록 되어있는데, 이부분은 롬복에서만 사용되고 있습니다. test관련 configuration과 통일성을 갖게하기 위해서 상속방식을 사용하지 않는 것으로 변경했습니다.

### 🔥 어떻게 해결했나요 ?
- 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 롬복이 런타임 패키징에 포함되는 것이 치명적이지는 않지만, 불필요한 부분이라 생각되어 변경했습니다.

### 📚 참고 자료, 할 말
