### PR TITLE
[FE] fix: 링크 페이지에서 링크 복사 버튼 클릭 후 페이지 전환 문제 해결 및 로그인/로그아웃 시 토스트 위치 변경

### DIFF
--- a/frontend/src/components/common/CopyTextButton/index.tsx
+++ b/frontend/src/components/common/CopyTextButton/index.tsx
@@ -8,7 +8,9 @@ interface CopyTextButtonProps {
 }
 
 const CopyTextButton = ({ targetText, alt }: CopyTextButtonProps) => {
-  const handleCopyTextButtonClick = async () => {
+  const handleCopyTextButtonClick = async (event: React.MouseEvent) => {
+    event.stopPropagation();
+
     try {
       await navigator.clipboard.writeText(targetText);
       alert('텍스트가 클립보드에 복사되었어요');

--- a/frontend/src/components/reviewURL/ReviewZoneURLModal/index.tsx
+++ b/frontend/src/components/reviewURL/ReviewZoneURLModal/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { AlertModal, CopyTextButton, Checkbox } from '@/components';
+import { useGetUserProfile } from '@/hooks/oAuth';
 
 import * as S from './styles';
 interface ReviewZoneURLModalProps {
@@ -10,6 +11,7 @@ interface ReviewZoneURLModalProps {
 
 const ReviewZoneURLModal = ({ reviewZoneURL, closeModal }: ReviewZoneURLModalProps) => {
   const [isChecked, setIsChecked] = useState(false);
+  const { isUserLoggedIn } = useGetUserProfile();
 
   const handleCheckboxClick = () => {
     setIsChecked(!isChecked);
@@ -67,9 +69,11 @@ const ReviewZoneURLModal = ({ reviewZoneURL, closeModal }: ReviewZoneURLModalPro
               height: '2.7rem',
             }}
           />
-          <S.CheckMessage>링크를 저장해두었어요!</S.CheckMessage>
+          <S.CheckMessage>
+            {isUserLoggedIn ? '링크는 프로젝트 목록에서 확인할 수 있어요!' : '링크를 저장해두었어요!'}
+          </S.CheckMessage>
         </S.CheckContainer>
-        <S.WarningMessage>* 창이 닫히면 링크를 다시 확인할 수 없어요!</S.WarningMessage>
+        {!isUserLoggedIn && <S.WarningMessage>* 창이 닫히면 링크를 다시 확인할 수 없어요!</S.WarningMessage>}
       </S.ReviewZoneURLModal>
     </AlertModal>
   );

--- a/frontend/src/hooks/oAuth/useOAuthLogout.ts
+++ b/frontend/src/hooks/oAuth/useOAuthLogout.ts
@@ -25,11 +25,11 @@ const useOAuthLogout = () => {
 
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [OAUTH_QUERY_KEY.userProfile] });
-      showToast({ type: 'success', message: '로그아웃이 완료되었어요!', position: 'top' });
+      showToast({ type: 'success', message: '로그아웃 완료!', position: 'top' });
       redirectOnSuccess();
     },
     onError: () => {
-      showToast({ type: 'error', message: '로그아웃에 실패했어요. 다시 시도해주세요!', position: 'top' });
+      showToast({ type: 'error', message: '로그아웃 실패! 다시 시도해주세요!', position: 'top' });
     },
   });
 

--- a/frontend/src/hooks/oAuth/useOAuthLogout.ts
+++ b/frontend/src/hooks/oAuth/useOAuthLogout.ts
@@ -29,7 +29,7 @@ const useOAuthLogout = () => {
       redirectOnSuccess();
     },
     onError: () => {
-      showToast({ type: 'error', message: '로그아웃 실패! 다시 시도해주세요!', position: 'top' });
+      showToast({ type: 'error', message: '로그아웃에 실패했어요. 다시 시도해주세요!', position: 'top' });
     },
   });
 

