### PR TITLE
[BE] refactor: 기존 api가 리뷰 그룹 정보를 포함하도록 수정

### DIFF
--- a/backend/src/main/java/reviewme/highlight/controller/HighlightController.java
+++ b/backend/src/main/java/reviewme/highlight/controller/HighlightController.java
@@ -19,10 +19,9 @@ public class HighlightController {
 
     @PostMapping("/v2/highlight")
     public ResponseEntity<Void> highlight(
-            @Valid @RequestBody HighlightsRequest request,
-            @ReviewGroupSession ReviewGroup reviewGroup
+            @Valid @RequestBody HighlightsRequest request
     ) {
-        highlightService.editHighlight(request, reviewGroup);
+        highlightService.editHighlight(request);
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/reviewme/highlight/service/HighlightService.java
+++ b/backend/src/main/java/reviewme/highlight/service/HighlightService.java
@@ -10,18 +10,23 @@ import reviewme.highlight.service.dto.HighlightsRequest;
 import reviewme.highlight.service.mapper.HighlightMapper;
 import reviewme.review.service.validator.AnswerValidator;
 import reviewme.reviewgroup.domain.ReviewGroup;
+import reviewme.reviewgroup.domain.exception.ReviewGroupNotFoundException;
+import reviewme.reviewgroup.repository.ReviewGroupRepository;
 
 @Service
 @RequiredArgsConstructor
 public class HighlightService {
 
     private final HighlightRepository highlightRepository;
+    private final ReviewGroupRepository reviewGroupRepository;
 
     private final HighlightMapper highlightMapper;
     private final AnswerValidator answerValidator;
 
     @Transactional
-    public void editHighlight(HighlightsRequest highlightsRequest, ReviewGroup reviewGroup) {
+    public void editHighlight(HighlightsRequest highlightsRequest) {
+        ReviewGroup reviewGroup = reviewGroupRepository.findById(highlightsRequest.reviewGroupId())
+                .orElseThrow(() -> new ReviewGroupNotFoundException(highlightsRequest.reviewGroupId()));
         List<Long> requestedAnswerIds = highlightsRequest.getUniqueAnswerIds();
         answerValidator.validateQuestionContainsAnswers(highlightsRequest.questionId(), requestedAnswerIds);
         answerValidator.validateReviewGroupContainsAnswers(reviewGroup, requestedAnswerIds);

--- a/backend/src/main/java/reviewme/highlight/service/dto/HighlightsRequest.java
+++ b/backend/src/main/java/reviewme/highlight/service/dto/HighlightsRequest.java
@@ -7,6 +7,9 @@ import reviewme.highlight.service.mapper.HighlightFragment;
 
 public record HighlightsRequest(
 
+        @NotNull(message = "리뷰 그룹 ID를 입력해주세요.")
+        Long reviewGroupId,
+
         @NotNull(message = "질문 ID를 입력해주세요.")
         Long questionId,
 

--- a/backend/src/main/java/reviewme/review/controller/ReviewController.java
+++ b/backend/src/main/java/reviewme/review/controller/ReviewController.java
@@ -50,13 +50,13 @@ public class ReviewController {
         return ResponseEntity.created(URI.create("/reviews/" + savedReviewId)).build();
     }
 
-    @GetMapping("/v2/reviews/received")
+    @GetMapping("/v2/groups/{reviewGroupId}/reviews/received")
     public ResponseEntity<ReceivedReviewPageResponse> findReceivedReviews(
+            @PathVariable long reviewGroupId,
             @RequestParam(required = false) Long lastReviewId,
-            @RequestParam(required = false) Integer size,
-            @ReviewGroupSession ReviewGroup reviewGroup
+            @RequestParam(required = false) Integer size
     ) {
-        ReceivedReviewPageResponse response = reviewListLookupService.getReceivedReviews(lastReviewId, size, reviewGroup);
+        ReceivedReviewPageResponse response = reviewListLookupService.getReceivedReviews(reviewGroupId, lastReviewId, size);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/reviewme/review/controller/ReviewController.java
+++ b/backend/src/main/java/reviewme/review/controller/ReviewController.java
@@ -69,11 +69,11 @@ public class ReviewController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/v2/reviews/summary")
+    @GetMapping("/v2/groups/{reviewGroupId}/reviews/summary")
     public ResponseEntity<ReceivedReviewsSummaryResponse> findReceivedReviewOverview(
-            @ReviewGroupSession ReviewGroup reviewGroup
+            @PathVariable long reviewGroupId
     ) {
-        ReceivedReviewsSummaryResponse response = reviewSummaryService.getReviewSummary(reviewGroup);
+        ReceivedReviewsSummaryResponse response = reviewSummaryService.getReviewSummary(reviewGroupId);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/reviewme/review/controller/ReviewController.java
+++ b/backend/src/main/java/reviewme/review/controller/ReviewController.java
@@ -77,13 +77,13 @@ public class ReviewController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/v2/reviews/gather")
+    @GetMapping("/v2/groups/{reviewGroupId}/reviews/gather")
     public ResponseEntity<ReviewsGatheredBySectionResponse> getReceivedReviewsBySectionId(
-            @RequestParam("sectionId") long sectionId,
-            @ReviewGroupSession ReviewGroup reviewGroup
+            @PathVariable long reviewGroupId,
+            @RequestParam("sectionId") long sectionId
     ) {
         ReviewsGatheredBySectionResponse response =
-                reviewGatheredLookupService.getReceivedReviewsBySectionId(reviewGroup, sectionId);
+                reviewGatheredLookupService.getReceivedReviewsBySectionId(reviewGroupId, sectionId);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/reviewme/review/service/ReviewGatheredLookupService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewGatheredLookupService.java
@@ -9,15 +9,17 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import reviewme.highlight.domain.Highlight;
 import reviewme.highlight.repository.HighlightRepository;
-import reviewme.template.domain.Question;
-import reviewme.template.repository.QuestionRepository;
 import reviewme.review.domain.Answer;
 import reviewme.review.repository.AnswerRepository;
 import reviewme.review.service.dto.response.gathered.ReviewsGatheredBySectionResponse;
 import reviewme.review.service.exception.SectionNotFoundInTemplateException;
 import reviewme.review.service.mapper.ReviewGatherMapper;
 import reviewme.reviewgroup.domain.ReviewGroup;
+import reviewme.reviewgroup.domain.exception.ReviewGroupNotFoundException;
+import reviewme.reviewgroup.repository.ReviewGroupRepository;
+import reviewme.template.domain.Question;
 import reviewme.template.domain.Section;
+import reviewme.template.repository.QuestionRepository;
 import reviewme.template.repository.SectionRepository;
 
 @Service
@@ -32,9 +34,12 @@ public class ReviewGatheredLookupService {
     private final HighlightRepository highlightRepository;
 
     private final ReviewGatherMapper reviewGatherMapper;
+    private final ReviewGroupRepository reviewGroupRepository;
 
     @Transactional(readOnly = true)
-    public ReviewsGatheredBySectionResponse getReceivedReviewsBySectionId(ReviewGroup reviewGroup, long sectionId) {
+    public ReviewsGatheredBySectionResponse getReceivedReviewsBySectionId(long reviewGroupId, long sectionId) {
+        ReviewGroup reviewGroup = reviewGroupRepository.findById(reviewGroupId)
+                .orElseThrow(() -> new ReviewGroupNotFoundException(reviewGroupId));
         Section section = getSectionOrThrow(sectionId, reviewGroup);
         Map<Question, List<Answer>> questionAnswers = getQuestionAnswers(section, reviewGroup);
 

--- a/backend/src/main/java/reviewme/review/service/ReviewListLookupService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewListLookupService.java
@@ -10,6 +10,8 @@ import reviewme.review.service.dto.response.list.ReceivedReviewPageResponse;
 import reviewme.review.service.dto.response.list.ReceivedReviewPageElementResponse;
 import reviewme.review.service.mapper.ReviewListMapper;
 import reviewme.reviewgroup.domain.ReviewGroup;
+import reviewme.reviewgroup.domain.exception.ReviewGroupNotFoundException;
+import reviewme.reviewgroup.repository.ReviewGroupRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -17,9 +19,12 @@ public class ReviewListLookupService {
 
     private final ReviewRepository reviewRepository;
     private final ReviewListMapper reviewListMapper;
+    private final ReviewGroupRepository reviewGroupRepository;
 
     @Transactional(readOnly = true)
-    public ReceivedReviewPageResponse getReceivedReviews(Long lastReviewId, Integer size, ReviewGroup reviewGroup) {
+    public ReceivedReviewPageResponse getReceivedReviews(long reviewGroupId, Long lastReviewId, Integer size) {
+        ReviewGroup reviewGroup = reviewGroupRepository.findById(reviewGroupId)
+                .orElseThrow(() -> new ReviewGroupNotFoundException(reviewGroupId));
         PageSize pageSize = new PageSize(size);
         List<ReceivedReviewPageElementResponse> reviewListResponse
                 = reviewListMapper.mapToReviewList(reviewGroup, lastReviewId, pageSize.getSize());

--- a/backend/src/main/java/reviewme/review/service/ReviewSummaryService.java
+++ b/backend/src/main/java/reviewme/review/service/ReviewSummaryService.java
@@ -6,16 +6,21 @@ import org.springframework.transaction.annotation.Transactional;
 import reviewme.review.repository.ReviewRepository;
 import reviewme.review.service.dto.response.list.ReceivedReviewsSummaryResponse;
 import reviewme.reviewgroup.domain.ReviewGroup;
+import reviewme.reviewgroup.domain.exception.ReviewGroupNotFoundException;
+import reviewme.reviewgroup.repository.ReviewGroupRepository;
 
 @Service
 @RequiredArgsConstructor
 public class ReviewSummaryService {
 
     private final ReviewRepository reviewRepository;
+    private final ReviewGroupRepository reviewGroupRepository;
 
     @Transactional(readOnly = true)
-    public ReceivedReviewsSummaryResponse getReviewSummary(ReviewGroup reviewGroup) {
-        int totalReviewCount = reviewRepository.countByReviewGroupId(reviewGroup.getId());
+    public ReceivedReviewsSummaryResponse getReviewSummary(long reviewGroupId) {
+        ReviewGroup reviewGroup = reviewGroupRepository.findById(reviewGroupId)
+                .orElseThrow(() -> new ReviewGroupNotFoundException(reviewGroupId));
+        int totalReviewCount = reviewRepository.countByReviewGroupId(reviewGroupId);
 
         return new ReceivedReviewsSummaryResponse(
                 reviewGroup.getProjectName(),

--- a/backend/src/main/java/reviewme/reviewgroup/controller/ReviewGroupController.java
+++ b/backend/src/main/java/reviewme/reviewgroup/controller/ReviewGroupController.java
@@ -13,7 +13,7 @@ import reviewme.reviewgroup.service.ReviewGroupService;
 import reviewme.reviewgroup.service.dto.ReviewGroupCreationRequest;
 import reviewme.reviewgroup.service.dto.ReviewGroupCreationResponse;
 import reviewme.reviewgroup.service.dto.ReviewGroupPageResponse;
-import reviewme.reviewgroup.service.dto.ReviewGroupResponse;
+import reviewme.reviewgroup.service.dto.ReviewGroupSummaryResponse;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,8 +23,8 @@ public class ReviewGroupController {
     private final ReviewGroupLookupService reviewGroupLookupService;
 
     @GetMapping("/v2/groups/summary")
-    public ResponseEntity<ReviewGroupResponse> getReviewGroupSummary(@RequestParam String reviewRequestCode) {
-        ReviewGroupResponse response = reviewGroupLookupService.getReviewGroupSummary(reviewRequestCode);
+    public ResponseEntity<ReviewGroupSummaryResponse> getReviewGroupSummary(@RequestParam String reviewRequestCode) {
+        ReviewGroupSummaryResponse response = reviewGroupLookupService.getReviewGroupSummary(reviewRequestCode);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/reviewme/reviewgroup/domain/exception/ReviewGroupNotFoundException.java
+++ b/backend/src/main/java/reviewme/reviewgroup/domain/exception/ReviewGroupNotFoundException.java
@@ -1,0 +1,13 @@
+package reviewme.reviewgroup.domain.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import reviewme.global.exception.NotFoundException;
+
+@Slf4j
+public class ReviewGroupNotFoundException extends NotFoundException {
+
+    public ReviewGroupNotFoundException(long reviewGroupId) {
+        super("리뷰 그룹을 찾을 수 없어요.");
+        log.info("Can't find review group - reviewGroupId: {}", reviewGroupId);
+    }
+}

--- a/backend/src/main/java/reviewme/reviewgroup/service/ReviewGroupLookupService.java
+++ b/backend/src/main/java/reviewme/reviewgroup/service/ReviewGroupLookupService.java
@@ -7,7 +7,7 @@ import reviewme.reviewgroup.service.dto.ReviewGroupPageResponse;
 import reviewme.reviewgroup.service.exception.ReviewGroupNotFoundByReviewRequestCodeException;
 import reviewme.reviewgroup.domain.ReviewGroup;
 import reviewme.reviewgroup.repository.ReviewGroupRepository;
-import reviewme.reviewgroup.service.dto.ReviewGroupResponse;
+import reviewme.reviewgroup.service.dto.ReviewGroupSummaryResponse;
 
 @Service
 @RequiredArgsConstructor
@@ -16,11 +16,12 @@ public class ReviewGroupLookupService {
     private final ReviewGroupRepository reviewGroupRepository;
 
     @Transactional(readOnly = true)
-    public ReviewGroupResponse getReviewGroupSummary(String reviewRequestCode) {
+    public ReviewGroupSummaryResponse getReviewGroupSummary(String reviewRequestCode) {
         ReviewGroup reviewGroup = reviewGroupRepository.findByReviewRequestCode(reviewRequestCode)
                 .orElseThrow(() -> new ReviewGroupNotFoundByReviewRequestCodeException(reviewRequestCode));
 
-        return new ReviewGroupResponse(null, reviewGroup.getReviewee(), reviewGroup.getProjectName());
+        // todo: 리뷰어 id 가 있다면 같이 응답해야 함
+        return new ReviewGroupSummaryResponse(null, reviewGroup.getReviewee(), reviewGroup.getProjectName());
     }
 
     public ReviewGroupPageResponse getMyReviewGroups() {

--- a/backend/src/main/java/reviewme/reviewgroup/service/ReviewGroupService.java
+++ b/backend/src/main/java/reviewme/reviewgroup/service/ReviewGroupService.java
@@ -7,6 +7,7 @@ import reviewme.reviewgroup.domain.ReviewGroup;
 import reviewme.reviewgroup.repository.ReviewGroupRepository;
 import reviewme.reviewgroup.service.dto.ReviewGroupCreationRequest;
 import reviewme.reviewgroup.service.dto.ReviewGroupCreationResponse;
+import reviewme.reviewgroup.service.exception.GroupAccessCodeNullException;
 import reviewme.reviewgroup.service.exception.ReviewGroupNotFoundByReviewRequestCodeException;
 import reviewme.template.domain.Template;
 import reviewme.template.service.DefaultTemplateService;

--- a/backend/src/main/java/reviewme/reviewgroup/service/ReviewGroupService.java
+++ b/backend/src/main/java/reviewme/reviewgroup/service/ReviewGroupService.java
@@ -7,29 +7,25 @@ import reviewme.reviewgroup.domain.ReviewGroup;
 import reviewme.reviewgroup.repository.ReviewGroupRepository;
 import reviewme.reviewgroup.service.dto.ReviewGroupCreationRequest;
 import reviewme.reviewgroup.service.dto.ReviewGroupCreationResponse;
-import reviewme.reviewgroup.service.exception.GroupAccessCodeNullException;
 import reviewme.reviewgroup.service.exception.ReviewGroupNotFoundByReviewRequestCodeException;
 import reviewme.template.domain.Template;
-import reviewme.template.repository.TemplateRepository;
-import reviewme.template.service.exception.TemplateNotFoundException;
+import reviewme.template.service.DefaultTemplateService;
 
 @Service
 @RequiredArgsConstructor
 public class ReviewGroupService {
 
     private static final int REVIEW_REQUEST_CODE_LENGTH = 8;
-    private static final long DEFAULT_TEMPLATE_ID = 1L;
 
     private final ReviewGroupRepository reviewGroupRepository;
     private final RandomCodeGenerator randomCodeGenerator;
-    private final TemplateRepository templateRepository;
+    private final DefaultTemplateService defaultTemplateService;
 
     @Transactional
     public ReviewGroupCreationResponse createReviewGroup(ReviewGroupCreationRequest request, Long memberId) {
         String reviewRequestCode = generateReviewRequestCode();
 
-        Template template = templateRepository.findById(DEFAULT_TEMPLATE_ID)
-                .orElseThrow(() -> new TemplateNotFoundException(DEFAULT_TEMPLATE_ID));
+        Template template = defaultTemplateService.getDefaultTemplate();
 
         ReviewGroup reviewGroup;
         if (memberId != null) {

--- a/backend/src/main/java/reviewme/reviewgroup/service/dto/ReviewGroupSummaryResponse.java
+++ b/backend/src/main/java/reviewme/reviewgroup/service/dto/ReviewGroupSummaryResponse.java
@@ -2,7 +2,7 @@ package reviewme.reviewgroup.service.dto;
 
 import jakarta.annotation.Nullable;
 
-public record ReviewGroupResponse(
+public record ReviewGroupSummaryResponse(
 
         @Nullable Long revieweeId,
         String revieweeName,

--- a/backend/src/main/java/reviewme/template/controller/SectionController.java
+++ b/backend/src/main/java/reviewme/template/controller/SectionController.java
@@ -4,8 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
-import reviewme.reviewgroup.controller.ReviewGroupSession;
-import reviewme.reviewgroup.domain.ReviewGroup;
 import reviewme.template.service.TemplateService;
 import reviewme.template.service.dto.response.SectionNamesResponse;
 
@@ -16,10 +14,8 @@ public class SectionController {
     private final TemplateService templateService;
 
     @GetMapping("/v2/sections")
-    public ResponseEntity<SectionNamesResponse> getSectionNames(
-            @ReviewGroupSession ReviewGroup reviewGroup
-    ) {
-        SectionNamesResponse sectionNames = templateService.getSectionNames(reviewGroup);
+    public ResponseEntity<SectionNamesResponse> getSectionNames() {
+        SectionNamesResponse sectionNames = templateService.getSectionNames();
         return ResponseEntity.ok(sectionNames);
     }
 }

--- a/backend/src/main/java/reviewme/template/service/DefaultTemplateService.java
+++ b/backend/src/main/java/reviewme/template/service/DefaultTemplateService.java
@@ -1,0 +1,23 @@
+package reviewme.template.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import reviewme.template.domain.Template;
+import reviewme.template.repository.TemplateRepository;
+import reviewme.template.service.exception.DefaultTemplateNotFoundException;
+
+@Service
+@RequiredArgsConstructor
+public class DefaultTemplateService {
+
+    private static final long DEFAULT_TEMPLATE_Id = 1L;
+
+    private final TemplateRepository templateRepository;
+
+    @Transactional(readOnly = true)
+    public Template getDefaultTemplate() {
+        return templateRepository.findById(DEFAULT_TEMPLATE_Id)
+                .orElseThrow(() -> new DefaultTemplateNotFoundException(DEFAULT_TEMPLATE_Id));
+    }
+}

--- a/backend/src/main/java/reviewme/template/service/TemplateService.java
+++ b/backend/src/main/java/reviewme/template/service/TemplateService.java
@@ -16,6 +16,7 @@ import reviewme.template.service.exception.TemplateNotFoundByReviewGroupExceptio
 public class TemplateService {
 
     private final ReviewGroupService reviewGroupService;
+    private final DefaultTemplateService defaultTemplateService;
     private final TemplateRepository templateRepository;
 
     @Transactional(readOnly = true)
@@ -29,11 +30,8 @@ public class TemplateService {
     }
 
     @Transactional(readOnly = true)
-    public SectionNamesResponse getSectionNames(ReviewGroup reviewGroup) {
-        Template template = templateRepository.findById(reviewGroup.getTemplateId())
-                .orElseThrow(() -> new TemplateNotFoundByReviewGroupException(
-                        reviewGroup.getId(), reviewGroup.getTemplateId())
-                );
+    public SectionNamesResponse getSectionNames() {
+        Template template = defaultTemplateService.getDefaultTemplate();
         return SectionNamesResponse.from(template);
     }
 }

--- a/backend/src/main/java/reviewme/template/service/exception/DefaultTemplateNotFoundException.java
+++ b/backend/src/main/java/reviewme/template/service/exception/DefaultTemplateNotFoundException.java
@@ -4,10 +4,10 @@ import lombok.extern.slf4j.Slf4j;
 import reviewme.global.exception.DataInconsistencyException;
 
 @Slf4j
-public class TemplateNotFoundException extends DataInconsistencyException {
+public class DefaultTemplateNotFoundException extends DataInconsistencyException {
 
-    public TemplateNotFoundException(long templateId) {
+    public DefaultTemplateNotFoundException(long templateId) {
         super("서버 내부에서 문제가 발생했어요. 서버에 문의해주세요.");
-        log.error("Template not found - templateId: {}", templateId, this);
+        log.error("Default template not found - templateId: {}", templateId, this);
     }
 }

--- a/backend/src/test/java/reviewme/api/HighlightApiTest.java
+++ b/backend/src/test/java/reviewme/api/HighlightApiTest.java
@@ -18,6 +18,7 @@ class HighlightApiTest extends ApiTest {
     void 존재하는_답변에_하이라이트를_생성한다() {
         String request = """
                  {
+                     "reviewGroupId": 1,
                      "questionId": 1,
                      "highlights": [{
                        "answerId": 3,
@@ -37,6 +38,7 @@ class HighlightApiTest extends ApiTest {
         };
 
         FieldDescriptor[] requestFields = {
+                fieldWithPath("reviewGroupId").description("리뷰 그룹 ID"),
                 fieldWithPath("questionId").description("질문 ID"),
                 fieldWithPath("highlights").description("하이라이트 목록"),
                 fieldWithPath("highlights[].answerId").description("답변 ID"),

--- a/backend/src/test/java/reviewme/api/ReviewApiTest.java
+++ b/backend/src/test/java/reviewme/api/ReviewApiTest.java
@@ -211,11 +211,15 @@ class ReviewApiTest extends ApiTest {
         );
         ReceivedReviewPageResponse response = new ReceivedReviewPageResponse(
                 "아루3", "리뷰미", 1L, true, receivedReviews);
-        BDDMockito.given(reviewListLookupService.getReceivedReviews(anyLong(), anyInt(), any()))
+        BDDMockito.given(reviewListLookupService.getReceivedReviews(anyLong(), anyLong(), anyInt()))
                 .willReturn(response);
 
         CookieDescriptor[] cookieDescriptors = {
                 cookieWithName("JSESSIONID").description("세션 ID")
+        };
+
+        ParameterDescriptor[] requestPathDescriptors = {
+                parameterWithName("reviewGroupId").description("리뷰 그룹 ID")
         };
 
         ParameterDescriptor[] queryParameter = {
@@ -242,17 +246,19 @@ class ReviewApiTest extends ApiTest {
 
         RestDocumentationResultHandler handler = document(
                 "received-review-list-with-pagination",
+                pathParameters(requestPathDescriptors),
                 requestCookies(cookieDescriptors),
                 queryParameters(queryParameter),
                 responseFields(responseFieldDescriptors)
         );
 
         givenWithSpec().log().all()
+                .pathParam("reviewGroupId", "1")
                 .cookie("JSESSIONID", "ASVNE1VAKDNV4")
                 .queryParam("reviewRequestCode", "hello!!")
                 .queryParam("lastReviewId", "2")
                 .queryParam("size", "5")
-                .when().get("/v2/reviews/received")
+                .when().get("/v2/groups/{reviewGroupId}/reviews/received")
                 .then().log().all()
                 .apply(handler)
                 .statusCode(200);

--- a/backend/src/test/java/reviewme/api/ReviewApiTest.java
+++ b/backend/src/test/java/reviewme/api/ReviewApiTest.java
@@ -317,11 +317,14 @@ class ReviewApiTest extends ApiTest {
                                 new VoteResponse("짜장", 3),
                                 new VoteResponse("짬뽕", 5))))
         );
-        BDDMockito.given(reviewGatheredLookupService.getReceivedReviewsBySectionId(any(), anyLong()))
+        BDDMockito.given(reviewGatheredLookupService.getReceivedReviewsBySectionId(anyLong(), anyLong()))
                 .willReturn(response);
 
         CookieDescriptor[] cookieDescriptors = {
                 cookieWithName("JSESSIONID").description("세션 ID")
+        };
+        ParameterDescriptor[] requestPathDescriptors = {
+                parameterWithName("reviewGroupId").description("리뷰 그룹 ID")
         };
         ParameterDescriptor[] queryParameterDescriptors = {
                 parameterWithName("sectionId").description("섹션 ID")
@@ -348,15 +351,17 @@ class ReviewApiTest extends ApiTest {
         };
         RestDocumentationResultHandler handler = document(
                 "received-review-by-section",
+                pathParameters(requestPathDescriptors),
                 requestCookies(cookieDescriptors),
                 queryParameters(queryParameterDescriptors),
                 responseFields(responseFieldDescriptors)
         );
 
         givenWithSpec().log().all()
+                .pathParam("reviewGroupId", "1")
                 .cookie("JSESSIONID", "ABCDEFGHI1234")
                 .queryParam("sectionId", 1)
-                .when().get("/v2/reviews/gather")
+                .when().get("/v2/groups/{reviewGroupId}/reviews/gather")
                 .then().log().all()
                 .apply(handler)
                 .statusCode(200);

--- a/backend/src/test/java/reviewme/api/ReviewApiTest.java
+++ b/backend/src/test/java/reviewme/api/ReviewApiTest.java
@@ -266,11 +266,14 @@ class ReviewApiTest extends ApiTest {
 
     @Test
     void 자신이_받은_리뷰의_요약를_조회한다() {
-        BDDMockito.given(reviewSummaryService.getReviewSummary(any()))
+        BDDMockito.given(reviewSummaryService.getReviewSummary(anyLong()))
                 .willReturn(new ReceivedReviewsSummaryResponse("리뷰미", "산초", 5));
 
         CookieDescriptor[] cookieDescriptors = {
                 cookieWithName("JSESSIONID").description("세션 ID")
+        };
+        ParameterDescriptor[] requestPathDescriptors = {
+                parameterWithName("reviewGroupId").description("리뷰 그룹 ID")
         };
 
         FieldDescriptor[] responseFieldDescriptors = {
@@ -281,13 +284,15 @@ class ReviewApiTest extends ApiTest {
 
         RestDocumentationResultHandler handler = document(
                 "received-review-summary",
+                pathParameters(requestPathDescriptors),
                 requestCookies(cookieDescriptors),
                 responseFields(responseFieldDescriptors)
         );
 
         givenWithSpec().log().all()
+                .pathParam("reviewGroupId", "1")
                 .cookie("JSESSIONID", "ABCDEFGHI1234")
-                .when().get("/v2/reviews/summary")
+                .when().get("/v2/groups/{reviewGroupId}/reviews/summary")
                 .then().log().all()
                 .apply(handler)
                 .statusCode(200);

--- a/backend/src/test/java/reviewme/api/ReviewGroupApiTest.java
+++ b/backend/src/test/java/reviewme/api/ReviewGroupApiTest.java
@@ -25,7 +25,7 @@ import reviewme.reviewgroup.service.dto.ReviewGroupCreationRequest;
 import reviewme.reviewgroup.service.dto.ReviewGroupCreationResponse;
 import reviewme.reviewgroup.service.dto.ReviewGroupPageElementResponse;
 import reviewme.reviewgroup.service.dto.ReviewGroupPageResponse;
-import reviewme.reviewgroup.service.dto.ReviewGroupResponse;
+import reviewme.reviewgroup.service.dto.ReviewGroupSummaryResponse;
 
 class ReviewGroupApiTest extends ApiTest {
 
@@ -110,7 +110,7 @@ class ReviewGroupApiTest extends ApiTest {
     @Test
     void 리뷰_요청_코드로_회원이_만든_리뷰_그룹_정보를_반환한다() {
         BDDMockito.given(reviewGroupLookupService.getReviewGroupSummary(anyString()))
-                .willReturn(new ReviewGroupResponse(1L, "아루", "리뷰미"));
+                .willReturn(new ReviewGroupSummaryResponse(1L,"아루", "리뷰미"));
 
         ParameterDescriptor[] parameterDescriptors = {
                 parameterWithName("reviewRequestCode").description("리뷰 요청 코드")
@@ -139,7 +139,7 @@ class ReviewGroupApiTest extends ApiTest {
     @Test
     void 리뷰_요청_코드로_비회원이_만든_리뷰_그룹_정보를_반환한다() {
         BDDMockito.given(reviewGroupLookupService.getReviewGroupSummary(anyString()))
-                .willReturn(new ReviewGroupResponse(null, "아루", "리뷰미"));
+                .willReturn(new ReviewGroupSummaryResponse(null, "아루", "리뷰미"));
 
         ParameterDescriptor[] parameterDescriptors = {
                 parameterWithName("reviewRequestCode").description("리뷰 요청 코드")

--- a/backend/src/test/java/reviewme/api/TemplateApiTest.java
+++ b/backend/src/test/java/reviewme/api/TemplateApiTest.java
@@ -1,6 +1,5 @@
 package reviewme.api;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
 import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
@@ -104,7 +103,7 @@ class TemplateApiTest extends ApiTest {
                 new SectionNameResponse(1, "섹션1 이름"),
                 new SectionNameResponse(2, "섹션2 이름")
         ));
-        BDDMockito.given(templateService.getSectionNames(any()))
+        BDDMockito.given(templateService.getSectionNames())
                 .willReturn(response);
 
         CookieDescriptor[] cookieDescriptors = {

--- a/backend/src/test/java/reviewme/highlight/service/HighlightServiceTest.java
+++ b/backend/src/test/java/reviewme/highlight/service/HighlightServiceTest.java
@@ -61,10 +61,12 @@ class HighlightServiceTest {
         HighlightIndexRangeRequest indexRangeRequest = new HighlightIndexRangeRequest(1, 1);
         HighlightedLineRequest lineRequest = new HighlightedLineRequest(0, List.of(indexRangeRequest));
         HighlightRequest highlightRequest1 = new HighlightRequest(textAnswer2.getId(), List.of(lineRequest));
-        HighlightsRequest highlightsRequest = new HighlightsRequest(question.getId(), List.of(highlightRequest1));
+        HighlightsRequest highlightsRequest = new HighlightsRequest(
+                reviewGroup.getId(), question.getId(), List.of(highlightRequest1
+        ));
 
         // when
-        highlightService.editHighlight(highlightsRequest, reviewGroup);
+        highlightService.editHighlight(highlightsRequest);
 
         // then
         assertAll(() -> assertThat(highlightRepository.existsById(highlight.getId())).isFalse());
@@ -87,10 +89,12 @@ class HighlightServiceTest {
         HighlightIndexRangeRequest indexRangeRequest = new HighlightIndexRangeRequest(startIndex, endIndex);
         HighlightedLineRequest lineRequest = new HighlightedLineRequest(0, List.of(indexRangeRequest));
         HighlightRequest highlightRequest = new HighlightRequest(textAnswer.getId(), List.of(lineRequest));
-        HighlightsRequest highlightsRequest = new HighlightsRequest(question.getId(), List.of(highlightRequest));
+        HighlightsRequest highlightsRequest = new HighlightsRequest(
+                reviewGroup.getId(), question.getId(), List.of(highlightRequest)
+        );
 
         // when
-        highlightService.editHighlight(highlightsRequest, reviewGroup);
+        highlightService.editHighlight(highlightsRequest);
 
         // then
         List<Highlight> highlights = highlightRepository.findAllByAnswerIdsOrderedAsc(List.of(textAnswer.getId()));
@@ -113,10 +117,10 @@ class HighlightServiceTest {
         reviewRepository.save(비회원_작성_리뷰(template.getId(), reviewGroup.getId(), List.of(textAnswer)));
         Highlight highlight = highlightRepository.save(new Highlight(textAnswer.getId(), 1, new HighlightRange(1, 1)));
 
-        HighlightsRequest highlightsRequest = new HighlightsRequest(question.getId(), List.of());
+        HighlightsRequest highlightsRequest = new HighlightsRequest(reviewGroup.getId(), question.getId(), List.of());
 
         // when
-        highlightService.editHighlight(highlightsRequest, reviewGroup);
+        highlightService.editHighlight(highlightsRequest);
 
         // then
         assertAll(() -> assertThat(highlightRepository.existsById(highlight.getId())).isFalse());

--- a/backend/src/test/java/reviewme/highlight/service/mapper/HighlightMapperTest.java
+++ b/backend/src/test/java/reviewme/highlight/service/mapper/HighlightMapperTest.java
@@ -67,6 +67,7 @@ class HighlightMapperTest {
         HighlightRequest highlightRequest1 = new HighlightRequest(textAnswer1.getId(), List.of(lineRequest1));
         HighlightRequest highlightRequest2 = new HighlightRequest(textAnswer2.getId(), List.of(lineRequest2));
         HighlightsRequest highlightsRequest = new HighlightsRequest(
+                reviewGroupId,
                 question.getId(),
                 List.of(highlightRequest1, highlightRequest2)
         );
@@ -87,7 +88,7 @@ class HighlightMapperTest {
     @Test
     void 하이라이트_할_내용이_없는_요청이_오면_매핑_결과_빈_리스트를_반환한다() {
         // given
-        HighlightsRequest highlightsRequest = new HighlightsRequest(1L, List.of());
+        HighlightsRequest highlightsRequest = new HighlightsRequest(1L, 1L, List.of());
 
         // when
         List<Highlight> highlights = highlightMapper.mapToHighlights(highlightsRequest);

--- a/backend/src/test/java/reviewme/review/service/ReviewGatheredLookupServiceTest.java
+++ b/backend/src/test/java/reviewme/review/service/ReviewGatheredLookupServiceTest.java
@@ -80,7 +80,7 @@ class ReviewGatheredLookupServiceTest {
 
             // when
             ReviewsGatheredBySectionResponse actual = reviewLookupService.getReceivedReviewsBySectionId(
-                    reviewGroup, section1.getId()
+                    reviewGroup.getId(), section1.getId()
             );
 
             // then
@@ -111,7 +111,7 @@ class ReviewGatheredLookupServiceTest {
 
             // when
             ReviewsGatheredBySectionResponse actual = reviewLookupService.getReceivedReviewsBySectionId(
-                    reviewGroup, section1.getId()
+                    reviewGroup.getId(), section1.getId()
             );
 
             // then
@@ -137,7 +137,7 @@ class ReviewGatheredLookupServiceTest {
 
             // when
             ReviewsGatheredBySectionResponse actual = reviewLookupService.getReceivedReviewsBySectionId(
-                    reviewGroup, section1.getId()
+                    reviewGroup.getId(), section1.getId()
             );
 
             // then
@@ -158,7 +158,7 @@ class ReviewGatheredLookupServiceTest {
 
             // when
             ReviewsGatheredBySectionResponse actual = reviewLookupService.getReceivedReviewsBySectionId(
-                    reviewGroup, section1.getId()
+                    reviewGroup.getId(), section1.getId()
             );
 
             // then
@@ -193,7 +193,7 @@ class ReviewGatheredLookupServiceTest {
 
             // when
             ReviewsGatheredBySectionResponse actual = reviewLookupService.getReceivedReviewsBySectionId(
-                    reviewGroup, section1.getId()
+                    reviewGroup.getId(), section1.getId()
             );
 
             // then
@@ -222,7 +222,7 @@ class ReviewGatheredLookupServiceTest {
 
             // when
             ReviewsGatheredBySectionResponse actual = reviewLookupService.getReceivedReviewsBySectionId(
-                    reviewGroup, section1.getId()
+                    reviewGroup.getId(), section1.getId()
             );
 
             // then
@@ -253,7 +253,7 @@ class ReviewGatheredLookupServiceTest {
 
         // when
         ReviewsGatheredBySectionResponse actual = reviewLookupService.getReceivedReviewsBySectionId(
-                reviewGroup, section1.getId()
+                reviewGroup.getId(), section1.getId()
         );
 
         // then
@@ -294,7 +294,7 @@ class ReviewGatheredLookupServiceTest {
 
         // when
         ReviewsGatheredBySectionResponse actual = reviewLookupService.getReceivedReviewsBySectionId(
-                reviewGroupBE, section1.getId());
+                reviewGroupBE.getId(), section1.getId());
 
         // then
         assertThat(actual.reviews()).hasSize(1);
@@ -312,7 +312,7 @@ class ReviewGatheredLookupServiceTest {
 
         // when
         ReviewsGatheredBySectionResponse actual = reviewLookupService.getReceivedReviewsBySectionId(
-                reviewGroup, section1.getId()
+                reviewGroup.getId(), section1.getId()
         );
 
         // then

--- a/backend/src/test/java/reviewme/review/service/ReviewListLookupServiceTest.java
+++ b/backend/src/test/java/reviewme/review/service/ReviewListLookupServiceTest.java
@@ -43,7 +43,7 @@ class ReviewListLookupServiceTest {
 
         // when
         ReceivedReviewPageResponse response = reviewListLookupService.getReceivedReviews(
-                Long.MAX_VALUE, 5, reviewGroup
+                reviewGroup.getId(), Long.MAX_VALUE, 5
         );
 
         // then
@@ -68,7 +68,7 @@ class ReviewListLookupServiceTest {
 
         // when
         ReceivedReviewPageResponse response
-                = reviewListLookupService.getReceivedReviews(Long.MAX_VALUE, 2, reviewGroup);
+                = reviewListLookupService.getReceivedReviews(reviewGroup.getId(), Long.MAX_VALUE, 2);
 
         // then
         assertAll(

--- a/backend/src/test/java/reviewme/review/service/ReviewSummaryServiceTest.java
+++ b/backend/src/test/java/reviewme/review/service/ReviewSummaryServiceTest.java
@@ -55,7 +55,7 @@ class ReviewSummaryServiceTest {
         reviewRepository.save(비회원_작성_리뷰(template.getId(), reviewGroup2.getId(), List.of()));
 
         // when
-        ReceivedReviewsSummaryResponse actual = reviewSummaryService.getReviewSummary(reviewGroup1);
+        ReceivedReviewsSummaryResponse actual = reviewSummaryService.getReviewSummary(reviewGroup1.getId());
 
         // then
         assertAll(

--- a/backend/src/test/java/reviewme/reviewgroup/service/ReviewGroupLookupServiceTest.java
+++ b/backend/src/test/java/reviewme/reviewgroup/service/ReviewGroupLookupServiceTest.java
@@ -9,7 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import reviewme.reviewgroup.service.exception.ReviewGroupNotFoundByReviewRequestCodeException;
 import reviewme.reviewgroup.domain.ReviewGroup;
 import reviewme.reviewgroup.repository.ReviewGroupRepository;
-import reviewme.reviewgroup.service.dto.ReviewGroupResponse;
+import reviewme.reviewgroup.service.dto.ReviewGroupSummaryResponse;
 import reviewme.support.ServiceTest;
 
 @ServiceTest
@@ -33,7 +33,7 @@ class ReviewGroupLookupServiceTest {
         ));
 
         // when
-        ReviewGroupResponse response = reviewGroupLookupService.getReviewGroupSummary(
+        ReviewGroupSummaryResponse response = reviewGroupLookupService.getReviewGroupSummary(
                 reviewGroup.getReviewRequestCode()
         );
 

--- a/backend/src/test/java/reviewme/template/service/DefaultTemplateServiceTest.java
+++ b/backend/src/test/java/reviewme/template/service/DefaultTemplateServiceTest.java
@@ -1,0 +1,52 @@
+package reviewme.template.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reviewme.template.domain.Template;
+import reviewme.template.repository.TemplateRepository;
+import reviewme.template.service.exception.DefaultTemplateNotFoundException;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultTemplateServiceTest {
+
+    @InjectMocks
+    private DefaultTemplateService defaultTemplateService;
+
+    @Mock
+    private TemplateRepository templateRepository;
+
+    @Test
+    void 기본_템플릿을_반환한다() {
+        // given
+        Template defaultTemplate = mock(Template.class);
+        given(templateRepository.findById(anyLong()))
+                .willReturn(Optional.of(defaultTemplate));
+
+        // when
+        Template actual = defaultTemplateService.getDefaultTemplate();
+
+        // then
+        assertThat(actual).isEqualTo(defaultTemplate);
+    }
+
+    @Test
+    void 기본_템플릿이_없으면_예외가_발생한다() {
+        // given
+        given(templateRepository.findById(anyLong()))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatCode(() -> defaultTemplateService.getDefaultTemplate())
+                .isInstanceOf(DefaultTemplateNotFoundException.class);
+    }
+}

--- a/backend/src/test/java/reviewme/template/service/TemplateServiceTest.java
+++ b/backend/src/test/java/reviewme/template/service/TemplateServiceTest.java
@@ -56,7 +56,7 @@ class TemplateServiceTest {
         ReviewGroup reviewGroup = reviewGroupRepository.save(템플릿_지정_리뷰_그룹(template.getId()));
 
         // when
-        SectionNamesResponse actual = templateService.getSectionNames(reviewGroup);
+        SectionNamesResponse actual = templateService.getSectionNames();
 
         // then
         assertThat(actual.sections()).extracting(SectionNameResponse::name)


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #1048 

---

### 🚀 어떤 기능을 구현했나요 ?
- 기존 api 에 리뷰 그룹 정보가 담기도록 했습니다.

### 🔥 어떻게 해결했나요 ?
- 회의 내용을 바탕으로 구현하고 다시 PR 열었습니다 ㅎㅎ

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- ❗️DefaultTemplateService 괜찮나요?❗️