### PR TITLE
[BE] refactor: 하이라이트 api에서 요청 본문이 아닌 uri에 리뷰 정보를 포함하도록 변경

### DIFF
--- a/backend/src/main/java/reviewme/highlight/controller/HighlightController.java
+++ b/backend/src/main/java/reviewme/highlight/controller/HighlightController.java
@@ -6,9 +6,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-import reviewme.security.aspect.RequireReviewGroupAccess;
 import reviewme.highlight.service.HighlightService;
 import reviewme.highlight.service.dto.HighlightsRequest;
+import reviewme.security.aspect.RequireReviewGroupAccess;
 
 @RestController
 @RequiredArgsConstructor

--- a/backend/src/main/java/reviewme/highlight/controller/HighlightController.java
+++ b/backend/src/main/java/reviewme/highlight/controller/HighlightController.java
@@ -24,10 +24,6 @@ public class HighlightController {
             @PathVariable String reviewRequestCode,
             @Valid @RequestBody HighlightsRequest request
     ) {
-        /*
-        TODO : aop 인증 로직 필요 (존재하는 세션에 대해 reviewGroupId와 일치 여부 확인)
-        */
-
         // TODO : reviewRequestCode를 위한 임시 사용, 이후 삭제 예정.
         ReviewGroup reviewGroup = reviewGroupService.getReviewGroupByReviewRequestCode(reviewRequestCode);
 

--- a/backend/src/main/java/reviewme/highlight/controller/HighlightController.java
+++ b/backend/src/main/java/reviewme/highlight/controller/HighlightController.java
@@ -19,12 +19,15 @@ public class HighlightController {
     private final HighlightService highlightService;
     private final ReviewGroupService reviewGroupService;
 
-    @PostMapping("/v2/groups/{reviewRequestCode}/highlight")
-    @RequireReviewGroupAccess(target = "#reviewRequestCode")
+    @PostMapping("/v2/groups/{reviewRequestCode}/highlights")
     public ResponseEntity<Void> highlightByReviewGroup(
             @PathVariable String reviewRequestCode,
             @Valid @RequestBody HighlightsRequest request
     ) {
+        /*
+        TODO : aop 인증 로직 필요 (존재하는 세션에 대해 reviewGroupId와 일치 여부 확인)
+        */
+
         // TODO : reviewRequestCode를 위한 임시 사용, 이후 삭제 예정.
         ReviewGroup reviewGroup = reviewGroupService.getReviewGroupByReviewRequestCode(reviewRequestCode);
 

--- a/backend/src/main/java/reviewme/highlight/controller/HighlightController.java
+++ b/backend/src/main/java/reviewme/highlight/controller/HighlightController.java
@@ -3,25 +3,32 @@ package reviewme.highlight.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import reviewme.highlight.service.HighlightService;
 import reviewme.highlight.service.dto.HighlightsRequest;
-import reviewme.security.aspect.RequireReviewGroupAccess;
+import reviewme.reviewgroup.domain.ReviewGroup;
+import reviewme.reviewgroup.service.ReviewGroupService;
 
 @RestController
 @RequiredArgsConstructor
 public class HighlightController {
 
     private final HighlightService highlightService;
+    private final ReviewGroupService reviewGroupService;
 
-    @PostMapping("/v2/highlight")
-    @RequireReviewGroupAccess(target = "#request.reviewGroupId()")
-    public ResponseEntity<Void> highlight(
+    @PostMapping("/v2/groups/{reviewRequestCode}/highlight")
+    @RequireReviewGroupAccess(target = "#reviewRequestCode")
+    public ResponseEntity<Void> highlightByReviewGroup(
+            @PathVariable String reviewRequestCode,
             @Valid @RequestBody HighlightsRequest request
     ) {
-        highlightService.editHighlight(request);
+        // TODO : reviewRequestCode를 위한 임시 사용, 이후 삭제 예정.
+        ReviewGroup reviewGroup = reviewGroupService.getReviewGroupByReviewRequestCode(reviewRequestCode);
+
+        highlightService.highlightByReviewGroup(reviewGroup.getId(), request);
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/reviewme/highlight/service/HighlightService.java
+++ b/backend/src/main/java/reviewme/highlight/service/HighlightService.java
@@ -24,9 +24,9 @@ public class HighlightService {
     private final AnswerValidator answerValidator;
 
     @Transactional
-    public void editHighlight(HighlightsRequest highlightsRequest) {
-        ReviewGroup reviewGroup = reviewGroupRepository.findById(highlightsRequest.reviewGroupId())
-                .orElseThrow(() -> new ReviewGroupNotFoundException(highlightsRequest.reviewGroupId()));
+    public void highlightByReviewGroup(long reviewGroupId, HighlightsRequest highlightsRequest) {
+        ReviewGroup reviewGroup = reviewGroupRepository.findById(reviewGroupId)
+                .orElseThrow(() -> new ReviewGroupNotFoundException(reviewGroupId));
         List<Long> requestedAnswerIds = highlightsRequest.getUniqueAnswerIds();
         answerValidator.validateQuestionContainsAnswers(highlightsRequest.questionId(), requestedAnswerIds);
         answerValidator.validateReviewGroupContainsAnswers(reviewGroup, requestedAnswerIds);

--- a/backend/src/main/java/reviewme/highlight/service/dto/HighlightsRequest.java
+++ b/backend/src/main/java/reviewme/highlight/service/dto/HighlightsRequest.java
@@ -7,9 +7,6 @@ import reviewme.highlight.service.mapper.HighlightFragment;
 
 public record HighlightsRequest(
 
-        @NotNull(message = "리뷰 그룹 ID를 입력해주세요.")
-        Long reviewGroupId,
-
         @NotNull(message = "질문 ID를 입력해주세요.")
         Long questionId,
 

--- a/backend/src/test/java/reviewme/api/HighlightApiTest.java
+++ b/backend/src/test/java/reviewme/api/HighlightApiTest.java
@@ -66,7 +66,7 @@ class HighlightApiTest extends ApiTest {
                 .cookie("JSESSIONID", "AVEBNKLCL13TNVZ")
                 .pathParam("reviewRequestCode", "rereco")
                 .body(request)
-                .when().post("/v2/groups/{reviewRequestCode}/highlight")
+                .when().post("/v2/groups/{reviewRequestCode}/highlights")
                 .then().log().all()
                 .apply(handler)
                 .status(HttpStatus.OK);

--- a/backend/src/test/java/reviewme/api/HighlightApiTest.java
+++ b/backend/src/test/java/reviewme/api/HighlightApiTest.java
@@ -1,5 +1,6 @@
 package reviewme.api;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
 import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -7,18 +8,27 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.mockito.Mockito;
 import org.springframework.http.HttpStatus;
 import org.springframework.restdocs.cookies.CookieDescriptor;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.payload.FieldDescriptor;
+import reviewme.reviewgroup.domain.ReviewGroup;
 
 class HighlightApiTest extends ApiTest {
 
     @Test
     void 존재하는_답변에_하이라이트를_생성한다() {
+        // TODO : api 경로에 reviewRequestCode를 groupId로 변경할 경우 아래의 모킹 코드를 삭제해야 한다.
+        ReviewGroup mockReviewGroup = Mockito.mock(ReviewGroup.class);
+        BDDMockito.given(mockReviewGroup.getId()).willReturn(1L);
+
+        BDDMockito.given(reviewGroupService.getReviewGroupByReviewRequestCode(anyString()))
+                .willReturn(mockReviewGroup);
+
         String request = """
                  {
-                     "reviewGroupId": 1,
                      "questionId": 1,
                      "highlights": [{
                        "answerId": 3,
@@ -38,7 +48,6 @@ class HighlightApiTest extends ApiTest {
         };
 
         FieldDescriptor[] requestFields = {
-                fieldWithPath("reviewGroupId").description("리뷰 그룹 ID"),
                 fieldWithPath("questionId").description("질문 ID"),
                 fieldWithPath("highlights").description("하이라이트 목록"),
                 fieldWithPath("highlights[].answerId").description("답변 ID"),
@@ -55,8 +64,9 @@ class HighlightApiTest extends ApiTest {
 
         givenWithSpec().log().all()
                 .cookie("JSESSIONID", "AVEBNKLCL13TNVZ")
+                .pathParam("reviewRequestCode", "rereco")
                 .body(request)
-                .when().post("/v2/highlight")
+                .when().post("/v2/groups/{reviewRequestCode}/highlight")
                 .then().log().all()
                 .apply(handler)
                 .status(HttpStatus.OK);

--- a/backend/src/test/java/reviewme/highlight/service/HighlightServiceTest.java
+++ b/backend/src/test/java/reviewme/highlight/service/HighlightServiceTest.java
@@ -61,12 +61,10 @@ class HighlightServiceTest {
         HighlightIndexRangeRequest indexRangeRequest = new HighlightIndexRangeRequest(1, 1);
         HighlightedLineRequest lineRequest = new HighlightedLineRequest(0, List.of(indexRangeRequest));
         HighlightRequest highlightRequest1 = new HighlightRequest(textAnswer2.getId(), List.of(lineRequest));
-        HighlightsRequest highlightsRequest = new HighlightsRequest(
-                reviewGroup.getId(), question.getId(), List.of(highlightRequest1
-        ));
+        HighlightsRequest highlightsRequest = new HighlightsRequest(question.getId(), List.of(highlightRequest1));
 
         // when
-        highlightService.editHighlight(highlightsRequest);
+        highlightService.highlightByReviewGroup(reviewGroup.getId(), highlightsRequest);
 
         // then
         assertAll(() -> assertThat(highlightRepository.existsById(highlight.getId())).isFalse());
@@ -89,12 +87,10 @@ class HighlightServiceTest {
         HighlightIndexRangeRequest indexRangeRequest = new HighlightIndexRangeRequest(startIndex, endIndex);
         HighlightedLineRequest lineRequest = new HighlightedLineRequest(0, List.of(indexRangeRequest));
         HighlightRequest highlightRequest = new HighlightRequest(textAnswer.getId(), List.of(lineRequest));
-        HighlightsRequest highlightsRequest = new HighlightsRequest(
-                reviewGroup.getId(), question.getId(), List.of(highlightRequest)
-        );
+        HighlightsRequest highlightsRequest = new HighlightsRequest(question.getId(), List.of(highlightRequest));
 
         // when
-        highlightService.editHighlight(highlightsRequest);
+        highlightService.highlightByReviewGroup(reviewGroup.getId(), highlightsRequest);
 
         // then
         List<Highlight> highlights = highlightRepository.findAllByAnswerIdsOrderedAsc(List.of(textAnswer.getId()));
@@ -117,10 +113,10 @@ class HighlightServiceTest {
         reviewRepository.save(비회원_작성_리뷰(template.getId(), reviewGroup.getId(), List.of(textAnswer)));
         Highlight highlight = highlightRepository.save(new Highlight(textAnswer.getId(), 1, new HighlightRange(1, 1)));
 
-        HighlightsRequest highlightsRequest = new HighlightsRequest(reviewGroup.getId(), question.getId(), List.of());
+        HighlightsRequest highlightsRequest = new HighlightsRequest(question.getId(), List.of());
 
         // when
-        highlightService.editHighlight(highlightsRequest);
+        highlightService.highlightByReviewGroup(reviewGroup.getId(), highlightsRequest);
 
         // then
         assertAll(() -> assertThat(highlightRepository.existsById(highlight.getId())).isFalse());

--- a/backend/src/test/java/reviewme/highlight/service/mapper/HighlightMapperTest.java
+++ b/backend/src/test/java/reviewme/highlight/service/mapper/HighlightMapperTest.java
@@ -67,7 +67,6 @@ class HighlightMapperTest {
         HighlightRequest highlightRequest1 = new HighlightRequest(textAnswer1.getId(), List.of(lineRequest1));
         HighlightRequest highlightRequest2 = new HighlightRequest(textAnswer2.getId(), List.of(lineRequest2));
         HighlightsRequest highlightsRequest = new HighlightsRequest(
-                reviewGroupId,
                 question.getId(),
                 List.of(highlightRequest1, highlightRequest2)
         );
@@ -88,7 +87,7 @@ class HighlightMapperTest {
     @Test
     void 하이라이트_할_내용이_없는_요청이_오면_매핑_결과_빈_리스트를_반환한다() {
         // given
-        HighlightsRequest highlightsRequest = new HighlightsRequest(1L, 1L, List.of());
+        HighlightsRequest highlightsRequest = new HighlightsRequest(1L, List.of());
 
         // when
         List<Highlight> highlights = highlightMapper.mapToHighlights(highlightsRequest);


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #1112

---

### 🚀 어떤 기능을 구현했나요 ?
- 디스코드에서 협의한 내용 대로, 하이라이트 api(/highlight)의 본문에 있던 리뷰 그룹 정보를 uri에 제공합니다.
- 리뷰 그룹 정보는 임시 형태인 reviewRequestCode를 pathVariable로 받을 수 있도록 변경합니다.

### 🔥 어떻게 해결했나요 ?
- 위 내용과 동일합니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
