### PR TITLE
[BE] refactor: 이전의 review 테이블을 삭제하고, new_review 테이블만을 사용하도록 변경 

### DIFF
--- a/backend/src/main/resources/db/migration/V7__review_table_change.sql
+++ b/backend/src/main/resources/db/migration/V7__review_table_change.sql
@@ -1,9 +1,9 @@
 -- 이전에 review 테이블 변경 사항 중 new_review가 아닌 review에 적용된 사항을 다시 반영합니다.
 ALTER TABLE new_review ADD COLUMN member_id BIGINT NULL;
 
--- 기존 review 테이블을 삭제하고, ew_review 테이블의 이름을 "review"로 변경합니다.
+-- 기존 review 테이블을 삭제하고, new_review 테이블의 이름을 "review"로 변경합니다.
 -- 운영 환경에서의 오류 발생 시, 작업 롤백을 위해 트랜잭션 실행합니다.
-BEGIN
+BEGIN;
 DROP TABLE IF EXISTS review;
 ALTER TABLE new_review RENAME TO review;
-COMMIT
+COMMIT;

--- a/backend/src/main/resources/db/migration/V7__review_table_change.sql
+++ b/backend/src/main/resources/db/migration/V7__review_table_change.sql
@@ -2,8 +2,6 @@
 ALTER TABLE new_review ADD COLUMN member_id BIGINT NULL;
 
 -- 기존 review 테이블을 삭제하고, new_review 테이블의 이름을 "review"로 변경합니다.
--- 운영 환경에서의 오류 발생 시, 작업 롤백을 위해 트랜잭션 실행합니다.
-START TRANSACTION;
-    DROP TABLE IF EXISTS review;
-    ALTER TABLE new_review RENAME TO review;
-COMMIT;
+-- flyway는 각 마이그레이션 스크립트가 자체적으로 하나의 트랜잭션으로 실행되어서 트랜잭션 처리는 따로 하지 않습니다.
+DROP TABLE IF EXISTS review;
+ALTER TABLE new_review RENAME TO review;

--- a/backend/src/main/resources/db/migration/V7__review_table_change.sql
+++ b/backend/src/main/resources/db/migration/V7__review_table_change.sql
@@ -3,7 +3,7 @@ ALTER TABLE new_review ADD COLUMN member_id BIGINT NULL;
 
 -- 기존 review 테이블을 삭제하고, new_review 테이블의 이름을 "review"로 변경합니다.
 -- 운영 환경에서의 오류 발생 시, 작업 롤백을 위해 트랜잭션 실행합니다.
-BEGIN;
-DROP TABLE IF EXISTS review;
-ALTER TABLE new_review RENAME TO review;
+START TRANSACTION;
+    DROP TABLE IF EXISTS review;
+    ALTER TABLE new_review RENAME TO review;
 COMMIT;

--- a/backend/src/main/resources/db/migration/V7__review_table_change.sql
+++ b/backend/src/main/resources/db/migration/V7__review_table_change.sql
@@ -2,6 +2,5 @@
 ALTER TABLE new_review ADD COLUMN member_id BIGINT NULL;
 
 -- 기존 review 테이블을 삭제하고, new_review 테이블의 이름을 "review"로 변경합니다.
--- flyway는 각 마이그레이션 스크립트가 자체적으로 하나의 트랜잭션으로 실행되어서 트랜잭션 처리는 따로 하지 않습니다.
 DROP TABLE IF EXISTS review;
 ALTER TABLE new_review RENAME TO review;

--- a/backend/src/main/resources/db/migration/V7__review_table_change.sql
+++ b/backend/src/main/resources/db/migration/V7__review_table_change.sql
@@ -1,0 +1,9 @@
+-- 이전에 review 테이블 변경 사항 중 new_review가 아닌 review에 적용된 사항을 다시 반영합니다.
+ALTER TABLE new_review ADD COLUMN member_id BIGINT NULL;
+
+-- 기존 review 테이블을 삭제하고, ew_review 테이블의 이름을 "review"로 변경합니다.
+-- 운영 환경에서의 오류 발생 시, 작업 롤백을 위해 트랜잭션 실행합니다.
+BEGIN
+DROP TABLE IF EXISTS review;
+ALTER TABLE new_review RENAME TO review;
+COMMIT


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #1103

---

### 🚀 어떤 기능을 구현했나요 ?
- 이전 작업에서 new_review가 아닌 review에 스키마 작업을 진행했습니다.
- 변경 사항을 new_review에 다시 적용합니다.
- 또한, review 테이블이 두 개라 추후에도 실수의 여지가 있기 때문에 사용되지 않는 review 테이블을 삭제합니다.
- new_review 테이블의 이름을 review로 변경합니다.

### 🔥 어떻게 해결했나요 ?
- 생각보다 변경 사항이 없어서 간단합니다!
- flyway 문서 참고해주세요.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 혹시 놓치고 있는 부분이 없을지 확인해주세요 🙏

### 📚 참고 자료, 할 말
