### PR TITLE
[BE] chore: flyway 중복 review_request_code 제거 sql 수정

### DIFF
--- a/backend/src/main/resources/db/migration/V11__uique_constraint_add.sql
+++ b/backend/src/main/resources/db/migration/V11__uique_constraint_add.sql
@@ -1,12 +1,13 @@
 -- 기존에 중복된 데이터를 제거합니다.
 -- 중복된 review_request_code 중 가장 오래된 하나만 남기고 삭제합니다.
 
-DELETE FROM review_group
-WHERE id NOT IN (
-    SELECT MIN(id)
+DELETE rg FROM review_group rg
+LEFT JOIN (
+    SELECT MIN(id) AS min_id
     FROM review_group
     GROUP BY review_request_code
-);
+) AS keep ON rg.id = keep.min_id
+WHERE keep.min_id IS NULL;
 
 
 -- 중복이 허용되지 않는 컬럼에 UNIQUE 제약 조건을 추가합니다.


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #1140

---

### 🚀 어떤 기능을 구현했나요 ?
- 현재는 review_group 테이블이 DELETE의 대상이면서 FROM 절에서도 사용하고 있습니다.
- MySQL에서는 DELETE에 동일한 테이블을 서브쿼리의 FROM 절에서 참조할 수 없다고 합니다.
- 따라서 수정이 서브쿼리를 사용하지 않으면서 삭제할 수 있는 방법이 필요합니다.

### 🔥 어떻게 해결했나요 ?
- 찾아보니, LEFT JOIN을 통해 가능하다고 하여 적용해봤습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
