### PR TITLE
[BE] feat: 사용자 프로필 조회 api 구현

### DIFF
--- a/backend/src/main/java/reviewme/member/controller/MemberController.java
+++ b/backend/src/main/java/reviewme/member/controller/MemberController.java
@@ -1,21 +1,28 @@
 package reviewme.member.controller;
 
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+import reviewme.auth.domain.GitHubMember;
 import reviewme.member.service.MemberService;
 import reviewme.member.service.dto.ProfileResponse;
+import reviewme.security.session.SessionManager;
 
 @RestController
 @RequiredArgsConstructor
 public class MemberController {
 
     private final MemberService memberService;
+    private final SessionManager sessionManager;
 
     @GetMapping("/v2/members/profile")
-    public ResponseEntity<ProfileResponse> getProfile() {
-        ProfileResponse response = memberService.getProfile();
+    public ResponseEntity<ProfileResponse> getProfile(
+            HttpSession session
+    ) {
+        GitHubMember gitHubMember = sessionManager.getGitHubMember(session);
+        ProfileResponse response = memberService.getProfile(gitHubMember);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/reviewme/member/service/MemberService.java
+++ b/backend/src/main/java/reviewme/member/service/MemberService.java
@@ -1,12 +1,22 @@
 package reviewme.member.service;
 
 import org.springframework.stereotype.Service;
+import reviewme.auth.domain.GitHubMember;
 import reviewme.member.service.dto.ProfileResponse;
+import reviewme.security.resolver.exception.LoginMemberSessionNotExistsException;
 
 @Service
 public class MemberService {
 
-    public ProfileResponse getProfile() {
-        return null;
+    public ProfileResponse getProfile(GitHubMember gitHubMember) {
+        if (gitHubMember == null) {
+            throw new LoginMemberSessionNotExistsException();
+        }
+
+        return new ProfileResponse(
+                gitHubMember.getMemberId(),
+                gitHubMember.getGitHubUserName(),
+                gitHubMember.getGitHubProfileImageUrl()
+        );
     }
 }

--- a/backend/src/main/java/reviewme/member/service/MemberService.java
+++ b/backend/src/main/java/reviewme/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package reviewme.member.service;
 
+import jakarta.annotation.Nullable;
 import org.springframework.stereotype.Service;
 import reviewme.auth.domain.GitHubMember;
 import reviewme.member.service.dto.ProfileResponse;
@@ -8,7 +9,7 @@ import reviewme.security.resolver.exception.LoginMemberSessionNotExistsException
 @Service
 public class MemberService {
 
-    public ProfileResponse getProfile(GitHubMember gitHubMember) {
+    public ProfileResponse getProfile(@Nullable GitHubMember gitHubMember) {
         if (gitHubMember == null) {
             throw new LoginMemberSessionNotExistsException();
         }

--- a/backend/src/main/java/reviewme/member/service/dto/ProfileResponse.java
+++ b/backend/src/main/java/reviewme/member/service/dto/ProfileResponse.java
@@ -1,6 +1,7 @@
 package reviewme.member.service.dto;
 
 public record ProfileResponse(
+        long memberId,
         String nickname,
         String profileImageUrl
 ) {

--- a/backend/src/test/java/reviewme/api/MemberApiTest.java
+++ b/backend/src/test/java/reviewme/api/MemberApiTest.java
@@ -1,5 +1,7 @@
 package reviewme.api;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
 import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -7,7 +9,6 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.BDDMockito;
 import org.springframework.restdocs.cookies.CookieDescriptor;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.payload.FieldDescriptor;
@@ -17,14 +18,15 @@ public class MemberApiTest extends ApiTest {
 
     @Test
     void 내_프로필을_불러온다() {
-        BDDMockito.given(memberService.getProfile())
-                .willReturn(new ProfileResponse("donghoony", "https://aru.image"));
+        given(memberService.getProfile(any()))
+                .willReturn(new ProfileResponse(1L, "nickname", "profileImageUrl"));
 
         CookieDescriptor[] cookieDescriptors = {
                 cookieWithName("JSESSIONID").description("세션 ID")
         };
 
         FieldDescriptor[] responseFieldDescriptors = {
+                fieldWithPath("memberId").description("회원 ID"),
                 fieldWithPath("nickname").description("닉네임"),
                 fieldWithPath("profileImageUrl").description("프로필 이미지 URL")
         };

--- a/backend/src/test/java/reviewme/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/reviewme/member/service/MemberServiceTest.java
@@ -1,0 +1,50 @@
+package reviewme.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import reviewme.auth.domain.GitHubMember;
+import reviewme.member.service.dto.ProfileResponse;
+import reviewme.security.resolver.exception.LoginMemberSessionNotExistsException;
+
+class MemberServiceTest {
+
+    @Nested
+    @DisplayName("사용자 프로필을 조회한다.")
+    class getProfile {
+
+        @Test
+        void 세션에_저장된_정보가_없으면_예외가_발생한다() {
+            // given
+            MemberService memberService = new MemberService();
+
+            // when, then
+            assertThatCode(() -> memberService.getProfile(null))
+                    .isInstanceOf(LoginMemberSessionNotExistsException.class);
+        }
+
+        @Test
+        void sessionExists() {
+            // given
+            long memberId = 1L;
+            String nickname = "user";
+            String profileImageUrl = "https://profile.com";
+            GitHubMember gitHubMember = new GitHubMember(memberId, nickname, profileImageUrl);
+            MemberService memberService = new MemberService();
+
+            // when
+            ProfileResponse profile = memberService.getProfile(gitHubMember);
+
+            // then
+            assertAll(
+                    () -> assertThat(profile.memberId()).isEqualTo(memberId),
+                    () -> assertThat(profile.nickname()).isEqualTo(nickname),
+                    () -> assertThat(profile.profileImageUrl()).isEqualTo(profileImageUrl)
+            );
+        }
+    }
+}

--- a/backend/src/test/java/reviewme/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/reviewme/member/service/MemberServiceTest.java
@@ -14,7 +14,7 @@ import reviewme.security.resolver.exception.LoginMemberSessionNotExistsException
 class MemberServiceTest {
 
     @Nested
-    @DisplayName("사용자 프로필을 조회한다.")
+    @DisplayName("사용자 프로필을 반환한다.")
     class getProfile {
 
         @Test
@@ -28,7 +28,7 @@ class MemberServiceTest {
         }
 
         @Test
-        void sessionExists() {
+        void 세션에_저장된_사용자_프로필을_반환한다() {
             // given
             long memberId = 1L;
             String nickname = "user";


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #1108 

---

### 🚀 어떤 기능을 구현했나요 ?
- 사용자 프로필을 조회하는 api 를 구현했습니다.

### 🔥 어떻게 해결했나요 ?
- 사용자 프로필은 세션에서 관리하기로 했으므로, 세션에 저장될 객체인 GitHubMember에 종속적인 코드를 작성하게 되었습니다.
- 하지만 다른 PR에서 말했듯, [세션에 프로필을 저장하자]는 정책은 우리가 정한것이니 괜찮다 생각했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 지금 생각하니, [세션에 프로필을 저장하자]는 정책이니까 session 패키지 하위에 ProfileResponse 를 반환하게 하는 클래스를 두는게 나았으려나요? 😅 테드가 이 코드들에 대해서 어떻게 생각할지 정말 궁금하네요..

### 📚 참고 자료, 할 말