--- a/frontend/src/hooks/oAuth/useOAuthLogout.ts
+++ b/frontend/src/hooks/oAuth/useOAuthLogout.ts
@@ -25,11 +25,11 @@ const useOAuthLogout = () => {
 
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [OAUTH_QUERY_KEY.userProfile] });
-      showToast({ type: 'success', message: '로그아웃이 완료되었어요!' });
+      showToast({ type: 'success', message: '로그아웃이 완료되었어요!', position: 'top' });
       redirectOnSuccess();
     },
     onError: () => {
-      showToast({ type: 'error', message: '로그아웃에 실패했어요. 다시 시도해주세요!' });
+      showToast({ type: 'error', message: '로그아웃에 실패했어요. 다시 시도해주세요!', position: 'top' });
     },
   });
 

--- a/frontend/src/pages/OAuthCallbackPage/index.tsx
+++ b/frontend/src/pages/OAuthCallbackPage/index.tsx
@@ -41,14 +41,14 @@ const OAuthCallbackPage = () => {
       {
         onSuccess: () => {
           navigate(redirectUrl, { replace: true });
-          showToast({ type: 'success', message: '환영합니다! 첫 리뷰를 받아보세요!', position: 'top' });
+          showToast({ type: 'success', message: '로그인 성공! 환영해요!', position: 'top' });
 
           // 로그인 성공 시 프로필 정보를 받아오도록 함
           queryClient.invalidateQueries({ queryKey: [OAUTH_QUERY_KEY.userProfile] });
         },
         onError: () => {
           navigate(prevUrl, { replace: true });
-          showToast({ type: 'error', message: '로그인에 실패했어요. 다시 시도해주세요!', position: 'top' });
+          showToast({ type: 'error', message: '로그인 실패! 다시 시도해주세요!', position: 'top' });
         },
       },
     );

--- a/frontend/src/pages/OAuthCallbackPage/index.tsx
+++ b/frontend/src/pages/OAuthCallbackPage/index.tsx
@@ -48,7 +48,7 @@ const OAuthCallbackPage = () => {
         },
         onError: () => {
           navigate(prevUrl, { replace: true });
-          showToast({ type: 'error', message: '로그인 실패! 다시 시도해주세요!', position: 'top' });
+          showToast({ type: 'error', message: '로그인에 실패했어요. 다시 시도해주세요!', position: 'top' });
         },
       },
     );

--- a/frontend/src/pages/OAuthCallbackPage/index.tsx
+++ b/frontend/src/pages/OAuthCallbackPage/index.tsx
@@ -41,14 +41,14 @@ const OAuthCallbackPage = () => {
       {
         onSuccess: () => {
           navigate(redirectUrl, { replace: true });
-          showToast({ type: 'success', message: '환영합니다! 첫 리뷰를 받아보세요!' });
+          showToast({ type: 'success', message: '환영합니다! 첫 리뷰를 받아보세요!', position: 'top' });
 
           // 로그인 성공 시 프로필 정보를 받아오도록 함
           queryClient.invalidateQueries({ queryKey: [OAUTH_QUERY_KEY.userProfile] });
         },
         onError: () => {
           navigate(prevUrl, { replace: true });
-          showToast({ type: 'error', message: '로그인에 실패했어요. 다시 시도해주세요!' });
+          showToast({ type: 'error', message: '로그인에 실패했어요. 다시 시도해주세요!', position: 'top' });
         },
       },
     );


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #1143

---

### 🚀 어떤 기능을 구현했나요 ?
- 링크 페이지에서 링크 복사하기 버튼을 클릭하면, 복사가 완료되었다는 alert과 함께 목록 페이지로 넘어가는 문제가 있었습니다. event.stopPropagation() 추가했습니다.
- 로그아웃 버튼이 헤더쪽에 있다보니 Toast가 아래에 있을 경우, 눈에 잘 띄지 않아 로그인/로그아웃 시 Toast 위치를 탑으로 변경했습니다.
```tsx
showToast({ type: 'error', message: '로그아웃에 실패했어요. 다시 시도해주세요!', position: 'top' });
```
- 리뷰 링크 페이지에서 링크 생성 시 나오는 URL 모달 문구를 변경했습니다.

![스크린샷 2025-02-19 오후 9 30 15](https://github.com/user-attachments/assets/710d8ff6-e75a-4821-8753-1b11cf371e93)


### 🔥 어떻게 해결했나요 ?
- 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
- 단 1분이면 approve 가능한 PR입니다...!