### PR TITLE
[FE] refactor : 회원 전용 페이지 path 수정

### DIFF
--- a/frontend/src/constants/amplitudeEventName.ts
+++ b/frontend/src/constants/amplitudeEventName.ts
@@ -24,8 +24,8 @@ export const PAGE_VISITED_EVENT_NAME: { [key in Exclude<PageName, undefined>]: s
   detailedReview: '[page] 리뷰 상세 보기 페이지',
   reviewWriting: '[page] 리뷰 작성 페이지',
   reviewWritingComplete: '[page] 리뷰 작성 완료 페이지',
-  reviewLinks: '[page] 리뷰 링크 관리 페이지',
-  writtenReview: '[page] 작성한 리뷰 확인 페이지',
+  reviewLinks: '[page] 회원 전용 - 리뷰 링크 관리 페이지',
+  writtenReview: '[page] 회원 전용 - 작성한 리뷰 확인 페이지',
 };
 
 export const REVIEW_WRITING_EVENT_NAME = {

--- a/frontend/src/constants/route.ts
+++ b/frontend/src/constants/route.ts
@@ -1,12 +1,13 @@
-// TODO: ROUTE -> ROUTE 및 상수 인덱스에 추가하기
+import { gettingPath } from '@/utils';
+
 export const ROUTE = {
   home: '/',
-  reviewList: 'user/review-list',
-  reviewWriting: 'user/review-writing',
-  reviewWritingComplete: 'user/review-writing-complete',
-  detailedReview: 'user/detailed-review',
-  reviewZone: 'user/review-zone',
-  reviewCollection: 'user/review-collection',
-  reviewLinks: 'user/review-links',
-  writtenReview: 'user/written-review',
+  reviewList: gettingPath('review-list'),
+  reviewWriting: gettingPath('review-writing'),
+  reviewWritingComplete: gettingPath('review-writing-complete'),
+  detailedReview: gettingPath('detailed-review'),
+  reviewZone: gettingPath('review-zone'),
+  reviewCollection: gettingPath('review-collection'),
+  reviewLinks: gettingPath('review-links', true),
+  writtenReview: gettingPath('written-review', true),
 };

--- a/frontend/src/constants/route.ts
+++ b/frontend/src/constants/route.ts
@@ -1,13 +1,13 @@
-import { gettingPath } from '@/utils';
+import { makeRoutePath } from '@/utils';
 
 export const ROUTE = {
   home: '/',
-  reviewList: gettingPath('review-list'),
-  reviewWriting: gettingPath('review-writing'),
-  reviewWritingComplete: gettingPath('review-writing-complete'),
-  detailedReview: gettingPath('detailed-review'),
-  reviewZone: gettingPath('review-zone'),
-  reviewCollection: gettingPath('review-collection'),
-  reviewLinks: gettingPath('review-links', true),
-  writtenReview: gettingPath('written-review', true),
+  reviewList: makeRoutePath('review-list'),
+  reviewWriting: makeRoutePath('review-writing'),
+  reviewWritingComplete: makeRoutePath('review-writing-complete'),
+  detailedReview: makeRoutePath('detailed-review'),
+  reviewZone: makeRoutePath('review-zone'),
+  reviewCollection: makeRoutePath('review-collection'),
+  reviewLinks: makeRoutePath('review-links', true),
+  writtenReview: makeRoutePath('written-review', true),
 };

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -13,3 +13,4 @@ export * from './highlight/index';
 export * from './testUtils';
 export * from './analytics';
 export * from './validateInput';
+export * from './path';

--- a/frontend/src/utils/path.ts
+++ b/frontend/src/utils/path.ts
@@ -1,4 +1,4 @@
-export const gettingPath = (pageName: string, isForMember: boolean = false) => {
+export const makeRoutePath = (pageName: string, isForMember: boolean = false) => {
   let basic = 'user';
   if (isForMember) basic += '/logged-in';
   return `${basic}/${pageName}`;

--- a/frontend/src/utils/path.ts
+++ b/frontend/src/utils/path.ts
@@ -1,0 +1,5 @@
+export const gettingPath = (pageName: string, isForMember: boolean = false) => {
+  let basic = 'user';
+  if (isForMember) basic += '/logged-in';
+  return `${basic}/${pageName}`;
+};


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #1069

---

### 🚀 어떤 기능을 구현했나요 ?
- 로그인 후 접근해야하는 페이지를 간별할 수 있게 회원 전용 페이지 path에 'logged-in'을 추가했습니다. 
- `makeRoutePath` 유틸함수를 만들어서 보다 편리하게 path를 추가/변경할 수 있도록 했습니다. 


### 📚 참고 자료, 할 말
- 비로그인 시, 회원 전용 페이지에 접근한 경우 접근 권한 메세지를 보여주고 로그인을 유도하는 UI는 로그인 구현해야해요. 로그인 구현 시, 로그인 된 상태를 어떻게 처리하는 가를 함께 고려해야해서 현재 작업에는 포함되지 않았습니다.