### PR TITLE
[FE] fix: 로그인 요청 API 관련 수정

### DIFF
--- a/frontend/src/apis/endpoints.ts
+++ b/frontend/src/apis/endpoints.ts
@@ -56,9 +56,6 @@ export const WRITTEN_REVIEW_PARAMS = {
 
 export const OAUTH_LOGIN_API_PARAMS = {
   resource: 'auth/github',
-  queryString: {
-    code: 'code',
-  },
 };
 
 export const REVIEW_WRITING_API_URL = `${serverUrl}/${VERSION2}/${REVIEW_WRITING_API_PARAMS.resource}`;
@@ -102,8 +99,7 @@ const endPoint = {
     `${REVIEW_GROUPS_BASIC_API_URL}/${reviewRequestCode}/reviews/gather?${REVIEW_GROUP_API_PARAMS.queryString.sectionId}=${sectionId}`,
   postingHighlight: (reviewRequestCode: string) => `${REVIEW_GROUPS_BASIC_API_URL}/${reviewRequestCode}/highlights`,
   gettingUserProfile: `${serverUrl}/${VERSION2}/members/profile`,
-  postingOAuthLogin: (gitHubAuthCode: string) =>
-    `${OAUTH_API_URL}?${OAUTH_LOGIN_API_PARAMS.queryString.code}=${gitHubAuthCode}`,
+  postingOAuthLogin: `${OAUTH_API_URL}`,
   postingOAuthLogout: `${serverUrl}/${VERSION2}/auth/logout`,
   gettingWrittenReviewList: (lastReviewId: number | null, size: number) => {
     const basicUrl = `${WRITTEN_REVIEW_LIST_API_URL}?${WRITTEN_REVIEW_PARAMS.queryString.size}=${size}`;

--- a/frontend/src/apis/oAuth.ts
+++ b/frontend/src/apis/oAuth.ts
@@ -13,6 +13,7 @@ export const postOAuthLoginApi = async ({ gitHubAuthCode }: GetOAuthLoginApiProp
     headers: {
       'Content-Type': 'application/json',
     },
+    body: JSON.stringify({ code: gitHubAuthCode }),
   });
 
   if (!response.ok) {

--- a/frontend/src/apis/oAuth.ts
+++ b/frontend/src/apis/oAuth.ts
@@ -8,7 +8,7 @@ interface GetOAuthLoginApiProps {
 }
 
 export const postOAuthLoginApi = async ({ gitHubAuthCode }: GetOAuthLoginApiProps) => {
-  const response = await fetch(endPoint.postingOAuthLogin(gitHubAuthCode), {
+  const response = await fetch(endPoint.postingOAuthLogin, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/frontend/src/mocks/handlers/oAuth.ts
+++ b/frontend/src/mocks/handlers/oAuth.ts
@@ -1,22 +1,25 @@
 import { http, HttpResponse } from 'msw';
 
-import endPoint, { OAUTH_API_URL, OAUTH_LOGIN_API_PARAMS } from '@/apis/endpoints';
+import endPoint from '@/apis/endpoints';
+import { getRequestBody } from '@/utils/mockingUtils';
 
 import { memberOnlyCookie, MOCK_LOGIN_TOKEN_NAME, MOCK_USER_PROFILE } from '../mockData';
 
 import { authorizeWithCookie } from './cookies';
 
 const postOAuthLogin = () =>
-  http.post(new RegExp(`^${OAUTH_API_URL}`), async ({ request }) => {
-    const url = new URL(request.url);
-    const gitHubAuthCode = url.searchParams.get(OAUTH_LOGIN_API_PARAMS.queryString.code);
+  http.post(endPoint.postingOAuthLogin, async ({ request }) => {
+    const bodyResult = await getRequestBody(request);
+
+    // 요청 body가 없거나, code가 포함되지 않는 경우 에러
+    if (bodyResult instanceof Error || !bodyResult.code)
+      return HttpResponse.json({ error: bodyResult.message }, { status: 400 });
+
     // 로그인 성공 시 세션 쿠키 생성
-    if (gitHubAuthCode) {
-      return new HttpResponse(null, {
-        status: 204,
-        headers: { 'Set-cookie': `${MOCK_LOGIN_TOKEN_NAME}=2024-review-me` },
-      });
-    }
+    return HttpResponse.json(MOCK_USER_PROFILE, {
+      status: 200,
+      headers: { 'Set-cookie': `${MOCK_LOGIN_TOKEN_NAME}=2024-review-me` },
+    });
 
     return HttpResponse.json({ error: '깃허브 인증에 실패했어요' }, { status: 401 });
   });

--- a/frontend/src/mocks/handlers/oAuth.ts
+++ b/frontend/src/mocks/handlers/oAuth.ts
@@ -10,18 +10,17 @@ import { authorizeWithCookie } from './cookies';
 const postOAuthLogin = () =>
   http.post(endPoint.postingOAuthLogin, async ({ request }) => {
     const bodyResult = await getRequestBody(request);
+    const isValidBody = 'code' in bodyResult;
 
-    // 요청 body가 없거나, code가 포함되지 않는 경우 에러
-    if (bodyResult instanceof Error || !bodyResult.code)
-      return HttpResponse.json({ error: bodyResult.message }, { status: 400 });
+    // body가 없거나, code가 전달되지 않는 경우 에러
+    if (bodyResult instanceof Error || !isValidBody)
+      return HttpResponse.json({ error: '깃허브 인증에 실패했어요' }, { status: 400 });
 
     // 로그인 성공 시 세션 쿠키 생성
     return HttpResponse.json(MOCK_USER_PROFILE, {
       status: 200,
       headers: { 'Set-cookie': `${MOCK_LOGIN_TOKEN_NAME}=2024-review-me` },
     });
-
-    return HttpResponse.json({ error: '깃허브 인증에 실패했어요' }, { status: 401 });
   });
 
 const getUserProfile = () =>

--- a/frontend/src/pages/OAuthCallbackPage/index.tsx
+++ b/frontend/src/pages/OAuthCallbackPage/index.tsx
@@ -1,9 +1,8 @@
-import { useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router';
 
 import { LoginActionContextType } from '@/components/login/GitHubLoginButton';
-import { OAUTH_QUERY_KEY, ROUTE } from '@/constants';
+import { ROUTE } from '@/constants';
 import { useSearchParamAndQuery, useToastContext } from '@/hooks';
 import { useOAuthLogin } from '@/hooks/oAuth';
 
@@ -16,8 +15,6 @@ const OAuthCallbackPage = () => {
 
   const navigate = useNavigate();
   const { showToast } = useToastContext();
-
-  const queryClient = useQueryClient();
 
   const mutation = useOAuthLogin();
 
@@ -42,9 +39,6 @@ const OAuthCallbackPage = () => {
         onSuccess: () => {
           navigate(redirectUrl, { replace: true });
           showToast({ type: 'success', message: '로그인 성공! 환영해요!', position: 'top' });
-
-          // 로그인 성공 시 프로필 정보를 받아오도록 함
-          queryClient.invalidateQueries({ queryKey: [OAUTH_QUERY_KEY.userProfile] });
         },
         onError: () => {
           navigate(prevUrl, { replace: true });

--- a/frontend/src/pages/OAuthCallbackPage/index.tsx
+++ b/frontend/src/pages/OAuthCallbackPage/index.tsx
@@ -1,8 +1,9 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router';
 
 import { LoginActionContextType } from '@/components/login/GitHubLoginButton';
-import { ROUTE } from '@/constants';
+import { OAUTH_QUERY_KEY, ROUTE } from '@/constants';
 import { useSearchParamAndQuery, useToastContext } from '@/hooks';
 import { useOAuthLogin } from '@/hooks/oAuth';
 
@@ -15,6 +16,8 @@ const OAuthCallbackPage = () => {
 
   const navigate = useNavigate();
   const { showToast } = useToastContext();
+
+  const queryClient = useQueryClient();
 
   const mutation = useOAuthLogin();
 
@@ -39,6 +42,9 @@ const OAuthCallbackPage = () => {
         onSuccess: () => {
           navigate(redirectUrl, { replace: true });
           showToast({ type: 'success', message: '로그인 성공! 환영해요!', position: 'top' });
+
+          // 로그인 성공 시 프로필 정보를 받아오도록 함
+          queryClient.invalidateQueries({ queryKey: [OAUTH_QUERY_KEY.userProfile] });
         },
         onError: () => {
           navigate(prevUrl, { replace: true });


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #1145 

---

### 🚀 어떤 기능을 구현했나요 ?
- 로그인 요청 시 쿼리 파라미터가 아닌 body로 code를 전달하게 했습니다.
- 로그인 성공 시 사용자 정보가 함께 반환되지만, 프로필 버튼 등 로그인 상태는 프로필 요청 훅을 통해 관리하고 있기 때문에 우선은 쿼리 무효화 코드 부분을 그냥 남겨두었습니다.
  - 로그인 시 받은 정보를 어떻게 넘길지는 나중에 생각해봐요

### 🔥 어떻게 해결했나요 ?
- 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 우선은 로그인이 잘 되는 것을 목표로 해봅시다...!

### 📚 참고 자료, 할 말
