### PR TITLE
[BE] refactor: 비회원 인증을 Auth에서 하도록 변경

### DIFF
--- a/backend/src/main/java/reviewme/auth/controller/AuthController.java
+++ b/backend/src/main/java/reviewme/auth/controller/AuthController.java
@@ -2,15 +2,18 @@ package reviewme.auth.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import reviewme.auth.domain.GitHubMember;
 import reviewme.auth.service.AuthService;
 import reviewme.global.session.SessionManager;
+import reviewme.reviewgroup.service.dto.CheckValidAccessRequest;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,6 +30,16 @@ public class AuthController {
         GitHubMember gitHubMember = authService.authWithGithub(code);
         sessionManager.saveGitHubMember(session, gitHubMember);
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/v2/auth/review-group")
+    public ResponseEntity<Void> authWithReviewGroup(
+            @Valid @RequestBody CheckValidAccessRequest request,
+            HttpSession session
+    ) {
+        String reviewRequestCode  = authService.authWithReviewGroup(request);
+        sessionManager.saveReviewRequestCode(session, reviewRequestCode);
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/v2/auth/logout")

--- a/backend/src/main/java/reviewme/auth/controller/AuthController.java
+++ b/backend/src/main/java/reviewme/auth/controller/AuthController.java
@@ -29,7 +29,7 @@ public class AuthController {
     ) {
         GitHubMember gitHubMember = authService.authWithGithub(code);
         sessionManager.saveGitHubMember(session, gitHubMember);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/v2/auth/review-group")

--- a/backend/src/main/java/reviewme/auth/service/AuthService.java
+++ b/backend/src/main/java/reviewme/auth/service/AuthService.java
@@ -1,14 +1,18 @@
 
 package reviewme.auth.service;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import reviewme.auth.domain.GitHubMember;
 import reviewme.auth.infrastructure.GitHubOAuthClient;
 import reviewme.auth.infrastructure.dto.response.GitHubUserInfoResponse;
+import reviewme.auth.service.exception.ReviewGroupUnauthorizedException;
 import reviewme.member.domain.Member;
 import reviewme.member.repository.MemberRepository;
+import reviewme.reviewgroup.domain.ReviewGroup;
+import reviewme.reviewgroup.service.ReviewGroupService;
+import reviewme.reviewgroup.service.dto.CheckValidAccessRequest;
 
 @Service
 @RequiredArgsConstructor
@@ -16,6 +20,7 @@ public class AuthService {
 
     private final GitHubOAuthClient githubOAuthClient;
     private final GitHubMemberService gitHubMemberService;
+    private final ReviewGroupService reviewGroupService;
     private final MemberRepository memberRepository;
 
     @Transactional
@@ -28,5 +33,14 @@ public class AuthService {
     private Member getOrSaveMember(String email) {
         return memberRepository.findByEmail(email)
                 .orElseGet(() -> memberRepository.save(new Member(email)));
+    }
+
+    @Transactional(readOnly = true)
+    public String authWithReviewGroup(CheckValidAccessRequest request) {
+        ReviewGroup reviewGroup = reviewGroupService.getReviewGroupByReviewRequestCode(request.reviewRequestCode());
+        if (!reviewGroup.matchesGroupAccessCode(request.groupAccessCode())) {
+            throw new ReviewGroupUnauthorizedException(reviewGroup.getId());
+        }
+        return reviewGroup.getReviewRequestCode();
     }
 }

--- a/backend/src/main/java/reviewme/auth/service/exception/ReviewGroupUnauthorizedException.java
+++ b/backend/src/main/java/reviewme/auth/service/exception/ReviewGroupUnauthorizedException.java
@@ -1,4 +1,4 @@
-package reviewme.reviewgroup.service.exception;
+package reviewme.auth.service.exception;
 
 import lombok.extern.slf4j.Slf4j;
 import reviewme.global.exception.UnauthorizedException;

--- a/backend/src/main/java/reviewme/reviewgroup/controller/ReviewGroupController.java
+++ b/backend/src/main/java/reviewme/reviewgroup/controller/ReviewGroupController.java
@@ -1,7 +1,5 @@
 package reviewme.reviewgroup.controller;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,7 +10,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import reviewme.reviewgroup.service.ReviewGroupLookupService;
 import reviewme.reviewgroup.service.ReviewGroupService;
-import reviewme.reviewgroup.service.dto.CheckValidAccessRequest;
 import reviewme.reviewgroup.service.dto.ReviewGroupCreationRequest;
 import reviewme.reviewgroup.service.dto.ReviewGroupCreationResponse;
 import reviewme.reviewgroup.service.dto.ReviewGroupPageResponse;
@@ -38,17 +35,6 @@ public class ReviewGroupController {
         // 회원 세션 추후 추가해야 함
         ReviewGroupCreationResponse response = reviewGroupService.createReviewGroup(request);
         return ResponseEntity.ok(response);
-    }
-
-    @PostMapping("/v2/groups/check")
-    public ResponseEntity<Void> checkGroupAccessCode(
-            @Valid @RequestBody CheckValidAccessRequest request,
-            HttpServletRequest httpRequest
-    ) {
-        reviewGroupService.checkGroupAccessCode(request);
-        HttpSession session = httpRequest.getSession();
-        session.setAttribute("reviewRequestCode", request.reviewRequestCode());
-        return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/v2/groups")

--- a/backend/src/main/java/reviewme/reviewgroup/service/ReviewGroupService.java
+++ b/backend/src/main/java/reviewme/reviewgroup/service/ReviewGroupService.java
@@ -5,11 +5,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import reviewme.reviewgroup.domain.ReviewGroup;
 import reviewme.reviewgroup.repository.ReviewGroupRepository;
-import reviewme.reviewgroup.service.dto.CheckValidAccessRequest;
 import reviewme.reviewgroup.service.dto.ReviewGroupCreationRequest;
 import reviewme.reviewgroup.service.dto.ReviewGroupCreationResponse;
 import reviewme.reviewgroup.service.exception.ReviewGroupNotFoundByReviewRequestCodeException;
-import reviewme.reviewgroup.service.exception.ReviewGroupUnauthorizedException;
 import reviewme.template.domain.Template;
 import reviewme.template.repository.TemplateRepository;
 import reviewme.template.service.exception.TemplateNotFoundException;
@@ -43,15 +41,6 @@ public class ReviewGroupService {
                 )
         );
         return new ReviewGroupCreationResponse(reviewGroup.getReviewRequestCode());
-    }
-
-    @Transactional(readOnly = true)
-    public void checkGroupAccessCode(CheckValidAccessRequest request) {
-        ReviewGroup reviewGroup = reviewGroupRepository.findByReviewRequestCode(request.reviewRequestCode())
-                .orElseThrow(() -> new ReviewGroupNotFoundByReviewRequestCodeException(request.reviewRequestCode()));
-        if (!reviewGroup.matchesGroupAccessCode(request.groupAccessCode())) {
-            throw new ReviewGroupUnauthorizedException(reviewGroup.getId());
-        }
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/test/java/reviewme/api/AuthApiTest.java
+++ b/backend/src/test/java/reviewme/api/AuthApiTest.java
@@ -2,13 +2,17 @@ package reviewme.api;
 
 import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
 import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
+import static org.springframework.restdocs.cookies.CookieDocumentation.responseCookies;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.restdocs.cookies.CookieDescriptor;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.request.ParameterDescriptor;
 
 public class AuthApiTest extends ApiTest {
@@ -47,6 +51,39 @@ public class AuthApiTest extends ApiTest {
                 .when().post("/v2/auth/logout")
                 .then().log().all()
                 .apply(handler)
+                .statusCode(204);
+    }
+
+    @Test
+    void 리뷰_그룹_액세스_코드로_비회원을_인증한다() {
+        String request = """
+                {
+                    "reviewRequestCode": "ABCD1234",
+                    "groupAccessCode": "00001234"
+                }
+                """;
+
+        FieldDescriptor[] requestFieldDescriptors = {
+                fieldWithPath("reviewRequestCode").description("리뷰 요청 코드"),
+                fieldWithPath("groupAccessCode").description("그룹 접근 코드 (비밀번호)")
+        };
+
+        CookieDescriptor[] cookieDescriptors = {
+                cookieWithName("JSESSIONID").description("세션 ID")
+        };
+
+        RestDocumentationResultHandler handler = document(
+                "review-group-check-access",
+                requestFields(requestFieldDescriptors),
+                responseCookies(cookieDescriptors)
+        );
+
+        givenWithSpec().log().all()
+                .body(request)
+                .when().post("/v2/auth/review-group")
+                .then().log().all()
+                .apply(handler)
+                .cookie("JSESSIONID")
                 .statusCode(204);
     }
 }

--- a/backend/src/test/java/reviewme/api/ReviewGroupApiTest.java
+++ b/backend/src/test/java/reviewme/api/ReviewGroupApiTest.java
@@ -5,7 +5,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
 import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
-import static org.springframework.restdocs.cookies.CookieDocumentation.responseCookies;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
@@ -163,39 +162,6 @@ class ReviewGroupApiTest extends ApiTest {
                 .then().log().all()
                 .apply(handler)
                 .statusCode(200);
-    }
-
-    @Test
-    void 리뷰_그룹_코드와_액세스_코드로_일치_여부를_판단한다() {
-        String request = """
-                {
-                    "reviewRequestCode": "ABCD1234",
-                    "groupAccessCode": "00001234"
-                }
-                """;
-
-        FieldDescriptor[] requestFieldDescriptors = {
-                fieldWithPath("reviewRequestCode").description("리뷰 요청 코드"),
-                fieldWithPath("groupAccessCode").description("그룹 접근 코드 (비밀번호)")
-        };
-
-        CookieDescriptor[] cookieDescriptors = {
-                cookieWithName("JSESSIONID").description("세션 ID")
-        };
-
-        RestDocumentationResultHandler handler = document(
-                "review-group-check-access",
-                requestFields(requestFieldDescriptors),
-                responseCookies(cookieDescriptors)
-        );
-
-        givenWithSpec().log().all()
-                .body(request)
-                .when().post("/v2/groups/check")
-                .then().log().all()
-                .apply(handler)
-                .cookie("JSESSIONID")
-                .statusCode(204);
     }
 
     @Test

--- a/backend/src/test/java/reviewme/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/reviewme/auth/service/AuthServiceTest.java
@@ -1,5 +1,7 @@
 package reviewme.auth.service;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
@@ -11,13 +13,18 @@ import static org.mockito.Mockito.verify;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import reviewme.auth.infrastructure.GitHubOAuthClient;
 import reviewme.auth.infrastructure.dto.response.GitHubUserInfoResponse;
+import reviewme.auth.service.exception.ReviewGroupUnauthorizedException;
 import reviewme.member.domain.Member;
 import reviewme.member.repository.MemberRepository;
+import reviewme.reviewgroup.domain.ReviewGroup;
+import reviewme.reviewgroup.service.ReviewGroupService;
+import reviewme.reviewgroup.service.dto.CheckValidAccessRequest;
 import reviewme.support.ServiceTest;
 
 @ServiceTest
@@ -28,6 +35,9 @@ class AuthServiceTest {
 
     @SpyBean
     private MemberRepository memberRepository;
+
+    @MockBean
+    private ReviewGroupService reviewGroupService;
 
     @MockBean
     private GitHubOAuthClient gitHubOAuthClient;
@@ -67,6 +77,45 @@ class AuthServiceTest {
 
             // then
             verify(memberRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    class 리뷰_그룹의_액세스_코드를_통해_인증한다 {
+
+        private final String reviewRequestCode = "reviewRequestCode";
+        private final String groupAccessCode = "groupAccessCode";
+
+        @Test
+        void 올바른_액세스_코드라면_예외가_발생하지_않는다() {
+            // given
+            ReviewGroup reviewGroup = Mockito.mock(ReviewGroup.class);
+            given(reviewGroup.matchesGroupAccessCode(groupAccessCode)).willReturn(true);
+            given(reviewGroup.getReviewRequestCode()).willReturn(reviewRequestCode);
+
+            given(reviewGroupService.getReviewGroupByReviewRequestCode(reviewRequestCode))
+                    .willReturn(reviewGroup);
+
+            CheckValidAccessRequest request = new CheckValidAccessRequest(reviewRequestCode, groupAccessCode);
+
+            // when & then
+            assertDoesNotThrow(() -> authService.authWithReviewGroup(request));
+        }
+
+        @Test
+        void 잘못된_액세스_코드라면_예외가_발생한다() {
+            // given
+            ReviewGroup reviewGroup = Mockito.mock(ReviewGroup.class);
+            given(reviewGroup.getId()).willReturn(1L);
+
+            given(reviewGroupService.getReviewGroupByReviewRequestCode(reviewRequestCode))
+                    .willReturn(reviewGroup);
+
+            CheckValidAccessRequest wrongRequest = new CheckValidAccessRequest(reviewRequestCode, "wrongCode");
+
+            // when & then
+            assertThatThrownBy(() -> authService.authWithReviewGroup(wrongRequest))
+                    .isInstanceOf(ReviewGroupUnauthorizedException.class);
         }
     }
 }

--- a/backend/src/test/java/reviewme/reviewgroup/service/ReviewGroupServiceTest.java
+++ b/backend/src/test/java/reviewme/reviewgroup/service/ReviewGroupServiceTest.java
@@ -2,8 +2,6 @@ package reviewme.reviewgroup.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -20,11 +18,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import reviewme.reviewgroup.domain.ReviewGroup;
 import reviewme.reviewgroup.repository.ReviewGroupRepository;
-import reviewme.reviewgroup.service.dto.CheckValidAccessRequest;
 import reviewme.reviewgroup.service.dto.ReviewGroupCreationRequest;
 import reviewme.reviewgroup.service.dto.ReviewGroupCreationResponse;
 import reviewme.reviewgroup.service.exception.ReviewGroupNotFoundByReviewRequestCodeException;
-import reviewme.reviewgroup.service.exception.ReviewGroupUnauthorizedException;
 import reviewme.support.ServiceTest;
 import reviewme.template.domain.Question;
 import reviewme.template.domain.Section;
@@ -67,24 +63,6 @@ class ReviewGroupServiceTest {
         // then
         assertThat(response).isEqualTo(new ReviewGroupCreationResponse("AAAA"));
         then(randomCodeGenerator).should(times(2)).generate(anyInt());
-    }
-
-    @Test
-    void 리뷰_요청_코드와_리뷰_확인_코드가_일치하는지_확인한다() {
-        // given
-        String reviewRequestCode = "reviewRequestCode";
-        String groupAccessCode = "groupAccessCode";
-        reviewGroupRepository.save(리뷰_그룹(reviewRequestCode, groupAccessCode));
-
-        CheckValidAccessRequest request = new CheckValidAccessRequest(reviewRequestCode, groupAccessCode);
-        CheckValidAccessRequest wrongRequest = new CheckValidAccessRequest(reviewRequestCode, groupAccessCode + "!");
-
-        // when
-        assertAll(
-                () -> assertDoesNotThrow(() -> reviewGroupService.checkGroupAccessCode(request)),
-                () -> assertThatThrownBy(() -> reviewGroupService.checkGroupAccessCode(wrongRequest))
-                        .isInstanceOf(ReviewGroupUnauthorizedException.class)
-        );
     }
 
     @Test


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #1079 

---

### 🚀 어떤 기능을 구현했나요 ?
- 비회원에 대한 인증(GroupAccessCode)을 Auth에서 하도록 변경했습니다.

### 🔥 어떻게 해결했나요 ?
- 리뷰 그룹을 찾는 로직은 ReviewGroupService에 존재하는 기능을 그대로 사용하고, 찾은 ReviewGroup에 대한 인증을 확인하는 과정만 Auth에서 진행합니다.
- (추후 Member의 조회 또는 등록 과정도 이와 비슷하게 변경하면 될 것 같아요.)
- api 통일성 있게 변경했어요.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 리뷰 그룹 액세스 코드를 통한 리뷰 그룹 확인은 비회원 외에는 사용되지 않고, 이는 자원을 찾기보다는 인증에 더 가까운 기능임으로 통일성을 위해 Auth에서 하는 것이 맞다고 판단했습니다.
- 세션 기능 또한 Auth에서 처리하고 있으니 동일한 책임이라 생각됩니다.

### 📚 참고 자료, 할 말
- 이전의 제가 올린 PR(회원 도입에 따른 스키마 변경)보다 해당 PR을 먼저 머지해서 이후 작업을 하는 것이 좋겠습니다.