### PR TITLE
[BE] docs: dto 필드명 개선

### DIFF
--- a/backend/src/main/java/reviewme/review/service/dto/response/list/AuthoredReviewElementResponse.java
+++ b/backend/src/main/java/reviewme/review/service/dto/response/list/AuthoredReviewElementResponse.java
@@ -10,6 +10,6 @@ public record AuthoredReviewElementResponse(
         String projectName,
         LocalDateTime createdAt,
         String contentPreview,
-        List<SelectedCategoryOptionResponse> categories
+        List<SelectedCategoryOptionResponse> categoryOptions
 ) {
 }

--- a/backend/src/main/java/reviewme/review/service/dto/response/list/ReceivedReviewPageElementResponse.java
+++ b/backend/src/main/java/reviewme/review/service/dto/response/list/ReceivedReviewPageElementResponse.java
@@ -8,6 +8,6 @@ public record ReceivedReviewPageElementResponse(
         long reviewId,
         LocalDateTime createdAt,
         String contentPreview,
-        List<SelectedCategoryOptionResponse> categories
+        List<SelectedCategoryOptionResponse> categoryOptions
 ) {
 }

--- a/backend/src/test/java/reviewme/api/ReviewApiTest.java
+++ b/backend/src/test/java/reviewme/api/ReviewApiTest.java
@@ -247,9 +247,9 @@ class ReviewApiTest extends ApiTest {
                 fieldWithPath("reviews[].createdAt").description("리뷰 작성 날짜"),
                 fieldWithPath("reviews[].contentPreview").description("리뷰 미리보기"),
 
-                fieldWithPath("reviews[].categories[]").description("선택된 카테고리 목록"),
-                fieldWithPath("reviews[].categories[].optionId").description("카테고리 ID"),
-                fieldWithPath("reviews[].categories[].content").description("카테고리 내용")
+                fieldWithPath("reviews[].categoryOptions[]").description("선택된 카테고리 목록"),
+                fieldWithPath("reviews[].categoryOptions[].optionId").description("카테고리 ID"),
+                fieldWithPath("reviews[].categoryOptions[].content").description("카테고리 내용")
         };
 
         RestDocumentationResultHandler handler = document(
@@ -417,9 +417,9 @@ class ReviewApiTest extends ApiTest {
                 fieldWithPath("reviews[].createdAt").description("리뷰 작성 날짜"),
                 fieldWithPath("reviews[].contentPreview").description("리뷰 미리보기"),
 
-                fieldWithPath("reviews[].categories[]").description("선택된 카테고리 목록"),
-                fieldWithPath("reviews[].categories[].optionId").description("카테고리 ID"),
-                fieldWithPath("reviews[].categories[].content").description("카테고리 내용")
+                fieldWithPath("reviews[].categoryOptions[]").description("선택된 카테고리 목록"),
+                fieldWithPath("reviews[].categoryOptions[].optionId").description("카테고리 ID"),
+                fieldWithPath("reviews[].categoryOptions[].content").description("카테고리 내용")
         };
 
         RestDocumentationResultHandler handler = document(

--- a/backend/src/test/java/reviewme/api/ReviewApiTest.java
+++ b/backend/src/test/java/reviewme/api/ReviewApiTest.java
@@ -392,7 +392,7 @@ class ReviewApiTest extends ApiTest {
                 new AuthoredReviewElementResponse(2L, "테드2", "리뷰미", LocalDateTime.of(2024, 8, 1, 0, 0), "(리뷰 미리보기 2)",
                         List.of(new SelectedCategoryOptionResponse(2L, "카테고리 2")))
         );
-      
+
         AuthoredReviewsResponse response = new AuthoredReviewsResponse(1L, true, authoredReviews);
         given(reviewListLookupService.getAuthoredReviews(anyLong(), nullable(Long.class), nullable(Integer.class)))
                 .willReturn(response);


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #1136

---

### 🚀 어떤 기능을 구현했나요 ?
- `ReceivedReviewPageElementResponse`, `AuthoredReviewElementResponse`에서 사용되는 `List<SelectedCategoryOptionResponse> categories`의 필드명을 **categoryOptions**로 변경합니다.
- 특정 카테고리들을 나타내기 보단, "카테고리 타입의 옵션 항목들"이 더 명확해 보입니다.

### 🔥 어떻게 해결했나요 ?
- 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 혹시 더 좋은 네이밍이 있다면 말해주세요.

### 📚 참고 자료, 할 말
