### PR TITLE
[FE] feat: 변경되는 API요청 URL 적용

### DIFF
--- a/frontend/src/apis/endpoints.ts
+++ b/frontend/src/apis/endpoints.ts
@@ -22,8 +22,8 @@ export const DETAILED_REVIEW_API_PARAMS = {
   },
 };
 
-export const REVIEW_LIST_API_PARAMS = {
-  resource: 'reviews',
+export const REVIEW_RECEIVED_LIST_API_PARAMS = {
+  resource: 'reviews/received',
 };
 
 export const REVIEW_WRITING_API_PARAMS = {
@@ -73,11 +73,11 @@ const endPoint = {
   gettingDataToWriteReview: (reviewRequestCode: string) =>
     `${REVIEW_WRITING_API_URL}/${REVIEW_WRITING_API_PARAMS.queryString.write}?${REVIEW_WRITING_API_PARAMS.queryString.reviewRequestCode}=${reviewRequestCode}`,
   gettingReceivedReviewList: ({ lastReviewId, size, reviewRequestCode }: GetReviewListEndPointParams) => {
-    const basicUrl = makeReceivedReviewListBasicUrl(reviewRequestCode);
+    const basicUrl = makeReceivedReviewListBasicUrl(reviewRequestCode) + '?' + `reviewRequestCode=${reviewRequestCode}`;
     if (lastReviewId) {
-      return `${basicUrl}?lastReviewId=${lastReviewId}&size=${size}`;
+      return `${basicUrl}&lastReviewId=${lastReviewId}&size=${size}`;
     }
-    return `${basicUrl}?size=${size}`;
+    return `${basicUrl}&size=${size}`;
   },
   postingDataForReviewRequestCode: `${serverUrl}/${VERSION2}/groups`,
   checkingReviewRequestPassword: `${serverUrl}/${VERSION2}/auth/review-group`,

--- a/frontend/src/apis/endpoints.ts
+++ b/frontend/src/apis/endpoints.ts
@@ -50,6 +50,7 @@ export const REVIEW_GROUP_API_PARAMS = {
 export const REVIEW_WRITING_API_URL = `${serverUrl}/${VERSION2}/${REVIEW_WRITING_API_PARAMS.resource}`;
 
 export const DETAILED_REVIEW_API_URL = `${serverUrl}/${VERSION2}/${DETAILED_REVIEW_API_PARAMS.resource}`;
+//NOTE: reviewGroupId가 어느 정도 정해지면 그 때  REVIEW_GROUP_DATA_API_URL과 REVIEW_GROUPS_BASIC_API_URL 이 부분 수정
 export const REVIEW_GROUP_DATA_API_URL = `${serverUrl}/${VERSION2}/${REVIEW_GROUP_DATA_API_PARAMS.resource}`;
 const REVIEW_GROUPS_BASIC_API_URL = `${serverUrl}/${VERSION2}/groups`;
 

--- a/frontend/src/apis/endpoints.ts
+++ b/frontend/src/apis/endpoints.ts
@@ -34,13 +34,6 @@ export const REVIEW_WRITING_API_PARAMS = {
   },
 };
 
-export const REVIEW_PASSWORD_API_PARAMS = {
-  resource: 'groups',
-  queryString: {
-    check: 'check',
-  },
-};
-
 export const REVIEW_GROUP_DATA_API_PARAMS = {
   resource: 'groups',
   queryString: {
@@ -86,7 +79,7 @@ const endPoint = {
     return `${basicUrl}?size=${size}`;
   },
   postingDataForReviewRequestCode: `${serverUrl}/${VERSION2}/groups`,
-  checkingPassword: `${serverUrl}/${VERSION2}/${REVIEW_PASSWORD_API_PARAMS.resource}/${REVIEW_PASSWORD_API_PARAMS.queryString.check}`,
+  checkingReviewRequestPassword: `${serverUrl}/${VERSION2}/auth/review-group`,
   gettingReviewGroupData: (reviewRequestCode: string) =>
     `${REVIEW_GROUP_DATA_API_URL}?${REVIEW_GROUP_DATA_API_PARAMS.queryString.reviewRequestCode}=${reviewRequestCode}`,
   gettingSectionList: `${serverUrl}/${VERSION2}/sections`,

--- a/frontend/src/apis/endpoints.ts
+++ b/frontend/src/apis/endpoints.ts
@@ -73,11 +73,11 @@ const endPoint = {
   gettingDataToWriteReview: (reviewRequestCode: string) =>
     `${REVIEW_WRITING_API_URL}/${REVIEW_WRITING_API_PARAMS.queryString.write}?${REVIEW_WRITING_API_PARAMS.queryString.reviewRequestCode}=${reviewRequestCode}`,
   gettingReceivedReviewList: ({ lastReviewId, size, reviewRequestCode }: GetReviewListEndPointParams) => {
-    const basicUrl = makeReceivedReviewListBasicUrl(reviewRequestCode) + '?' + `reviewRequestCode=${reviewRequestCode}`;
+    const basicUrl = makeReceivedReviewListBasicUrl(reviewRequestCode);
     if (lastReviewId) {
-      return `${basicUrl}&lastReviewId=${lastReviewId}&size=${size}`;
+      return `${basicUrl}?lastReviewId=${lastReviewId}&size=${size}`;
     }
-    return `${basicUrl}&size=${size}`;
+    return `${basicUrl}?size=${size}`;
   },
   postingDataForReviewRequestCode: `${serverUrl}/${VERSION2}/groups`,
   checkingReviewRequestPassword: `${serverUrl}/${VERSION2}/auth/review-group`,

--- a/frontend/src/apis/endpoints.ts
+++ b/frontend/src/apis/endpoints.ts
@@ -64,6 +64,8 @@ export const makeReviewGroupBasicApiUrl = (reviewRequestCode: string) =>
   `${serverUrl}/${VERSION2}/group/${reviewRequestCode}/reviews/gather`;
 export const makeReceivedReviewListBasicUrl = (reviewRequestCode: string) =>
   `${serverUrl}/${VERSION2}/groups/${reviewRequestCode}/${REVIEW_LIST_API_PARAMS.resource}`;
+export const makeReviewSummaryInfoBasicUrl = (reviewRequestCode: string) =>
+  `${serverUrl}/${VERSION2}/group/${reviewRequestCode}/reviews/summary`;
 
 interface GetReviewListEndPointParams {
   lastReviewId: number | null;
@@ -72,7 +74,7 @@ interface GetReviewListEndPointParams {
 }
 const endPoint = {
   postingReview: `${serverUrl}/${VERSION2}/reviews`,
-  gettingReviewInfoData: `${serverUrl}/${VERSION2}/reviews/summary`,
+  gettingReviewSummaryInfoData: (reviewRequestCode: string) => makeReviewSummaryInfoBasicUrl(reviewRequestCode),
   gettingDetailedReview: (reviewId: number) => `${DETAILED_REVIEW_API_URL}/${reviewId}`,
   gettingDataToWriteReview: (reviewRequestCode: string) =>
     `${REVIEW_WRITING_API_URL}/${REVIEW_WRITING_API_PARAMS.queryString.write}?${REVIEW_WRITING_API_PARAMS.queryString.reviewRequestCode}=${reviewRequestCode}`,

--- a/frontend/src/apis/endpoints.ts
+++ b/frontend/src/apis/endpoints.ts
@@ -79,7 +79,7 @@ const endPoint = {
     }
     return `${basicUrl}?size=${size}`;
   },
-  postingDataForReviewRequestCode: `${serverUrl}/${VERSION2}/groups`,
+  postingDataForReviewRequestCode: REVIEW_GROUPS_BASIC_API_URL,
   checkingReviewRequestPassword: `${serverUrl}/${VERSION2}/auth/review-group`,
   gettingReviewGroupData: (reviewRequestCode: string) =>
     `${REVIEW_GROUP_DATA_API_URL}?${REVIEW_GROUP_DATA_API_PARAMS.queryString.reviewRequestCode}=${reviewRequestCode}`,

--- a/frontend/src/apis/endpoints.ts
+++ b/frontend/src/apis/endpoints.ts
@@ -50,27 +50,28 @@ export const REVIEW_WRITING_API_URL = `${serverUrl}/${VERSION2}/${REVIEW_WRITING
 export const DETAILED_REVIEW_API_URL = `${serverUrl}/${VERSION2}/${DETAILED_REVIEW_API_PARAMS.resource}`;
 export const REVIEW_GROUPS_BASIC_API_URL = `${serverUrl}/${VERSION2}/groups`;
 
-// NOTE: 추후에 reviewRequestCode가 아닌 reviewGroupId로 요청하는 방식으로 변경될 예정
-export const makeGrouppedReviewsBasicUrl = (reviewRequestCode: string) =>
-  `${REVIEW_GROUPS_BASIC_API_URL}/${reviewRequestCode}/reviews/gather`;
-export const makeReceivedReviewListBasicUrl = (reviewRequestCode: string) =>
-  `${REVIEW_GROUPS_BASIC_API_URL}/${reviewRequestCode}/${REVIEW_RECEIVED_LIST_API_PARAMS.resource}`;
-export const makeReviewSummaryInfoBasicUrl = (reviewRequestCode: string) =>
-  `${REVIEW_GROUPS_BASIC_API_URL}/${reviewRequestCode}/reviews/summary`;
-
 interface GetReviewListEndPointParams {
   lastReviewId: number | null;
   size: number;
   reviewRequestCode: string;
 }
+
+/*
+NOTE: reviewGroupId로 변경될 endpoint
+섹션 별 받은 리뷰 모아보기 GET /groups/{id}/reviews/gather
+받은 리뷰 목록 조회 GET /groups/{id}/reviews/received
+받은 리뷰 요약 조회 GET  /groups/{id}/reviews/summary
+하이라이트 수정 POST /highlight :: request 에 reviewGroupId 포함되어야 함
+*/
 const endPoint = {
   postingReview: `${serverUrl}/${VERSION2}/reviews`,
-  gettingReviewSummaryInfoData: (reviewRequestCode: string) => makeReviewSummaryInfoBasicUrl(reviewRequestCode),
+  gettingReviewSummaryInfoData: (reviewRequestCode: string) =>
+    `${REVIEW_GROUPS_BASIC_API_URL}/${reviewRequestCode}/reviews/summary`,
   gettingDetailedReview: (reviewId: number) => `${DETAILED_REVIEW_API_URL}/${reviewId}`,
   gettingDataToWriteReview: (reviewRequestCode: string) =>
     `${REVIEW_WRITING_API_URL}/${REVIEW_WRITING_API_PARAMS.queryString.write}?${REVIEW_WRITING_API_PARAMS.queryString.reviewRequestCode}=${reviewRequestCode}`,
   gettingReceivedReviewList: ({ lastReviewId, size, reviewRequestCode }: GetReviewListEndPointParams) => {
-    const basicUrl = makeReceivedReviewListBasicUrl(reviewRequestCode);
+    const basicUrl = `${REVIEW_GROUPS_BASIC_API_URL}/${reviewRequestCode}/${REVIEW_RECEIVED_LIST_API_PARAMS.resource}`;
     if (lastReviewId) {
       return `${basicUrl}?lastReviewId=${lastReviewId}&size=${size}`;
     }
@@ -82,7 +83,7 @@ const endPoint = {
     `${REVIEW_GROUPS_BASIC_API_URL}?${REVIEW_GROUP_DATA_API_PARAMS.queryString.reviewRequestCode}=${reviewRequestCode}`,
   gettingSectionList: `${serverUrl}/${VERSION2}/sections`,
   gettingGroupedReviews: (reviewRequestCode: string, sectionId: number) =>
-    `${makeGrouppedReviewsBasicUrl(reviewRequestCode)}?${REVIEW_GROUP_API_PARAMS.queryString.sectionId}=${sectionId}`,
+    `${REVIEW_GROUPS_BASIC_API_URL}/${reviewRequestCode}/reviews/gather?${REVIEW_GROUP_API_PARAMS.queryString.sectionId}=${sectionId}`,
   postingHighlight: (reviewRequestCode: string) => `${REVIEW_GROUPS_BASIC_API_URL}/${reviewRequestCode}/highlights`,
 };
 

--- a/frontend/src/apis/endpoints.ts
+++ b/frontend/src/apis/endpoints.ts
@@ -86,7 +86,7 @@ const endPoint = {
   gettingSectionList: `${serverUrl}/${VERSION2}/sections`,
   gettingGroupedReviews: (reviewRequestCode: string, sectionId: number) =>
     `${makeReviewGroupBasicApiUrl(reviewRequestCode)}?${REVIEW_GROUP_API_PARAMS.queryString.sectionId}=${sectionId}`,
-  postingHighlight: `${serverUrl}/${VERSION2}/highlight`,
+  postingHighlight: (reviewRequestCode: string) => `${serverUrl}/${VERSION2}/${reviewRequestCode}/highlight`,
 };
 
 export default endPoint;

--- a/frontend/src/apis/endpoints.ts
+++ b/frontend/src/apis/endpoints.ts
@@ -86,7 +86,7 @@ const endPoint = {
   gettingSectionList: `${serverUrl}/${VERSION2}/sections`,
   gettingGroupedReviews: (reviewRequestCode: string, sectionId: number) =>
     `${makeReviewGroupBasicApiUrl(reviewRequestCode)}?${REVIEW_GROUP_API_PARAMS.queryString.sectionId}=${sectionId}`,
-  postingHighlight: (reviewRequestCode: string) => `${serverUrl}/${VERSION2}/${reviewRequestCode}/highlight`,
+  postingHighlight: (reviewRequestCode: string) => `${REVIEW_GROUPS_BASIC_API_URL}/${reviewRequestCode}/highlight`,
 };
 
 export default endPoint;

--- a/frontend/src/apis/endpoints.ts
+++ b/frontend/src/apis/endpoints.ts
@@ -35,7 +35,6 @@ export const REVIEW_WRITING_API_PARAMS = {
 };
 
 export const REVIEW_GROUP_DATA_API_PARAMS = {
-  resource: 'groups',
   queryString: {
     reviewRequestCode: 'reviewRequestCode',
   },
@@ -48,11 +47,8 @@ export const REVIEW_GROUP_API_PARAMS = {
 };
 
 export const REVIEW_WRITING_API_URL = `${serverUrl}/${VERSION2}/${REVIEW_WRITING_API_PARAMS.resource}`;
-
 export const DETAILED_REVIEW_API_URL = `${serverUrl}/${VERSION2}/${DETAILED_REVIEW_API_PARAMS.resource}`;
-//NOTE: reviewGroupId가 어느 정도 정해지면 그 때  REVIEW_GROUP_DATA_API_URL과 REVIEW_GROUPS_BASIC_API_URL 이 부분 수정
-export const REVIEW_GROUP_DATA_API_URL = `${serverUrl}/${VERSION2}/${REVIEW_GROUP_DATA_API_PARAMS.resource}`;
-const REVIEW_GROUPS_BASIC_API_URL = `${serverUrl}/${VERSION2}/groups`;
+export const REVIEW_GROUPS_BASIC_API_URL = `${serverUrl}/${VERSION2}/groups`;
 
 // NOTE: 추후에 reviewRequestCode가 아닌 reviewGroupId로 요청하는 방식으로 변경될 예정
 export const makeReviewGroupBasicApiUrl = (reviewRequestCode: string) =>
@@ -83,7 +79,7 @@ const endPoint = {
   postingDataForReviewRequestCode: REVIEW_GROUPS_BASIC_API_URL,
   checkingReviewRequestPassword: `${serverUrl}/${VERSION2}/auth/review-group`,
   gettingReviewGroupData: (reviewRequestCode: string) =>
-    `${REVIEW_GROUP_DATA_API_URL}?${REVIEW_GROUP_DATA_API_PARAMS.queryString.reviewRequestCode}=${reviewRequestCode}`,
+    `${REVIEW_GROUPS_BASIC_API_URL}?${REVIEW_GROUP_DATA_API_PARAMS.queryString.reviewRequestCode}=${reviewRequestCode}`,
   gettingSectionList: `${serverUrl}/${VERSION2}/sections`,
   gettingGroupedReviews: (reviewRequestCode: string, sectionId: number) =>
     `${makeReviewGroupBasicApiUrl(reviewRequestCode)}?${REVIEW_GROUP_API_PARAMS.queryString.sectionId}=${sectionId}`,

--- a/frontend/src/apis/endpoints.ts
+++ b/frontend/src/apis/endpoints.ts
@@ -86,7 +86,7 @@ const endPoint = {
   gettingSectionList: `${serverUrl}/${VERSION2}/sections`,
   gettingGroupedReviews: (reviewRequestCode: string, sectionId: number) =>
     `${makeReviewGroupBasicApiUrl(reviewRequestCode)}?${REVIEW_GROUP_API_PARAMS.queryString.sectionId}=${sectionId}`,
-  postingHighlight: (reviewRequestCode: string) => `${REVIEW_GROUPS_BASIC_API_URL}/${reviewRequestCode}/highlight`,
+  postingHighlight: (reviewRequestCode: string) => `${REVIEW_GROUPS_BASIC_API_URL}/${reviewRequestCode}/highlights`,
 };
 
 export default endPoint;

--- a/frontend/src/apis/endpoints.ts
+++ b/frontend/src/apis/endpoints.ts
@@ -60,6 +60,9 @@ export const DETAILED_REVIEW_API_URL = `${serverUrl}/${VERSION2}/${DETAILED_REVI
 export const REVIEW_GROUP_DATA_API_URL = `${serverUrl}/${VERSION2}/${REVIEW_GROUP_DATA_API_PARAMS.resource}`;
 export const REVIEW_GROUP_API_URL = `${serverUrl}/${VERSION2}/reviews/gather`;
 
+export const makeReviewGroupBasicApiUrl = (reviewRequestCode: string) =>
+  `${serverUrl}/${VERSION2}/group/${reviewRequestCode}/reviews/gather`;
+
 const endPoint = {
   postingReview: `${serverUrl}/${VERSION2}/reviews`,
   gettingReviewInfoData: `${serverUrl}/${VERSION2}/reviews/summary`,
@@ -77,8 +80,8 @@ const endPoint = {
   gettingReviewGroupData: (reviewRequestCode: string) =>
     `${REVIEW_GROUP_DATA_API_URL}?${REVIEW_GROUP_DATA_API_PARAMS.queryString.reviewRequestCode}=${reviewRequestCode}`,
   gettingSectionList: `${serverUrl}/${VERSION2}/sections`,
-  gettingGroupedReviews: (sectionId: number) =>
-    `${REVIEW_GROUP_API_URL}?${REVIEW_GROUP_API_PARAMS.queryString.sectionId}=${sectionId}`,
+  gettingGroupedReviews: (reviewRequestCode: string, sectionId: number) =>
+    `${makeReviewGroupBasicApiUrl(reviewRequestCode)}?${REVIEW_GROUP_API_PARAMS.queryString.sectionId}=${sectionId}`,
   postingHighlight: `${serverUrl}/${VERSION2}/highlight`,
 };
 

--- a/frontend/src/apis/endpoints.ts
+++ b/frontend/src/apis/endpoints.ts
@@ -50,7 +50,7 @@ export const REVIEW_WRITING_API_URL = `${serverUrl}/${VERSION2}/${REVIEW_WRITING
 export const DETAILED_REVIEW_API_URL = `${serverUrl}/${VERSION2}/${DETAILED_REVIEW_API_PARAMS.resource}`;
 export const REVIEW_GROUPS_BASIC_API_URL = `${serverUrl}/${VERSION2}/groups`;
 
-interface GetReviewListEndPointParams {
+interface GetReviewListEndpointParams {
   lastReviewId: number | null;
   size: number;
   reviewRequestCode: string;
@@ -70,7 +70,7 @@ const endPoint = {
   gettingDetailedReview: (reviewId: number) => `${DETAILED_REVIEW_API_URL}/${reviewId}`,
   gettingDataToWriteReview: (reviewRequestCode: string) =>
     `${REVIEW_WRITING_API_URL}/${REVIEW_WRITING_API_PARAMS.queryString.write}?${REVIEW_WRITING_API_PARAMS.queryString.reviewRequestCode}=${reviewRequestCode}`,
-  gettingReceivedReviewList: ({ lastReviewId, size, reviewRequestCode }: GetReviewListEndPointParams) => {
+  gettingReceivedReviewList: ({ lastReviewId, size, reviewRequestCode }: GetReviewListEndpointParams) => {
     const basicUrl = `${REVIEW_GROUPS_BASIC_API_URL}/${reviewRequestCode}/${REVIEW_RECEIVED_LIST_API_PARAMS.resource}`;
     if (lastReviewId) {
       return `${basicUrl}?lastReviewId=${lastReviewId}&size=${size}`;

--- a/frontend/src/apis/endpoints.ts
+++ b/frontend/src/apis/endpoints.ts
@@ -51,7 +51,7 @@ export const DETAILED_REVIEW_API_URL = `${serverUrl}/${VERSION2}/${DETAILED_REVI
 export const REVIEW_GROUPS_BASIC_API_URL = `${serverUrl}/${VERSION2}/groups`;
 
 // NOTE: 추후에 reviewRequestCode가 아닌 reviewGroupId로 요청하는 방식으로 변경될 예정
-export const makeReviewGroupBasicApiUrl = (reviewRequestCode: string) =>
+export const makeGrouppedReviewsBasicUrl = (reviewRequestCode: string) =>
   `${REVIEW_GROUPS_BASIC_API_URL}/${reviewRequestCode}/reviews/gather`;
 export const makeReceivedReviewListBasicUrl = (reviewRequestCode: string) =>
   `${REVIEW_GROUPS_BASIC_API_URL}/${reviewRequestCode}/${REVIEW_RECEIVED_LIST_API_PARAMS.resource}`;
@@ -82,7 +82,7 @@ const endPoint = {
     `${REVIEW_GROUPS_BASIC_API_URL}?${REVIEW_GROUP_DATA_API_PARAMS.queryString.reviewRequestCode}=${reviewRequestCode}`,
   gettingSectionList: `${serverUrl}/${VERSION2}/sections`,
   gettingGroupedReviews: (reviewRequestCode: string, sectionId: number) =>
-    `${makeReviewGroupBasicApiUrl(reviewRequestCode)}?${REVIEW_GROUP_API_PARAMS.queryString.sectionId}=${sectionId}`,
+    `${makeGrouppedReviewsBasicUrl(reviewRequestCode)}?${REVIEW_GROUP_API_PARAMS.queryString.sectionId}=${sectionId}`,
   postingHighlight: (reviewRequestCode: string) => `${REVIEW_GROUPS_BASIC_API_URL}/${reviewRequestCode}/highlights`,
 };
 

--- a/frontend/src/apis/endpoints.ts
+++ b/frontend/src/apis/endpoints.ts
@@ -51,14 +51,15 @@ export const REVIEW_WRITING_API_URL = `${serverUrl}/${VERSION2}/${REVIEW_WRITING
 
 export const DETAILED_REVIEW_API_URL = `${serverUrl}/${VERSION2}/${DETAILED_REVIEW_API_PARAMS.resource}`;
 export const REVIEW_GROUP_DATA_API_URL = `${serverUrl}/${VERSION2}/${REVIEW_GROUP_DATA_API_PARAMS.resource}`;
-export const REVIEW_GROUP_API_URL = `${serverUrl}/${VERSION2}/reviews/gather`;
+const REVIEW_GROUPS_BASIC_API_URL = `${serverUrl}/${VERSION2}/groups`;
 
+// NOTE: 추후에 reviewRequestCode가 아닌 reviewGroupId로 요청하는 방식으로 변경될 예정
 export const makeReviewGroupBasicApiUrl = (reviewRequestCode: string) =>
-  `${serverUrl}/${VERSION2}/group/${reviewRequestCode}/reviews/gather`;
+  `${REVIEW_GROUPS_BASIC_API_URL}/${reviewRequestCode}/reviews/gather`;
 export const makeReceivedReviewListBasicUrl = (reviewRequestCode: string) =>
-  `${serverUrl}/${VERSION2}/groups/${reviewRequestCode}/${REVIEW_LIST_API_PARAMS.resource}`;
+  `${REVIEW_GROUPS_BASIC_API_URL}/${reviewRequestCode}/${REVIEW_RECEIVED_LIST_API_PARAMS.resource}`;
 export const makeReviewSummaryInfoBasicUrl = (reviewRequestCode: string) =>
-  `${serverUrl}/${VERSION2}/group/${reviewRequestCode}/reviews/summary`;
+  `${REVIEW_GROUPS_BASIC_API_URL}/${reviewRequestCode}/reviews/summary`;
 
 interface GetReviewListEndPointParams {
   lastReviewId: number | null;

--- a/frontend/src/apis/endpoints.ts
+++ b/frontend/src/apis/endpoints.ts
@@ -55,25 +55,33 @@ export const REVIEW_GROUP_API_PARAMS = {
 };
 
 export const REVIEW_WRITING_API_URL = `${serverUrl}/${VERSION2}/${REVIEW_WRITING_API_PARAMS.resource}`;
-export const REVIEW_LIST_API_URL = `${serverUrl}/${VERSION2}/${REVIEW_LIST_API_PARAMS.resource}`;
+
 export const DETAILED_REVIEW_API_URL = `${serverUrl}/${VERSION2}/${DETAILED_REVIEW_API_PARAMS.resource}`;
 export const REVIEW_GROUP_DATA_API_URL = `${serverUrl}/${VERSION2}/${REVIEW_GROUP_DATA_API_PARAMS.resource}`;
 export const REVIEW_GROUP_API_URL = `${serverUrl}/${VERSION2}/reviews/gather`;
 
 export const makeReviewGroupBasicApiUrl = (reviewRequestCode: string) =>
   `${serverUrl}/${VERSION2}/group/${reviewRequestCode}/reviews/gather`;
+export const makeReceivedReviewListBasicUrl = (reviewRequestCode: string) =>
+  `${serverUrl}/${VERSION2}/groups/${reviewRequestCode}/${REVIEW_LIST_API_PARAMS.resource}`;
 
+interface GetReviewListEndPointParams {
+  lastReviewId: number | null;
+  size: number;
+  reviewRequestCode: string;
+}
 const endPoint = {
   postingReview: `${serverUrl}/${VERSION2}/reviews`,
   gettingReviewInfoData: `${serverUrl}/${VERSION2}/reviews/summary`,
   gettingDetailedReview: (reviewId: number) => `${DETAILED_REVIEW_API_URL}/${reviewId}`,
   gettingDataToWriteReview: (reviewRequestCode: string) =>
     `${REVIEW_WRITING_API_URL}/${REVIEW_WRITING_API_PARAMS.queryString.write}?${REVIEW_WRITING_API_PARAMS.queryString.reviewRequestCode}=${reviewRequestCode}`,
-  gettingReviewList: (lastReviewId: number | null, size: number) => {
+  gettingReceivedReviewList: ({ lastReviewId, size, reviewRequestCode }: GetReviewListEndPointParams) => {
+    const basicUrl = makeReceivedReviewListBasicUrl(reviewRequestCode);
     if (lastReviewId) {
-      return `${REVIEW_LIST_API_URL}?lastReviewId=${lastReviewId}&size=${size}`;
+      return `${basicUrl}?lastReviewId=${lastReviewId}&size=${size}`;
     }
-    return `${REVIEW_LIST_API_URL}?size=${size}`;
+    return `${basicUrl}?size=${size}`;
   },
   postingDataForReviewRequestCode: `${serverUrl}/${VERSION2}/groups`,
   checkingPassword: `${serverUrl}/${VERSION2}/${REVIEW_PASSWORD_API_PARAMS.resource}/${REVIEW_PASSWORD_API_PARAMS.queryString.check}`,

--- a/frontend/src/apis/group.ts
+++ b/frontend/src/apis/group.ts
@@ -39,7 +39,7 @@ export const postPasswordValidationApi = async ({
   groupAccessCode,
   reviewRequestCode,
 }: GetPasswordValidationApiParams): Promise<PasswordResponse> => {
-  const response = await fetch(endPoint.checkingPassword, {
+  const response = await fetch(endPoint.checkingReviewRequestPassword, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/frontend/src/apis/group.ts
+++ b/frontend/src/apis/group.ts
@@ -10,14 +10,19 @@ export const postDataForReviewRequestCodeApi = async ({
 }: DataForReviewRequestCode) => {
   const requestData = groupAccessCode ? { ...commonRequestData, groupAccessCode } : commonRequestData;
 
-  const response = await fetch(endPoint.postingDataForReviewRequestCode, {
+  const fetchOptions: RequestInit = {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
-    // TODO : 회원 리뷰 링크 API 문서 나오면 비밀번호 관련해 변경해야함
     body: JSON.stringify(requestData),
-  });
+  };
+
+  if (!groupAccessCode) {
+    fetchOptions.credentials = 'include';
+  }
+
+  const response = await fetch(endPoint.postingDataForReviewRequestCode, fetchOptions);
 
   if (!response.ok) {
     throw new Error(`${createApiErrorMessage(response.status)} ${ERROR_BOUNDARY_IGNORE_ERROR}`);

--- a/frontend/src/apis/highlight.ts
+++ b/frontend/src/apis/highlight.ts
@@ -7,17 +7,14 @@ import endPoint from './endpoints';
 interface TransformHighlightParams {
   editorAnswerMap: EditorAnswerMap;
   questionId: number;
-  reviewRequestCode: string;
 }
 
 export const transformHighlightData = ({
   editorAnswerMap,
   questionId,
-  reviewRequestCode,
 }: TransformHighlightParams): HighlightPostPayload => {
   // NOTE: 하이라이트가 있는 답변만 서버에 보내줌 (줄에 하이라이트가 없으면 빈배열)
   return {
-    reviewGroupId: Number(reviewRequestCode),
     questionId,
     highlights: [...editorAnswerMap.values()]
       .filter((answer) => answer.lineList.some((line) => line.highlightList.length > 0))
@@ -37,13 +34,17 @@ export const isValidPayload = (payload: HighlightPostPayload) => {
   return payload.highlights.every((highlight) => highlight.lines.every((line) => line.ranges.length > 0));
 };
 
-export const postHighlight = async (params: TransformHighlightParams) => {
-  const postingData = transformHighlightData(params);
+export interface PostHighlightParams {
+  dataParams: TransformHighlightParams;
+  reviewRequestCode: string;
+}
+export const postHighlight = async ({ dataParams, reviewRequestCode }: PostHighlightParams) => {
+  const postingData = transformHighlightData(dataParams);
 
   if (!isValidPayload(postingData)) return console.error('유효하지 않은 형광펜 데이터입니다');
 
   try {
-    const response = await fetch(endPoint.postingHighlight, {
+    const response = await fetch(endPoint.postingHighlight(reviewRequestCode), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -51,7 +52,6 @@ export const postHighlight = async (params: TransformHighlightParams) => {
       credentials: 'include',
       body: JSON.stringify(postingData),
     });
-
     if (!response.ok) {
       throw new Error(ERROR_BOUNDARY_IGNORE_ERROR + createApiErrorMessage(response.status));
     }

--- a/frontend/src/apis/highlight.ts
+++ b/frontend/src/apis/highlight.ts
@@ -4,9 +4,20 @@ import { EditorAnswerMap, HighlightPostPayload } from '@/types';
 import createApiErrorMessage from './apiErrorMessageCreator';
 import endPoint from './endpoints';
 
-export const transformHighlightData = (editorAnswerMap: EditorAnswerMap, questionId: number): HighlightPostPayload => {
+interface TransformHighlightParams {
+  editorAnswerMap: EditorAnswerMap;
+  questionId: number;
+  reviewRequestCode: string;
+}
+
+export const transformHighlightData = ({
+  editorAnswerMap,
+  questionId,
+  reviewRequestCode,
+}: TransformHighlightParams): HighlightPostPayload => {
   // NOTE: 하이라이트가 있는 답변만 서버에 보내줌 (줄에 하이라이트가 없으면 빈배열)
   return {
+    reviewGroupId: Number(reviewRequestCode),
     questionId,
     highlights: [...editorAnswerMap.values()]
       .filter((answer) => answer.lineList.some((line) => line.highlightList.length > 0))
@@ -26,8 +37,8 @@ export const isValidPayload = (payload: HighlightPostPayload) => {
   return payload.highlights.every((highlight) => highlight.lines.every((line) => line.ranges.length > 0));
 };
 
-export const postHighlight = async (editorAnswerMap: EditorAnswerMap, questionId: number) => {
-  const postingData = transformHighlightData(editorAnswerMap, questionId);
+export const postHighlight = async (params: TransformHighlightParams) => {
+  const postingData = transformHighlightData(params);
 
   if (!isValidPayload(postingData)) return console.error('유효하지 않은 형광펜 데이터입니다');
 

--- a/frontend/src/apis/review.ts
+++ b/frontend/src/apis/review.ts
@@ -79,13 +79,13 @@ export const getDetailedReviewApi = async ({ reviewId }: GetDetailedReviewApi) =
   return data as DetailReviewData;
 };
 
-interface GetReviewListApiProps {
+interface GetReviewListApiParams {
   reviewRequestCode: string;
   lastReviewId: number | null;
   size: number;
 }
 
-export const getReviewListApi = async (props: GetReviewListApiProps) => {
+export const getReceivedReviewListApi = async (props: GetReviewListApiParams) => {
   const response = await fetch(endPoint.gettingReceivedReviewList(props), {
     method: 'GET',
     headers: {

--- a/frontend/src/apis/review.ts
+++ b/frontend/src/apis/review.ts
@@ -79,13 +79,13 @@ export const getDetailedReviewApi = async ({ reviewId }: GetDetailedReviewApi) =
   return data as DetailReviewData;
 };
 
-interface GetReviewListApiParams {
+interface GetReceivedReviewListApiParams {
   reviewRequestCode: string;
   lastReviewId: number | null;
   size: number;
 }
 
-export const getReceivedReviewListApi = async (props: GetReviewListApiParams) => {
+export const getReceivedReviewListApi = async (props: GetReceivedReviewListApiParams) => {
   const response = await fetch(endPoint.gettingReceivedReviewList(props), {
     method: 'GET',
     headers: {

--- a/frontend/src/apis/review.ts
+++ b/frontend/src/apis/review.ts
@@ -41,8 +41,8 @@ export const postReviewApi = async (formResult: ReviewWritingFormResult) => {
 };
 
 // 받은 리뷰들에 대한 정보(프로젝트 이름, 리뷰이, 받은 리뷰 개수)
-export const getReviewInfoDataApi = async () => {
-  const response = await fetch(endPoint.gettingReviewInfoData, {
+export const getReviewSummaryInfoDataApi = async (reviewRequestCode: string) => {
+  const response = await fetch(endPoint.gettingReviewSummaryInfoData(reviewRequestCode), {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',

--- a/frontend/src/apis/review.ts
+++ b/frontend/src/apis/review.ts
@@ -119,11 +119,12 @@ export const getSectionList = async () => {
 };
 
 interface GetGroupedReviewsProps {
+  reviewRequestCode: string;
   sectionId: number;
 }
 
-export const getGroupedReviews = async ({ sectionId }: GetGroupedReviewsProps) => {
-  const response = await fetch(endPoint.gettingGroupedReviews(sectionId), {
+export const getGroupedReviews = async ({ reviewRequestCode, sectionId }: GetGroupedReviewsProps) => {
+  const response = await fetch(endPoint.gettingGroupedReviews(reviewRequestCode, sectionId), {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',

--- a/frontend/src/apis/review.ts
+++ b/frontend/src/apis/review.ts
@@ -79,13 +79,14 @@ export const getDetailedReviewApi = async ({ reviewId }: GetDetailedReviewApi) =
   return data as DetailReviewData;
 };
 
-interface GetReviewListApi {
+interface GetReviewListApiProps {
+  reviewRequestCode: string;
   lastReviewId: number | null;
   size: number;
 }
 
-export const getReviewListApi = async ({ lastReviewId, size }: GetReviewListApi) => {
-  const response = await fetch(endPoint.gettingReviewList(lastReviewId, size), {
+export const getReviewListApi = async (props: GetReviewListApiProps) => {
+  const response = await fetch(endPoint.gettingReceivedReviewList(props), {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',

--- a/frontend/src/components/highlight/components/HighlightEditor/hooks/useHighlight.ts
+++ b/frontend/src/components/highlight/components/HighlightEditor/hooks/useHighlight.ts
@@ -16,6 +16,7 @@ import { UseLongPressHighlightPositionReturn } from './useLongPressHighlightPosi
 import useMutateHighlight from './useMutateHighlight';
 
 interface UseHighlightProps extends UseLongPressHighlightPositionReturn {
+  reviewRequestCode: string;
   questionId: number;
   answerList: ReviewAnswerResponseData[];
   isEditable: boolean;
@@ -62,6 +63,7 @@ const makeInitialEditorAnswerMap = (answerList: ReviewAnswerResponseData[]) => {
 };
 
 const useHighlight = ({
+  reviewRequestCode,
   questionId,
   answerList,
   isEditable,
@@ -88,6 +90,7 @@ const useHighlight = ({
   };
 
   const { mutate: mutateHighlight } = useMutateHighlight({
+    reviewRequestCode,
     questionId,
     updateEditorAnswerMap,
     resetHighlightMenu,

--- a/frontend/src/components/highlight/components/HighlightEditor/hooks/useMutateHighlight/index.ts
+++ b/frontend/src/components/highlight/components/HighlightEditor/hooks/useMutateHighlight/index.ts
@@ -1,8 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { postHighlight } from '@/apis/highlight';
+import { postHighlight, PostHighlightParams } from '@/apis/highlight';
 import { LOCAL_STORAGE_KEY, REVIEW_QUERY_KEY, SESSION_STORAGE_KEY } from '@/constants';
-import { useReviewRequestCodeParam } from '@/hooks';
 import { EditorAnswerMap } from '@/types';
 
 export interface UseMutateHighlightProps {
@@ -36,8 +35,14 @@ const useMutateHighlight = ({
   };
 
   const mutation = useMutation({
-    mutationFn: (newEditorAnswerMap: EditorAnswerMap) =>
-      postHighlight({ editorAnswerMap: newEditorAnswerMap, questionId, reviewRequestCode }),
+    mutationFn: (newEditorAnswerMap: EditorAnswerMap) => {
+      const params: PostHighlightParams = {
+        dataParams: { editorAnswerMap: newEditorAnswerMap, questionId },
+        reviewRequestCode,
+      };
+
+      return postHighlight(params);
+    },
     onMutate: () => {
       if (mutation.isPending) return;
     },

--- a/frontend/src/components/highlight/components/HighlightEditor/hooks/useMutateHighlight/index.ts
+++ b/frontend/src/components/highlight/components/HighlightEditor/hooks/useMutateHighlight/index.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { postHighlight } from '@/apis/highlight';
 import { LOCAL_STORAGE_KEY, REVIEW_QUERY_KEY, SESSION_STORAGE_KEY } from '@/constants';
+import { useReviewRequestCodeParam } from '@/hooks';
 import { EditorAnswerMap } from '@/types';
 
 export interface UseMutateHighlightProps {
@@ -17,6 +18,7 @@ const useMutateHighlight = ({
   updateEditorAnswerMap,
   resetHighlightMenu,
 }: UseMutateHighlightProps) => {
+  const { reviewRequestCode } = useReviewRequestCodeParam();
   const queryClient = useQueryClient();
   /**
    * 형광펜 API 성공 후, 현재 질문에 대한 쿼리 캐시 무효화해서, 변경된 형광펜 데이터 불러오도록 함
@@ -33,7 +35,8 @@ const useMutateHighlight = ({
   };
 
   const mutation = useMutation({
-    mutationFn: (newEditorAnswerMap: EditorAnswerMap) => postHighlight(newEditorAnswerMap, questionId),
+    mutationFn: (newEditorAnswerMap: EditorAnswerMap) =>
+      postHighlight({ editorAnswerMap: newEditorAnswerMap, questionId, reviewRequestCode }),
     onMutate: () => {
       if (mutation.isPending) return;
     },

--- a/frontend/src/components/highlight/components/HighlightEditor/hooks/useMutateHighlight/index.ts
+++ b/frontend/src/components/highlight/components/HighlightEditor/hooks/useMutateHighlight/index.ts
@@ -6,6 +6,7 @@ import { useReviewRequestCodeParam } from '@/hooks';
 import { EditorAnswerMap } from '@/types';
 
 export interface UseMutateHighlightProps {
+  reviewRequestCode: string;
   questionId: number;
   updateEditorAnswerMap: (editorAnswerMap: EditorAnswerMap) => void;
   resetHighlightMenu: () => void;
@@ -13,12 +14,12 @@ export interface UseMutateHighlightProps {
 }
 
 const useMutateHighlight = ({
+  reviewRequestCode,
   questionId,
   handleErrorModal,
   updateEditorAnswerMap,
   resetHighlightMenu,
 }: UseMutateHighlightProps) => {
-  const { reviewRequestCode } = useReviewRequestCodeParam();
   const queryClient = useQueryClient();
   /**
    * 형광펜 API 성공 후, 현재 질문에 대한 쿼리 캐시 무효화해서, 변경된 형광펜 데이터 불러오도록 함

--- a/frontend/src/components/highlight/components/HighlightEditor/hooks/useMutateHighlight/test.ts
+++ b/frontend/src/components/highlight/components/HighlightEditor/hooks/useMutateHighlight/test.ts
@@ -33,7 +33,6 @@ describe('하이라이트 요청 테스트', () => {
       const data = transformHighlightData({
         editorAnswerMap: EDITOR_ANSWER_MAP,
         questionId: QUESTION_ID,
-        reviewRequestCode: props.reviewRequestCode,
       });
       expect(isValidPayload(data)).toBeTruthy();
 

--- a/frontend/src/components/highlight/components/HighlightEditor/hooks/useMutateHighlight/test.ts
+++ b/frontend/src/components/highlight/components/HighlightEditor/hooks/useMutateHighlight/test.ts
@@ -2,6 +2,7 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { act } from 'react';
 
 import { isValidPayload, transformHighlightData } from '@/apis/highlight';
+import { VALID_REVIEW_REQUEST_CODE } from '@/mocks/mockData';
 import QueryClientWrapper from '@/queryTestSetup/QueryClientWrapper';
 import { EditorAnswer, EditorAnswerMap } from '@/types';
 import { testWithAuthCookie } from '@/utils';
@@ -21,6 +22,7 @@ describe('하이라이트 요청 테스트', () => {
     const QUESTION_ID = 1;
 
     const props: UseMutateHighlightProps = {
+      reviewRequestCode: VALID_REVIEW_REQUEST_CODE.nonMember,
       questionId: QUESTION_ID,
       updateEditorAnswerMap: () => {},
       resetHighlightMenu: () => {},
@@ -28,7 +30,11 @@ describe('하이라이트 요청 테스트', () => {
     };
 
     const testHighlightAPI = async () => {
-      const data = transformHighlightData(EDITOR_ANSWER_MAP, QUESTION_ID);
+      const data = transformHighlightData({
+        editorAnswerMap: EDITOR_ANSWER_MAP,
+        questionId: QUESTION_ID,
+        reviewRequestCode: props.reviewRequestCode,
+      });
       expect(isValidPayload(data)).toBeTruthy();
 
       const { result } = renderHook(() => useMutateHighlight(props), {

--- a/frontend/src/components/highlight/components/HighlightEditor/index.tsx
+++ b/frontend/src/components/highlight/components/HighlightEditor/index.tsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react';
 
 import { EDITOR_ANSWER_CLASS_NAME, EDITOR_LINE_CLASS_NAME } from '@/constants';
+import useRequestCodeParam from '@/hooks/useReviewRequestCodeParam';
 import { ReviewAnswerResponseData } from '@/types';
 
 import EditorLineBlock from '../EditorLineBlock';
@@ -21,7 +22,7 @@ export interface HighlightEditorProps {
 
 const HighlightEditor = ({ questionId, answerList, handleErrorModal, handleModalMessage }: HighlightEditorProps) => {
   const editorRef = useRef<HTMLDivElement>(null);
-
+  const { reviewRequestCode } = useRequestCodeParam();
   const { isEditable, handleEditToggleButton } = useEditableState();
 
   const { highlightArea, checkHighlight } = useCheckHighlight();
@@ -45,6 +46,7 @@ const HighlightEditor = ({ questionId, answerList, handleErrorModal, handleModal
     removeHighlightByLongPress,
     resetLongPressRemovalTarget,
   } = useHighlight({
+    reviewRequestCode,
     questionId,
     answerList,
     isEditable,

--- a/frontend/src/components/layouts/ReviewDisplayLayout/ReviewInfoDataProvider.tsx
+++ b/frontend/src/components/layouts/ReviewDisplayLayout/ReviewInfoDataProvider.tsx
@@ -1,5 +1,7 @@
 import { createContext } from 'react';
 
+import { useReviewRequestCodeParam } from '@/hooks';
+
 import { useReviewInfoData } from './hooks';
 
 interface ReviewInfoData {
@@ -15,7 +17,8 @@ export const ReviewInfoDataContext = createContext<ReviewInfoData>({
 });
 
 export const ReviewInfoDataProvider = ({ children }: { children: React.ReactNode }) => {
-  const reviewInfoData = useReviewInfoData();
+  const { reviewRequestCode } = useReviewRequestCodeParam();
+  const reviewInfoData = useReviewInfoData({ reviewRequestCode });
 
   return <ReviewInfoDataContext.Provider value={reviewInfoData}>{children}</ReviewInfoDataContext.Provider>;
 };

--- a/frontend/src/components/layouts/ReviewDisplayLayout/hooks/useReviewInfoData/index.tsx
+++ b/frontend/src/components/layouts/ReviewDisplayLayout/hooks/useReviewInfoData/index.tsx
@@ -2,11 +2,12 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { getReviewSummaryInfoDataApi } from '@/apis/review';
 import { REVIEW_QUERY_KEY } from '@/constants';
-import { useReviewRequestCodeParam } from '@/hooks';
 import { ReviewInfoData } from '@/types';
 
-const useReviewInfoData = () => {
-  const { reviewRequestCode } = useReviewRequestCodeParam();
+interface UseReviewInfoDataProps {
+  reviewRequestCode: string;
+}
+const useReviewInfoData = ({ reviewRequestCode }: UseReviewInfoDataProps) => {
   const fetchReviewInfoData = async () => {
     return await getReviewSummaryInfoDataApi(reviewRequestCode);
   };

--- a/frontend/src/components/layouts/ReviewDisplayLayout/hooks/useReviewInfoData/index.tsx
+++ b/frontend/src/components/layouts/ReviewDisplayLayout/hooks/useReviewInfoData/index.tsx
@@ -1,12 +1,14 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 
-import { getReviewInfoDataApi } from '@/apis/review';
+import { getReviewSummaryInfoDataApi } from '@/apis/review';
 import { REVIEW_QUERY_KEY } from '@/constants';
+import { useReviewRequestCodeParam } from '@/hooks';
 import { ReviewInfoData } from '@/types';
 
 const useReviewInfoData = () => {
+  const { reviewRequestCode } = useReviewRequestCodeParam();
   const fetchReviewInfoData = async () => {
-    return await getReviewInfoDataApi();
+    return await getReviewSummaryInfoDataApi(reviewRequestCode);
   };
 
   const { data } = useSuspenseQuery<ReviewInfoData>({

--- a/frontend/src/components/reviewURL/URLGeneratorForm/hooks/usePostDataForReviewRequestCode/test.tsx
+++ b/frontend/src/components/reviewURL/URLGeneratorForm/hooks/usePostDataForReviewRequestCode/test.tsx
@@ -3,6 +3,7 @@ import { renderHook, act, waitFor } from '@testing-library/react';
 import { VALID_REVIEW_REQUEST_CODE } from '@/mocks/mockData/group';
 import QueryClientWrapper from '@/queryTestSetup/QueryClientWrapper';
 import { DataForReviewRequestCode } from '@/types';
+import { testWithAuthCookie } from '@/utils';
 
 import usePostDataForReviewRequestCode from '.';
 
@@ -51,6 +52,8 @@ describe('usePostDataForReviewRequestCode', () => {
       projectName: 'review-me',
     };
 
-    await testReviewRequestCode(dataForReviewRequestCode, VALID_REVIEW_REQUEST_CODE.member);
+    await testWithAuthCookie(
+      async () => await testReviewRequestCode(dataForReviewRequestCode, VALID_REVIEW_REQUEST_CODE.member),
+    );
   });
 });

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -7,6 +7,7 @@ export { default as useAccordion } from './useAccordion';
 export { default as useBreadcrumbPaths } from './useBreadcrumbPaths';
 export { default as useTopButton } from './useTopButton';
 export { default as useTrackVisitedPageInAmplitude } from './useTrackVisitedPageInAmplitude';
+export { default as useReviewRequestCodeParam } from './useReviewRequestCodeParam';
 export * from './review';
 export * from './reviewGroup';
 export * from './modal';

--- a/frontend/src/hooks/review/useGetReviewList/index.ts
+++ b/frontend/src/hooks/review/useGetReviewList/index.ts
@@ -1,6 +1,6 @@
 import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
 
-import { getReviewListApi } from '@/apis/review';
+import { getReceivedReviewListApi } from '@/apis/review';
 import { REVIEW_QUERY_KEY } from '@/constants';
 
 interface UseGetReviewListProps {
@@ -10,7 +10,7 @@ const useGetReviewList = ({ reviewRequestCode }: UseGetReviewListProps) => {
   const result = useSuspenseInfiniteQuery({
     queryKey: [REVIEW_QUERY_KEY.reviews],
     queryFn: ({ pageParam }) =>
-      getReviewListApi({
+      getReceivedReviewListApi({
         lastReviewId: pageParam === 0 ? null : pageParam, // 첫 api 요청 시, null 값 보내기
         size: 10,
         reviewRequestCode,

--- a/frontend/src/hooks/review/useGetReviewList/index.ts
+++ b/frontend/src/hooks/review/useGetReviewList/index.ts
@@ -1,20 +1,19 @@
 import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
 
 import { getReviewListApi } from '@/apis/review';
-import { REVIEW_QUERY_KEY, ROUTE_PARAM } from '@/constants';
-import useSearchParamAndQuery from '@/hooks/useSearchParamAndQuery';
+import { REVIEW_QUERY_KEY } from '@/constants';
 
-const useGetReviewList = () => {
-  const { param } = useSearchParamAndQuery({ paramKey: ROUTE_PARAM.reviewRequestCode });
-  if (!param) console.error('reviewRequestCode를 읽지 못했어요');
-
+interface UseGetReviewListProps {
+  reviewRequestCode: string;
+}
+const useGetReviewList = ({ reviewRequestCode }: UseGetReviewListProps) => {
   const result = useSuspenseInfiniteQuery({
     queryKey: [REVIEW_QUERY_KEY.reviews],
     queryFn: ({ pageParam }) =>
       getReviewListApi({
         lastReviewId: pageParam === 0 ? null : pageParam, // 첫 api 요청 시, null 값 보내기
         size: 10,
-        reviewRequestCode: param ?? '',
+        reviewRequestCode,
       }),
 
     initialPageParam: 0,

--- a/frontend/src/hooks/review/useGetReviewList/index.ts
+++ b/frontend/src/hooks/review/useGetReviewList/index.ts
@@ -1,15 +1,20 @@
 import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
 
 import { getReviewListApi } from '@/apis/review';
-import { REVIEW_QUERY_KEY } from '@/constants';
+import { REVIEW_QUERY_KEY, ROUTE_PARAM } from '@/constants';
+import useSearchParamAndQuery from '@/hooks/useSearchParamAndQuery';
 
 const useGetReviewList = () => {
+  const { param } = useSearchParamAndQuery({ paramKey: ROUTE_PARAM.reviewRequestCode });
+  if (!param) console.error('reviewRequestCode를 읽지 못했어요');
+
   const result = useSuspenseInfiniteQuery({
     queryKey: [REVIEW_QUERY_KEY.reviews],
     queryFn: ({ pageParam }) =>
       getReviewListApi({
         lastReviewId: pageParam === 0 ? null : pageParam, // 첫 api 요청 시, null 값 보내기
         size: 10,
+        reviewRequestCode: param ?? '',
       }),
 
     initialPageParam: 0,

--- a/frontend/src/hooks/review/useGetReviewList/test.ts
+++ b/frontend/src/hooks/review/useGetReviewList/test.ts
@@ -1,5 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react';
 
+import { VALID_REVIEW_REQUEST_CODE } from '@/mocks/mockData';
 import QueryClientWrapper from '@/queryTestSetup/QueryClientWrapper';
 import { testWithAuthCookie } from '@/utils';
 
@@ -8,9 +9,12 @@ import useGetReviewList from './index';
 describe('리뷰 목록 페이지 API 연동 테스트', () => {
   test('성공적으로 데이터를 가져온다', async () => {
     const testReviewListAPI = async () => {
-      const { result } = renderHook(() => useGetReviewList(), {
-        wrapper: QueryClientWrapper,
-      });
+      const { result } = renderHook(
+        () => useGetReviewList({ reviewRequestCode: VALID_REVIEW_REQUEST_CODE.nonMember }),
+        {
+          wrapper: QueryClientWrapper,
+        },
+      );
 
       await waitFor(() => {
         expect(result.current.isSuccess).toBe(true);

--- a/frontend/src/hooks/useReviewRequestCodeParam.ts
+++ b/frontend/src/hooks/useReviewRequestCodeParam.ts
@@ -4,9 +4,9 @@ import useSearchParamAndQuery from './useSearchParamAndQuery';
 
 const useRequestCodeParam = () => {
   const { param } = useSearchParamAndQuery({ paramKey: ROUTE_PARAM.reviewRequestCode });
-  if (!param) console.error('리뷰 요청 코드를 찾을 수 없어요.');
+  if (!param) throw new Error('유효하지 않은 리뷰 요청 코드예요');
 
-  return { reviewRequestCode: param ?? '' };
+  return { reviewRequestCode: param };
 };
 
 export default useRequestCodeParam;

--- a/frontend/src/hooks/useReviewRequestCodeParam.ts
+++ b/frontend/src/hooks/useReviewRequestCodeParam.ts
@@ -1,0 +1,12 @@
+import { ROUTE_PARAM } from '@/constants';
+
+import useSearchParamAndQuery from './useSearchParamAndQuery';
+
+const useRequestCodeParam = () => {
+  const { param } = useSearchParamAndQuery({ paramKey: ROUTE_PARAM.reviewRequestCode });
+  if (!param) console.error('리뷰 요청 코드를 찾을 수 없어요.');
+
+  return { reviewRequestCode: param ?? '' };
+};
+
+export default useRequestCodeParam;

--- a/frontend/src/mocks/handlers/group.ts
+++ b/frontend/src/mocks/handlers/group.ts
@@ -13,15 +13,27 @@ import {
 
 // NOTE: reviewRequestCode 생성 정상 응답
 const postDataForReviewRequestCode = () => {
-  return http.post(endPoint.postingDataForReviewRequestCode, async ({ request }) => {
+  return http.post(endPoint.postingDataForReviewRequestCode, async ({ request, cookies }) => {
     // request body의 존재 검증
     const bodyResult = await getRequestBody(request);
 
     if (bodyResult instanceof Error) return HttpResponse.json({ error: bodyResult.message }, { status: 400 });
-    const { nonMember: nonMemberReviewRequestCode, member: memberReviewRequestCode } = VALID_REVIEW_REQUEST_CODE;
+
+    const isNonMember = 'groupAccessCode' in bodyResult;
+    const reviewRequestCode = isNonMember ? VALID_REVIEW_REQUEST_CODE.nonMember : VALID_REVIEW_REQUEST_CODE.member;
+
+    // 회원용일 경우, credentials과 쿠키 검증
+    if (!isNonMember) {
+      const isError = request.credentials !== 'include' || !cookies[MOCK_AUTH_TOKEN_NAME];
+
+      if (isError) {
+        return HttpResponse.json({ error: '인증 관련 쿠키를 가져올 수 없습니다' }, { status: 401 });
+      }
+    }
+
     return HttpResponse.json(
       {
-        reviewRequestCode: 'groupAccessCode' in bodyResult ? nonMemberReviewRequestCode : memberReviewRequestCode,
+        reviewRequestCode,
       },
       { status: 200 },
     );

--- a/frontend/src/mocks/handlers/group.ts
+++ b/frontend/src/mocks/handlers/group.ts
@@ -29,7 +29,7 @@ const postDataForReviewRequestCode = () => {
 };
 
 const postPassWordValidation = () => {
-  return http.post(endPoint.checkingPassword, async ({ request, cookies }) => {
+  return http.post(endPoint.checkingReviewRequestPassword, async ({ request, cookies }) => {
     const bodyResult = await getRequestBody(request);
     if (bodyResult instanceof Error) return HttpResponse.json({ error: bodyResult.message }, { status: 400 });
 

--- a/frontend/src/mocks/handlers/group.ts
+++ b/frontend/src/mocks/handlers/group.ts
@@ -1,6 +1,6 @@
-import { http, HttpResponse } from 'msw';
+import { DefaultBodyType, http, HttpResponse, StrictRequest } from 'msw';
 
-import endPoint, { REVIEW_GROUP_DATA_API_PARAMS, REVIEW_GROUP_DATA_API_URL } from '@/apis/endpoints';
+import endPoint, { REVIEW_GROUP_DATA_API_PARAMS } from '@/apis/endpoints';
 import { API_ERROR_MESSAGE, INVALID_REVIEW_PASSWORD_MESSAGE } from '@/constants';
 import { getRequestBody } from '@/utils/mockingUtils';
 
@@ -71,28 +71,54 @@ const postPassWordValidation = () => {
   });
 };
 
+const handleReviewGroupDataRequest = (request: StrictRequest<DefaultBodyType>) => {
+  const url = new URL(request.url);
+  const params = new URLSearchParams(url.search);
+  const { queryString } = REVIEW_GROUP_DATA_API_PARAMS;
+
+  // 리뷰 그룹 정보에 대한 요청인지 확인
+  if (!params.has(queryString.reviewRequestCode)) {
+    return HttpResponse.json({ error: '리뷰 요청 코드가 없습니다.' }, { status: 400 });
+  }
+
+  // 요청 URL에서 reviewRequestCode 추출
+  const reviewRequestCode = params.get(queryString.reviewRequestCode);
+
+  // 유효한 리뷰 요청 코드인지 확인
+  if (reviewRequestCode) {
+    return HttpResponse.json(REVIEW_GROUP_DATA, { status: 200 });
+  }
+
+  return HttpResponse.json({ error: '잘못된 리뷰 그룹 데이터 요청' }, { status: 404 });
+};
+
 /**
  * 리뷰 연결 페이지에서 리뷰이 이름, 프로젝트 이름을 가져오는 목 핸들러
  */
 // 예시 출력
-const getReviewGroupData = () => {
-  return http.get(new RegExp(`^${REVIEW_GROUP_DATA_API_URL}?`), async ({ request }) => {
-    const url = new URL(request.url);
-    const params = new URLSearchParams(url.search);
-    const { queryString } = REVIEW_GROUP_DATA_API_PARAMS;
-    // 리뷰 그룹 정보에 대한 요청인지 확인
-    if (!params.has(queryString.reviewRequestCode)) return;
+const getNonMemberReviewGroupData = () => {
+  const { nonMember } = VALID_REVIEW_REQUEST_CODE;
+  const nonMemberUrl = endPoint.gettingReviewGroupData(nonMember);
 
-    //요청 url에서 reviewRequestCode 추출
-    const reviewRequestCode = params.get(queryString.reviewRequestCode);
-
-    if (reviewRequestCode) {
-      return HttpResponse.json(REVIEW_GROUP_DATA);
-    }
-
-    return HttpResponse.json({ error: '잘못된 리뷰 그룹 데이터 요청' }, { status: 404 });
+  return http.get(nonMemberUrl, async ({ request }) => {
+    return handleReviewGroupDataRequest(request);
   });
 };
-const groupHandler = [postDataForReviewRequestCode(), getReviewGroupData(), postPassWordValidation()];
+
+const getMemberReviewGroupData = () => {
+  const { member } = VALID_REVIEW_REQUEST_CODE;
+  const memberUrl = endPoint.gettingReviewGroupData(member);
+
+  return http.get(memberUrl, async ({ request }) => {
+    return handleReviewGroupDataRequest(request);
+  });
+};
+
+const groupHandler = [
+  postDataForReviewRequestCode(),
+  getNonMemberReviewGroupData(),
+  getMemberReviewGroupData(),
+  postPassWordValidation(),
+];
 
 export default groupHandler;

--- a/frontend/src/mocks/handlers/highlight.ts
+++ b/frontend/src/mocks/handlers/highlight.ts
@@ -2,12 +2,19 @@ import { http, HttpResponse } from 'msw';
 
 import endPoint from '@/apis/endpoints';
 
+import { VALID_REVIEW_REQUEST_CODE } from '../mockData';
+
 import { authorizeWithCookie } from './cookies';
 
-const postMockHighlight = () =>
-  http.post(endPoint.postingHighlight, ({ cookies }) => {
+const postMockHighlight = () => {
+  const noMemberUrl = endPoint.postingHighlight(VALID_REVIEW_REQUEST_CODE.nonMember);
+  const memberUrl = endPoint.postingHighlight(VALID_REVIEW_REQUEST_CODE.member);
+  const targetUrl = new RegExp(`^(${noMemberUrl}|${memberUrl})`);
+
+  return http.post(targetUrl, ({ cookies }) => {
     return authorizeWithCookie(cookies, () => HttpResponse.json({ status: 200 }));
   });
+};
 
 const highlightHandler = [postMockHighlight()];
 export default highlightHandler;

--- a/frontend/src/mocks/handlers/highlight.ts
+++ b/frontend/src/mocks/handlers/highlight.ts
@@ -7,9 +7,9 @@ import { VALID_REVIEW_REQUEST_CODE } from '../mockData';
 import { authorizeWithCookie } from './cookies';
 
 const postMockHighlight = () => {
-  const noMemberUrl = endPoint.postingHighlight(VALID_REVIEW_REQUEST_CODE.nonMember);
+  const nonMemberUrl = endPoint.postingHighlight(VALID_REVIEW_REQUEST_CODE.nonMember);
   const memberUrl = endPoint.postingHighlight(VALID_REVIEW_REQUEST_CODE.member);
-  const targetUrl = new RegExp(`^(${noMemberUrl}|${memberUrl})`);
+  const targetUrl = new RegExp(`^(${nonMemberUrl}|${memberUrl})`);
 
   return http.post(targetUrl, ({ cookies }) => {
     return authorizeWithCookie(cookies, () => HttpResponse.json({ status: 200 }));

--- a/frontend/src/mocks/handlers/review.ts
+++ b/frontend/src/mocks/handlers/review.ts
@@ -1,9 +1,16 @@
-import { DefaultBodyType, http, HttpResponse, StrictRequest } from 'msw';
+import {
+  DefaultBodyType,
+  http,
+  HttpResponse,
+  HttpResponseResolver,
+  JsonBodyType,
+  PathParams,
+  StrictRequest,
+} from 'msw';
 
 import endPoint, {
   DETAILED_REVIEW_API_PARAMS,
   DETAILED_REVIEW_API_URL,
-  makeGrouppedReviewsBasicUrl,
   REVIEW_GROUP_API_PARAMS,
   REVIEW_WRITING_API_PARAMS,
   REVIEW_WRITING_API_URL,
@@ -128,18 +135,25 @@ const getSectionList = () =>
     return authorizeWithCookie(cookies, () => HttpResponse.json(GROUPED_SECTION_MOCK_DATA));
   });
 
-const getGroupedReviews = () => {
-  const nonMemberUrl = makeGrouppedReviewsBasicUrl(VALID_REVIEW_REQUEST_CODE.nonMember);
-  const memberUrl = makeGrouppedReviewsBasicUrl(VALID_REVIEW_REQUEST_CODE.member);
-  const targetUrl = new RegExp(`^${nonMemberUrl}|^${memberUrl}`);
+interface HandleGroupedReviewAPIParams {
+  request: StrictRequest<DefaultBodyType>;
+  cookies: Record<string, string>;
+}
+const handleGroupedReviewsAPI = ({ request, cookies }: HandleGroupedReviewAPIParams) => {
+  const url = new URL(request.url);
+  const sectionId = url.searchParams.get(REVIEW_GROUP_API_PARAMS.queryString.sectionId);
+  const { length } = GROUPED_REVIEWS_MOCK_DATA;
+  const index = (Number(sectionId) + length) % length;
 
-  return http.get(targetUrl, ({ request, cookies }) => {
-    const url = new URL(request.url);
-    const sectionId = url.searchParams.get(REVIEW_GROUP_API_PARAMS.queryString.sectionId);
-    const { length } = GROUPED_REVIEWS_MOCK_DATA;
-    const index = (Number(sectionId) + length) % length;
+  return authorizeWithCookie(cookies, () => HttpResponse.json(GROUPED_REVIEWS_MOCK_DATA[index]));
+};
 
-    return authorizeWithCookie(cookies, () => HttpResponse.json(GROUPED_REVIEWS_MOCK_DATA[index]));
+const getGroupedReviews = (reviewRequestCode: string) => {
+  const SECTION_ID = 1;
+  const reviewUrl = endPoint.gettingGroupedReviews(reviewRequestCode, SECTION_ID);
+
+  return http.get(reviewUrl, ({ request, cookies }) => {
+    return handleGroupedReviewsAPI({ request, cookies });
   });
 };
 
@@ -149,7 +163,8 @@ const reviewHandler = [
   getMemberReceivedReviewList(null, 10),
   getDataToWriteReview(),
   getSectionList(),
-  getGroupedReviews(),
+  getGroupedReviews(VALID_REVIEW_REQUEST_CODE.member),
+  getGroupedReviews(VALID_REVIEW_REQUEST_CODE.nonMember),
   getReviewSummaryInfoData(),
   postReview(),
 ];

--- a/frontend/src/mocks/handlers/review.ts
+++ b/frontend/src/mocks/handlers/review.ts
@@ -1,4 +1,4 @@
-import { http, HttpResponse } from 'msw';
+import { DefaultBodyType, http, HttpResponse, StrictRequest } from 'msw';
 
 import endPoint, {
   DETAILED_REVIEW_API_PARAMS,
@@ -9,15 +9,15 @@ import endPoint, {
   REVIEW_WRITING_API_URL,
   VERSION2,
 } from '@/apis/endpoints';
-
 import {
+  VALID_REVIEW_REQUEST_CODE,
   DETAILED_REVIEW_MOCK_DATA,
   DETAILED_PAGE_MOCK_API_SETTING_VALUES,
   REVIEW_QUESTION_DATA,
   REVIEW_LIST,
   MOCK_REVIEW_INFO_DATA,
-  VALID_REVIEW_REQUEST_CODE,
-} from '../mockData';
+} from '@/mocks/mockData';
+
 import { GROUPED_REVIEWS_MOCK_DATA, GROUPED_SECTION_MOCK_DATA } from '../mockData/reviewCollection';
 
 import { authorizeWithCookie } from './cookies';
@@ -64,35 +64,52 @@ const getDataToWriteReview = () =>
   });
 
 // TODO: 추후 getReviewList API에서 리뷰 정보(이름, 개수...)를 내려주지 않는 경우 핸들러도 수정 필요
-const getReviewList = (lastReviewId: number | null, size: number) => {
-  return http.get(endPoint.gettingReviewList(lastReviewId, size), ({ request, cookies }) => {
-    const handleAPI = () => {
-      const url = new URL(request.url);
+const getMemberReceivedReviewList = (lastReviewId: number | null, size: number) => {
+  const memberUrl = endPoint.gettingReceivedReviewList({
+    lastReviewId,
+    size,
+    reviewRequestCode: VALID_REVIEW_REQUEST_CODE.member,
+  });
 
-      const lastReviewIdParam = url.searchParams.get('lastReviewId');
-      const lastReviewId = lastReviewIdParam === 'null' ? 0 : Number(lastReviewIdParam);
+  return http.get(memberUrl, ({ request, cookies }) => {
+    return authorizeWithCookie(cookies, () => handleReviewListAPI(request, size));
+  });
+};
 
-      const isFirstPage = lastReviewId === 0;
-      const startIndex = isFirstPage
-        ? PAGE.firstPageStartIndex
-        : REVIEW_LIST.reviews.findIndex((review) => review.reviewId === lastReviewId) + 1;
+const getNonMemberReceivedReviewList = (lastReviewId: number | null, size: number) => {
+  const nonMemberUrl = endPoint.gettingReceivedReviewList({
+    lastReviewId,
+    size,
+    reviewRequestCode: VALID_REVIEW_REQUEST_CODE.nonMember,
+  });
 
-      const endIndex = startIndex + size;
+  return http.get(nonMemberUrl, ({ request, cookies }) => {
+    return authorizeWithCookie(cookies, () => handleReviewListAPI(request, size));
+  });
+};
 
-      const paginatedReviews = REVIEW_LIST.reviews.slice(startIndex, endIndex);
+// 공통 API 처리 함수
+const handleReviewListAPI = (request: StrictRequest<DefaultBodyType>, size: number) => {
+  const url = new URL(request.url);
 
-      const isLastPage = endIndex >= REVIEW_LIST.reviews.length;
+  const lastReviewIdParam = url.searchParams.get('lastReviewId');
+  const lastReviewId = lastReviewIdParam === 'null' ? 0 : Number(lastReviewIdParam);
 
-      return HttpResponse.json({
-        revieweeName: REVIEW_LIST.revieweeName,
-        projectName: REVIEW_LIST.projectName,
-        lastReviewId: paginatedReviews.length > 0 ? paginatedReviews[paginatedReviews.length - 1].reviewId : 0,
-        isLastPage: isLastPage,
-        reviews: paginatedReviews,
-      });
-    };
+  const isFirstPage = lastReviewId === 0;
+  const startIndex = isFirstPage
+    ? PAGE.firstPageStartIndex
+    : REVIEW_LIST.reviews.findIndex((review) => review.reviewId === lastReviewId) + 1;
 
-    return authorizeWithCookie(cookies, handleAPI);
+  const endIndex = startIndex + size;
+  const paginatedReviews = REVIEW_LIST.reviews.slice(startIndex, endIndex);
+  const isLastPage = endIndex >= REVIEW_LIST.reviews.length;
+
+  return HttpResponse.json({
+    revieweeName: REVIEW_LIST.revieweeName,
+    projectName: REVIEW_LIST.projectName,
+    lastReviewId: paginatedReviews.length > 0 ? paginatedReviews[paginatedReviews.length - 1].reviewId : 0,
+    isLastPage: isLastPage,
+    reviews: paginatedReviews,
   });
 };
 
@@ -123,7 +140,8 @@ const getGroupedReviews = () => {
 
 const reviewHandler = [
   getDetailedReview(),
-  getReviewList(null, 10),
+  getNonMemberReceivedReviewList(null, 10),
+  getMemberReceivedReviewList(null, 10),
   getDataToWriteReview(),
   getSectionList(),
   getGroupedReviews(),

--- a/frontend/src/mocks/handlers/review.ts
+++ b/frontend/src/mocks/handlers/review.ts
@@ -28,9 +28,9 @@ export const PAGE = {
 };
 
 const getReviewSummaryInfoData = () => {
-  const noMemberUrl = endPoint.gettingReviewSummaryInfoData(VALID_REVIEW_REQUEST_CODE.nonMember);
+  const nonMemberUrl = endPoint.gettingReviewSummaryInfoData(VALID_REVIEW_REQUEST_CODE.nonMember);
   const memberUrl = endPoint.gettingReviewSummaryInfoData(VALID_REVIEW_REQUEST_CODE.member);
-  const targetUrl = new RegExp(`^(${noMemberUrl}|${memberUrl})`);
+  const targetUrl = new RegExp(`^(${nonMemberUrl}|${memberUrl})`);
 
   return http.get(targetUrl, ({ cookies }) => {
     return authorizeWithCookie(cookies, () => HttpResponse.json(MOCK_REVIEW_INFO_DATA));
@@ -129,9 +129,9 @@ const getSectionList = () =>
   });
 
 const getGroupedReviews = () => {
-  const noMemberUrl = makeReviewGroupBasicApiUrl(VALID_REVIEW_REQUEST_CODE.nonMember);
+  const nonMemberUrl = makeReviewGroupBasicApiUrl(VALID_REVIEW_REQUEST_CODE.nonMember);
   const memberUrl = makeReviewGroupBasicApiUrl(VALID_REVIEW_REQUEST_CODE.member);
-  const targetUrl = new RegExp(`^${noMemberUrl}|^${memberUrl}`);
+  const targetUrl = new RegExp(`^${nonMemberUrl}|^${memberUrl}`);
 
   return http.get(targetUrl, ({ request, cookies }) => {
     const url = new URL(request.url);

--- a/frontend/src/mocks/handlers/review.ts
+++ b/frontend/src/mocks/handlers/review.ts
@@ -13,10 +13,10 @@ import endPoint, {
 import {
   DETAILED_REVIEW_MOCK_DATA,
   DETAILED_PAGE_MOCK_API_SETTING_VALUES,
-  REVIEW_REQUEST_CODE,
   REVIEW_QUESTION_DATA,
   REVIEW_LIST,
   MOCK_REVIEW_INFO_DATA,
+  VALID_REVIEW_REQUEST_CODE,
 } from '../mockData';
 import { GROUPED_REVIEWS_MOCK_DATA, GROUPED_SECTION_MOCK_DATA } from '../mockData/reviewCollection';
 
@@ -57,7 +57,7 @@ const getDataToWriteReview = () =>
     const url = new URL(request.url);
     const urlRequestCode = url.searchParams.get(REVIEW_WRITING_API_PARAMS.queryString.reviewRequestCode);
 
-    if (REVIEW_REQUEST_CODE === urlRequestCode) {
+    if (VALID_REVIEW_REQUEST_CODE.nonMember === urlRequestCode) {
       return HttpResponse.json(REVIEW_QUESTION_DATA);
     }
     return HttpResponse.json({ error: '잘못된 리뷰 작성 데이터 요청' }, { status: 404 });

--- a/frontend/src/mocks/handlers/review.ts
+++ b/frontend/src/mocks/handlers/review.ts
@@ -3,7 +3,7 @@ import { DefaultBodyType, http, HttpResponse, StrictRequest } from 'msw';
 import endPoint, {
   DETAILED_REVIEW_API_PARAMS,
   DETAILED_REVIEW_API_URL,
-  makeReviewGroupBasicApiUrl,
+  makeGrouppedReviewsBasicUrl,
   REVIEW_GROUP_API_PARAMS,
   REVIEW_WRITING_API_PARAMS,
   REVIEW_WRITING_API_URL,
@@ -129,8 +129,8 @@ const getSectionList = () =>
   });
 
 const getGroupedReviews = () => {
-  const nonMemberUrl = makeReviewGroupBasicApiUrl(VALID_REVIEW_REQUEST_CODE.nonMember);
-  const memberUrl = makeReviewGroupBasicApiUrl(VALID_REVIEW_REQUEST_CODE.member);
+  const nonMemberUrl = makeGrouppedReviewsBasicUrl(VALID_REVIEW_REQUEST_CODE.nonMember);
+  const memberUrl = makeGrouppedReviewsBasicUrl(VALID_REVIEW_REQUEST_CODE.member);
   const targetUrl = new RegExp(`^${nonMemberUrl}|^${memberUrl}`);
 
   return http.get(targetUrl, ({ request, cookies }) => {

--- a/frontend/src/mocks/handlers/review.ts
+++ b/frontend/src/mocks/handlers/review.ts
@@ -4,6 +4,7 @@ import endPoint, {
   DETAILED_REVIEW_API_PARAMS,
   DETAILED_REVIEW_API_URL,
   makeReviewGroupBasicApiUrl,
+  makeReviewSummaryInfoBasicUrl,
   REVIEW_GROUP_API_PARAMS,
   REVIEW_WRITING_API_PARAMS,
   REVIEW_WRITING_API_URL,
@@ -27,10 +28,15 @@ export const PAGE = {
   firstPageStartIndex: 0,
 };
 
-const getReviewInfoData = () =>
-  http.get(endPoint.gettingReviewInfoData, ({ cookies }) => {
+const getReviewInfoData = () => {
+  const noMemberUrl = makeReviewSummaryInfoBasicUrl(VALID_REVIEW_REQUEST_CODE.nonMember);
+  const memberUrl = makeReviewSummaryInfoBasicUrl(VALID_REVIEW_REQUEST_CODE.member);
+  const targetUrl = new RegExp(`^(${noMemberUrl}|${memberUrl})`);
+
+  return http.get(targetUrl, ({ cookies }) => {
     return authorizeWithCookie(cookies, () => HttpResponse.json(MOCK_REVIEW_INFO_DATA));
   });
+};
 
 const getDetailedReview = () =>
   http.get(new RegExp(`^${DETAILED_REVIEW_API_URL}/\\d+$`), ({ request, cookies }) => {

--- a/frontend/src/mocks/handlers/review.ts
+++ b/frontend/src/mocks/handlers/review.ts
@@ -4,7 +4,6 @@ import endPoint, {
   DETAILED_REVIEW_API_PARAMS,
   DETAILED_REVIEW_API_URL,
   makeReviewGroupBasicApiUrl,
-  makeReviewSummaryInfoBasicUrl,
   REVIEW_GROUP_API_PARAMS,
   REVIEW_WRITING_API_PARAMS,
   REVIEW_WRITING_API_URL,
@@ -28,9 +27,9 @@ export const PAGE = {
   firstPageStartIndex: 0,
 };
 
-const getReviewInfoData = () => {
-  const noMemberUrl = makeReviewSummaryInfoBasicUrl(VALID_REVIEW_REQUEST_CODE.nonMember);
-  const memberUrl = makeReviewSummaryInfoBasicUrl(VALID_REVIEW_REQUEST_CODE.member);
+const getReviewSummaryInfoData = () => {
+  const noMemberUrl = endPoint.gettingReviewSummaryInfoData(VALID_REVIEW_REQUEST_CODE.nonMember);
+  const memberUrl = endPoint.gettingReviewSummaryInfoData(VALID_REVIEW_REQUEST_CODE.member);
   const targetUrl = new RegExp(`^(${noMemberUrl}|${memberUrl})`);
 
   return http.get(targetUrl, ({ cookies }) => {
@@ -130,9 +129,9 @@ const getSectionList = () =>
   });
 
 const getGroupedReviews = () => {
-  const targetUrl = new RegExp(
-    `^${makeReviewGroupBasicApiUrl(VALID_REVIEW_REQUEST_CODE.nonMember)}|^${makeReviewGroupBasicApiUrl(VALID_REVIEW_REQUEST_CODE.member)}`,
-  );
+  const noMemberUrl = makeReviewGroupBasicApiUrl(VALID_REVIEW_REQUEST_CODE.nonMember);
+  const memberUrl = makeReviewGroupBasicApiUrl(VALID_REVIEW_REQUEST_CODE.member);
+  const targetUrl = new RegExp(`^${noMemberUrl}|^${memberUrl}`);
 
   return http.get(targetUrl, ({ request, cookies }) => {
     const url = new URL(request.url);
@@ -151,7 +150,7 @@ const reviewHandler = [
   getDataToWriteReview(),
   getSectionList(),
   getGroupedReviews(),
-  getReviewInfoData(),
+  getReviewSummaryInfoData(),
   postReview(),
 ];
 

--- a/frontend/src/mocks/handlers/review.ts
+++ b/frontend/src/mocks/handlers/review.ts
@@ -1,12 +1,4 @@
-import {
-  DefaultBodyType,
-  http,
-  HttpResponse,
-  HttpResponseResolver,
-  JsonBodyType,
-  PathParams,
-  StrictRequest,
-} from 'msw';
+import { DefaultBodyType, http, HttpResponse, StrictRequest } from 'msw';
 
 import endPoint, {
   DETAILED_REVIEW_API_PARAMS,

--- a/frontend/src/mocks/handlers/review.ts
+++ b/frontend/src/mocks/handlers/review.ts
@@ -3,8 +3,8 @@ import { http, HttpResponse } from 'msw';
 import endPoint, {
   DETAILED_REVIEW_API_PARAMS,
   DETAILED_REVIEW_API_URL,
+  makeReviewGroupBasicApiUrl,
   REVIEW_GROUP_API_PARAMS,
-  REVIEW_GROUP_API_URL,
   REVIEW_WRITING_API_PARAMS,
   REVIEW_WRITING_API_URL,
   VERSION2,
@@ -107,7 +107,11 @@ const getSectionList = () =>
   });
 
 const getGroupedReviews = () => {
-  return http.get(new RegExp(`^${REVIEW_GROUP_API_URL}`), ({ request, cookies }) => {
+  const targetUrl = new RegExp(
+    `^${makeReviewGroupBasicApiUrl(VALID_REVIEW_REQUEST_CODE.nonMember)}|^${makeReviewGroupBasicApiUrl(VALID_REVIEW_REQUEST_CODE.member)}`,
+  );
+
+  return http.get(targetUrl, ({ request, cookies }) => {
     const url = new URL(request.url);
     const sectionId = url.searchParams.get(REVIEW_GROUP_API_PARAMS.queryString.sectionId);
     const { length } = GROUPED_REVIEWS_MOCK_DATA;

--- a/frontend/src/mocks/mockData/reviewWriting/reviewFormResultData.ts
+++ b/frontend/src/mocks/mockData/reviewWriting/reviewFormResultData.ts
@@ -1,9 +1,9 @@
 import { ReviewWritingFormResult } from '@/types';
 
-import { REVIEW_REQUEST_CODE } from './reviewQuestionData';
+import { VALID_REVIEW_REQUEST_CODE } from '../group';
 
 export const REVIEW_FORM_RESULT_DATA: ReviewWritingFormResult = {
-  reviewRequestCode: REVIEW_REQUEST_CODE,
+  reviewRequestCode: VALID_REVIEW_REQUEST_CODE.nonMember,
   answers: [
     { questionId: 1, selectedOptionIds: [1], text: null },
     { questionId: 2, selectedOptionIds: [6], text: null },

--- a/frontend/src/mocks/mockData/reviewWriting/reviewQuestionData.ts
+++ b/frontend/src/mocks/mockData/reviewWriting/reviewQuestionData.ts
@@ -1,7 +1,5 @@
 import { ReviewWritingCardSection, ReviewWritingFormData } from '@/types';
 
-export const REVIEW_REQUEST_CODE = 'ABCD1234';
-
 export const FEEDBACK_SECTION: ReviewWritingCardSection = {
   sectionId: 7,
   sectionName: '단점 피드백',

--- a/frontend/src/pages/ReviewCollectionPage/components/ReviewCollectionPageContents/index.tsx
+++ b/frontend/src/pages/ReviewCollectionPage/components/ReviewCollectionPageContents/index.tsx
@@ -28,7 +28,7 @@ const ReviewCollectionPageContents = () => {
   const [selectedSection, setSelectedSection] = useState<DropdownItem>(dropdownSectionList[0]);
 
   const { data: groupedReviews } = useGetGroupedReviews({
-    reviewRequestCode: reviewRequestCode ?? '',
+    reviewRequestCode: reviewRequestCode,
     sectionId: selectedSection.value as number,
   });
 

--- a/frontend/src/pages/ReviewCollectionPage/components/ReviewCollectionPageContents/index.tsx
+++ b/frontend/src/pages/ReviewCollectionPage/components/ReviewCollectionPageContents/index.tsx
@@ -4,8 +4,8 @@ import { Accordion, Dropdown, HighlightEditorContainer } from '@/components';
 import { DropdownItem } from '@/components/common/Dropdown';
 import ReviewEmptySection from '@/components/common/ReviewEmptySection';
 import { ReviewInfoDataContext } from '@/components/layouts/ReviewDisplayLayout/ReviewInfoDataProvider';
-import { REVIEW_EMPTY, ROUTE_PARAM, SESSION_STORAGE_KEY } from '@/constants';
-import { useSearchParamAndQuery } from '@/hooks';
+import { REVIEW_EMPTY, SESSION_STORAGE_KEY } from '@/constants';
+import { useReviewRequestCodeParam } from '@/hooks';
 import { GroupedReview } from '@/types';
 import { substituteString } from '@/utils';
 
@@ -16,8 +16,7 @@ import DoughnutChart from '../DoughnutChart';
 import * as S from './styles';
 
 const ReviewCollectionPageContents = () => {
-  const { param: reviewRequestCode } = useSearchParamAndQuery({ paramKey: ROUTE_PARAM.reviewRequestCode });
-  if (!reviewRequestCode) console.error('reviewRequestCode를 읽지 못했어요');
+  const { reviewRequestCode } = useReviewRequestCodeParam();
 
   const { revieweeName, projectName, totalReviewCount } = useContext(ReviewInfoDataContext);
 

--- a/frontend/src/pages/ReviewCollectionPage/components/ReviewCollectionPageContents/index.tsx
+++ b/frontend/src/pages/ReviewCollectionPage/components/ReviewCollectionPageContents/index.tsx
@@ -4,7 +4,8 @@ import { Accordion, Dropdown, HighlightEditorContainer } from '@/components';
 import { DropdownItem } from '@/components/common/Dropdown';
 import ReviewEmptySection from '@/components/common/ReviewEmptySection';
 import { ReviewInfoDataContext } from '@/components/layouts/ReviewDisplayLayout/ReviewInfoDataProvider';
-import { REVIEW_EMPTY, SESSION_STORAGE_KEY } from '@/constants';
+import { REVIEW_EMPTY, ROUTE_PARAM, SESSION_STORAGE_KEY } from '@/constants';
+import { useSearchParamAndQuery } from '@/hooks';
 import { GroupedReview } from '@/types';
 import { substituteString } from '@/utils';
 
@@ -15,16 +16,22 @@ import DoughnutChart from '../DoughnutChart';
 import * as S from './styles';
 
 const ReviewCollectionPageContents = () => {
+  const { param: reviewRequestCode } = useSearchParamAndQuery({ paramKey: ROUTE_PARAM.reviewRequestCode });
+  if (!reviewRequestCode) console.error('reviewRequestCode를 읽지 못했어요');
+
   const { revieweeName, projectName, totalReviewCount } = useContext(ReviewInfoDataContext);
 
   const { data: reviewSectionList } = useGetSectionList();
-
   const dropdownSectionList = reviewSectionList.sections.map((section) => {
     return { text: section.name, value: section.id };
   });
 
   const [selectedSection, setSelectedSection] = useState<DropdownItem>(dropdownSectionList[0]);
-  const { data: groupedReviews } = useGetGroupedReviews({ sectionId: selectedSection.value as number });
+
+  const { data: groupedReviews } = useGetGroupedReviews({
+    reviewRequestCode: reviewRequestCode ?? '',
+    sectionId: selectedSection.value as number,
+  });
 
   groupedReviews.reviews.forEach((review) => {
     review.votes?.sort((voteA, voteB) => voteB.count - voteA.count);

--- a/frontend/src/pages/ReviewCollectionPage/hooks/useGetGroupedReviews.ts
+++ b/frontend/src/pages/ReviewCollectionPage/hooks/useGetGroupedReviews.ts
@@ -5,12 +5,13 @@ import { REVIEW_QUERY_KEY, SESSION_STORAGE_KEY } from '@/constants';
 import { GroupedReviews } from '@/types';
 
 interface UseGetGroupedReviewsProps {
+  reviewRequestCode: string;
   sectionId: number;
 }
 
-const useGetGroupedReviews = ({ sectionId }: UseGetGroupedReviewsProps) => {
+const useGetGroupedReviews = ({ reviewRequestCode, sectionId }: UseGetGroupedReviewsProps) => {
   const fetchGroupedReviews = async () => {
-    const result = await getGroupedReviews({ sectionId });
+    const result = await getGroupedReviews({ reviewRequestCode, sectionId });
     sessionStorage.setItem(SESSION_STORAGE_KEY.currentReviewCollectionSectionId, sectionId.toString());
     return result;
   };

--- a/frontend/src/pages/ReviewListPage/components/ReviewListPageContents/index.tsx
+++ b/frontend/src/pages/ReviewListPage/components/ReviewListPageContents/index.tsx
@@ -7,7 +7,7 @@ import UndraggableWrapper from '@/components/common/UndraggableWrapper';
 import { ReviewInfoDataContext } from '@/components/layouts/ReviewDisplayLayout/ReviewInfoDataProvider';
 import { REVIEW_EMPTY } from '@/constants';
 import { ROUTE } from '@/constants/route';
-import { useGetReviewList, useSearchParamAndQuery } from '@/hooks';
+import { useGetReviewList, useReviewRequestCodeParam } from '@/hooks';
 
 import { useInfiniteScroll } from '../../hooks';
 
@@ -15,13 +15,11 @@ import * as S from './styles';
 
 const ReviewListPageContents = () => {
   const navigate = useNavigate();
+  const { reviewRequestCode } = useReviewRequestCodeParam();
 
-  const { data, fetchNextPage, isLoading, isSuccess } = useGetReviewList();
+  const { data, fetchNextPage, isLoading, isSuccess } = useGetReviewList({ reviewRequestCode });
+
   const { totalReviewCount } = useContext(ReviewInfoDataContext);
-
-  const { param: reviewRequestCode } = useSearchParamAndQuery({
-    paramKey: 'reviewRequestCode',
-  });
 
   const handleReviewClick = (id: number) => {
     navigate(`/${ROUTE.detailedReview}/${reviewRequestCode}/${id}`);

--- a/frontend/src/pages/ReviewWritingPage/form/hooks/question/useGetDataToWrite/test.ts
+++ b/frontend/src/pages/ReviewWritingPage/form/hooks/question/useGetDataToWrite/test.ts
@@ -1,15 +1,18 @@
 import { renderHook, waitFor } from '@testing-library/react';
 
-import { REVIEW_REQUEST_CODE } from '@/mocks/mockData';
+import { VALID_REVIEW_REQUEST_CODE } from '@/mocks/mockData';
 import QueryClientWrapper from '@/queryTestSetup/QueryClientWrapper';
 
 import useGetReviewFormData from '.';
 
 describe('리뷰 작성을 위한 데이터 요청 테스트', () => {
   test('성공적으로 데이터를 가져온다.', async () => {
-    const { result } = renderHook(() => useGetReviewFormData({ reviewRequestCode: REVIEW_REQUEST_CODE }), {
-      wrapper: QueryClientWrapper,
-    });
+    const { result } = renderHook(
+      () => useGetReviewFormData({ reviewRequestCode: VALID_REVIEW_REQUEST_CODE.nonMember }),
+      {
+        wrapper: QueryClientWrapper,
+      },
+    );
 
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true);

--- a/frontend/src/pages/ReviewZonePage/index.tsx
+++ b/frontend/src/pages/ReviewZonePage/index.tsx
@@ -5,7 +5,7 @@ import { useRecoilState } from 'recoil';
 import ReviewZoneIcon from '@/assets/reviewZone.svg';
 import { Button, ImgWithSkeleton } from '@/components';
 import { ROUTE } from '@/constants';
-import { useGetReviewGroupData, useSearchParamAndQuery, useModals } from '@/hooks';
+import { useGetReviewGroupData, useModals, useReviewRequestCodeParam } from '@/hooks';
 import { reviewRequestCodeAtom } from '@/recoil';
 import { calculateParticle } from '@/utils';
 
@@ -27,11 +27,7 @@ const ReviewZonePage = () => {
 
   const navigate = useNavigate();
 
-  const { param: reviewRequestCode } = useSearchParamAndQuery({
-    paramKey: 'reviewRequestCode',
-  });
-
-  if (!reviewRequestCode) throw new Error('유효하지 않은 리뷰 요청 코드예요');
+  const { reviewRequestCode } = useReviewRequestCodeParam();
 
   useEffect(() => {
     if (!storedReviewRequestCode && reviewRequestCode) {

--- a/frontend/src/types/highlight.ts
+++ b/frontend/src/types/highlight.ts
@@ -25,7 +25,6 @@ export interface ReviewAnswerResponseData {
  * 하이라이트 변경 시, 서버에 보내는 하이라이트 정보 타입
  */
 export interface HighlightPostPayload {
-  reviewGroupId: number;
   questionId: number;
   highlights: {
     answerId: number;

--- a/frontend/src/types/highlight.ts
+++ b/frontend/src/types/highlight.ts
@@ -25,6 +25,7 @@ export interface ReviewAnswerResponseData {
  * 하이라이트 변경 시, 서버에 보내는 하이라이트 정보 타입
  */
 export interface HighlightPostPayload {
+  reviewGroupId: number;
   questionId: number;
   highlights: {
     answerId: number;


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #1102

---
### ⚠️ 리뷰 전 읽기1. reviewGroupId 대신 revieRequestCode 사용
원래는 reviewRequestCode가 아닌 reviewGroupId를 사용해야해요.
그러나 아래의 이유로, 이번 배포에서는 url로 받을 수 있는 reviewRequestCode를 대신 사용하는 것으로 백엔드와 결정했어요.
이번 배포 이후에 이 부분을 백엔드, 프론트가 다 같이 이야기를 나눠봐야해요.

-  백엔드쪽에서 내려주는 reviewGroupId가 현재 없음
-  프론트 코드에서 데이터를 받아오는 곳과 이를 활용해 다시 api를 요청하는 코드간의 뎁스가 있어서 단기간에 이를 해결할 수 없음 (아마 context api를 적용해야할 듯 싶어요) 

### 리뷰 전 읽기2. 형광펜 API 변경 사항
아직 API 문서에 반영되지 않은 형광펜 API 추가 사항이에요.

```
post 요청 url : groups/{reviewRequestCode}/highlights
post 요청 body : reviewGroupId 는 없다. 그 이외는 모두 api 문서와 동일
```

### 변경된 API

**리뷰미 api 변경 사항**: 리뷰 확인 코드 

**리뷰 그룹 아이디가 포함되어야하는 것** 
- 섹션별 받은 리뷰 모아보기
- 받은 리뷰 목록 조회
- 받은 리뷰 요약 조회
- 하이라이트 수정


### 🚀 어떤 기능을 구현했나요 ?
-  이번 배포에서 변경되는 API요청 URL을 적용
  -  groups가 공통적으로 들어가서, 이를 상수로 재사용
- 여러 기능이 추가되면서 API resource가 헷갈리는 부분이 생김 -> 몇몇  API의 endpoint, 핸들러 함수명을 수정 (ex: 지신이 받은 리뷰 목록의 경우, receivedReviewList 라는 표현으로 수정)
- 회원 리뷰 그룹 생성 시, credentials 추가 😓
 - 목 핸들러에서 회원/비회원을 분기 처리해 회원으로 리뷰 그룹 생성 시 쿠키 여부와 credentials='include'여부를 모두 검사

 
#### 🤔 credentials를 검사하는 이유? 
하나의 api 핸들러에서 회원인지 여부에 따라 crendentials 속성을 fetch option에 추가해주고 있어요.
혹시 모를 오류를 사전에 감지하기 위해서 목 핸들러에서 이를 감지하도록 했어요.  

#### 🤔  컴포넌트에서 API 핸들러를 실행하는 훅에 reviewRequestCode를 넘겨주는 이유?
훅은 데이터 로직, 컴포넌트는 UI 로직을 담당하는 것이 더 직관적라고 생각해서 이렇게 진행했어요.
이렇게 분리하니, 훅만으로 하는 API 테스트 시 url을 지정해주는 번거로운 작업이 없이 props만으로 reviewRequestCode를 주면 되어서 편했어요.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 구현하고 몇번 더 검토했지만, 혹시 모르니 API문서와 함께 더블 체크 부탁드립니다. 🙏

### 📚 참고 자료, 할 말
