### PR TITLE
[BE] fix: 새로운 세션을 만들지 않게 수정

### DIFF
--- a/backend/src/main/java/reviewme/auth/controller/AuthController.java
+++ b/backend/src/main/java/reviewme/auth/controller/AuthController.java
@@ -29,9 +29,10 @@ public class AuthController {
     @PostMapping("/v2/auth/github")
     public ResponseEntity<ProfileResponse> authWithGitHub(
             @RequestBody GitHubOAuthRequest request,
-            HttpSession session
+            HttpServletRequest httpRequest
     ) {
         GitHubMember gitHubMember = authService.authWithGitHub(request);
+        HttpSession session = httpRequest.getSession(true);
         sessionManager.saveGitHubMember(session, gitHubMember);
         ProfileResponse response = memberService.getProfile(gitHubMember);
         return ResponseEntity.ok(response);
@@ -40,9 +41,10 @@ public class AuthController {
     @PostMapping("/v2/auth/group")
     public ResponseEntity<Void> authWithReviewGroup(
             @Valid @RequestBody CheckValidAccessRequest request,
-            HttpSession session
+            HttpServletRequest httpRequest
     ) {
         String reviewRequestCode = authService.authWithReviewGroup(request);
+        HttpSession session = httpRequest.getSession(true);
         sessionManager.saveReviewRequestCode(session, reviewRequestCode);
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/reviewme/auth/controller/AuthController.java
+++ b/backend/src/main/java/reviewme/auth/controller/AuthController.java
@@ -32,8 +32,7 @@ public class AuthController {
             HttpServletRequest httpRequest
     ) {
         GitHubMember gitHubMember = authService.authWithGitHub(request);
-        HttpSession session = httpRequest.getSession(true);
-        sessionManager.saveGitHubMember(session, gitHubMember);
+        sessionManager.saveGitHubMember(httpRequest, gitHubMember);
         ProfileResponse response = memberService.getProfile(gitHubMember);
         return ResponseEntity.ok(response);
     }
@@ -44,8 +43,7 @@ public class AuthController {
             HttpServletRequest httpRequest
     ) {
         String reviewRequestCode = authService.authWithReviewGroup(request);
-        HttpSession session = httpRequest.getSession(true);
-        sessionManager.saveReviewRequestCode(session, reviewRequestCode);
+        sessionManager.saveReviewRequestCode(httpRequest, reviewRequestCode);
         return ResponseEntity.noContent().build();
     }
 

--- a/backend/src/main/java/reviewme/global/GlobalExceptionHandler.java
+++ b/backend/src/main/java/reviewme/global/GlobalExceptionHandler.java
@@ -47,7 +47,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(ForbiddenException.class)
-    public ProblemDetail handleForbiddenException(UnauthorizedException ex) {
+    public ProblemDetail handleForbiddenException(ForbiddenException ex) {
         return ProblemDetail.forStatusAndDetail(HttpStatus.FORBIDDEN, ex.getErrorMessage());
     }
 

--- a/backend/src/main/java/reviewme/member/controller/MemberController.java
+++ b/backend/src/main/java/reviewme/member/controller/MemberController.java
@@ -1,7 +1,6 @@
 package reviewme.member.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,8 +21,7 @@ public class MemberController {
     public ResponseEntity<ProfileResponse> getProfile(
             HttpServletRequest request
     ) {
-        HttpSession session = request.getSession(false);
-        GitHubMember gitHubMember = sessionManager.getGitHubMember(session);
+        GitHubMember gitHubMember = sessionManager.getGitHubMember(request);
         ProfileResponse response = memberService.getProfile(gitHubMember);
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/reviewme/member/controller/MemberController.java
+++ b/backend/src/main/java/reviewme/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package reviewme.member.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -19,8 +20,9 @@ public class MemberController {
 
     @GetMapping("/v2/members/profile")
     public ResponseEntity<ProfileResponse> getProfile(
-            HttpSession session
+            HttpServletRequest request
     ) {
+        HttpSession session = request.getSession(false);
         GitHubMember gitHubMember = sessionManager.getGitHubMember(session);
         ProfileResponse response = memberService.getProfile(gitHubMember);
         return ResponseEntity.ok(response);

--- a/backend/src/main/java/reviewme/security/aspect/ResourceAuthorizationUtils.java
+++ b/backend/src/main/java/reviewme/security/aspect/ResourceAuthorizationUtils.java
@@ -1,6 +1,6 @@
 package reviewme.security.aspect;
 
-import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.Objects;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.reflect.MethodSignature;
@@ -40,9 +40,7 @@ public class ResourceAuthorizationUtils {
         }
     }
 
-    public static HttpSession getCurrentSession() {
-        return ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes())
-                .getRequest()
-                .getSession(false);
+    public static HttpServletRequest getCurrentRequest() {
+        return ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
     }
 }

--- a/backend/src/main/java/reviewme/security/resolver/GuestReviewGroupSessionResolver.java
+++ b/backend/src/main/java/reviewme/security/resolver/GuestReviewGroupSessionResolver.java
@@ -27,7 +27,6 @@ public class GuestReviewGroupSessionResolver implements HandlerMethodArgumentRes
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         GuestReviewGroup guestReviewGroup = Optional.ofNullable(webRequest.getNativeRequest(HttpServletRequest.class))
-                .map(httpServletRequest -> httpServletRequest.getSession(false))
                 .map(sessionManager::getReviewRequestCode)
                 .map(GuestReviewGroup::new)
                 .orElse(null);

--- a/backend/src/main/java/reviewme/security/resolver/GuestReviewGroupSessionResolver.java
+++ b/backend/src/main/java/reviewme/security/resolver/GuestReviewGroupSessionResolver.java
@@ -27,7 +27,7 @@ public class GuestReviewGroupSessionResolver implements HandlerMethodArgumentRes
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         GuestReviewGroup guestReviewGroup = Optional.ofNullable(webRequest.getNativeRequest(HttpServletRequest.class))
-                .map(HttpServletRequest::getSession)
+                .map(httpServletRequest -> httpServletRequest.getSession(false))
                 .map(sessionManager::getReviewRequestCode)
                 .map(GuestReviewGroup::new)
                 .orElse(null);

--- a/backend/src/main/java/reviewme/security/resolver/LoginMemberSessionResolver.java
+++ b/backend/src/main/java/reviewme/security/resolver/LoginMemberSessionResolver.java
@@ -27,7 +27,6 @@ public class LoginMemberSessionResolver implements HandlerMethodArgumentResolver
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         LoginMember loginMember = Optional.ofNullable(webRequest.getNativeRequest(HttpServletRequest.class))
-                .map(httpServletRequest -> httpServletRequest.getSession(false))
                 .map(sessionManager::getGitHubMember)
                 .map(gitHubMember -> new LoginMember(gitHubMember.getMemberId()))
                 .orElse(null);

--- a/backend/src/main/java/reviewme/security/resolver/LoginMemberSessionResolver.java
+++ b/backend/src/main/java/reviewme/security/resolver/LoginMemberSessionResolver.java
@@ -27,7 +27,7 @@ public class LoginMemberSessionResolver implements HandlerMethodArgumentResolver
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         LoginMember loginMember = Optional.ofNullable(webRequest.getNativeRequest(HttpServletRequest.class))
-                .map(HttpServletRequest::getSession)
+                .map(httpServletRequest -> httpServletRequest.getSession(false))
                 .map(sessionManager::getGitHubMember)
                 .map(gitHubMember -> new LoginMember(gitHubMember.getMemberId()))
                 .orElse(null);

--- a/backend/src/main/java/reviewme/security/session/SessionManager.java
+++ b/backend/src/main/java/reviewme/security/session/SessionManager.java
@@ -1,5 +1,6 @@
 package reviewme.security.session;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,7 +15,8 @@ public class SessionManager {
     private static final String GITHUB_MEMBER_KEY = "githubMember";
     private static final String REVIEW_REQUEST_CODE_KEY = "reviewRequestCode";
 
-    public void saveGitHubMember(HttpSession session, GitHubMember gitHubMember) {
+    public void saveGitHubMember(HttpServletRequest httpRequest, GitHubMember gitHubMember) {
+        HttpSession session = httpRequest.getSession(true);
         session.setAttribute(GITHUB_MEMBER_KEY, gitHubMember);
     }
 
@@ -25,12 +27,13 @@ public class SessionManager {
         return (GitHubMember) session.getAttribute(GITHUB_MEMBER_KEY);
     }
 
-    public void saveReviewRequestCode(HttpSession session, String reviewRequestCode) {
+    public void saveReviewRequestCode(HttpServletRequest httpRequest, String reviewRequestCode) {
+        HttpSession session = httpRequest.getSession(true);
         session.setAttribute(REVIEW_REQUEST_CODE_KEY, reviewRequestCode);
     }
 
     public String getReviewRequestCode(HttpSession session) {
-        if(session == null) {
+        if (session == null) {
             throw new GuestReviewGroupSessionNotExistsException();
         }
         return (String) session.getAttribute(REVIEW_REQUEST_CODE_KEY);

--- a/backend/src/main/java/reviewme/security/session/SessionManager.java
+++ b/backend/src/main/java/reviewme/security/session/SessionManager.java
@@ -19,7 +19,8 @@ public class SessionManager {
         session.setAttribute(GITHUB_MEMBER_KEY, gitHubMember);
     }
 
-    public @Nullable GitHubMember getGitHubMember(HttpSession session) {
+    public @Nullable GitHubMember getGitHubMember(HttpServletRequest httpRequest) {
+        HttpSession session = httpRequest.getSession(false);
         if (session == null) {
             return null;
         }
@@ -31,7 +32,8 @@ public class SessionManager {
         session.setAttribute(REVIEW_REQUEST_CODE_KEY, reviewRequestCode);
     }
 
-    public @Nullable String getReviewRequestCode(HttpSession session) {
+    public @Nullable String getReviewRequestCode(HttpServletRequest httpRequest) {
+        HttpSession session = httpRequest.getSession(false);
         if (session == null) {
             return null;
         }

--- a/backend/src/main/java/reviewme/security/session/SessionManager.java
+++ b/backend/src/main/java/reviewme/security/session/SessionManager.java
@@ -4,6 +4,8 @@ import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import reviewme.auth.domain.GitHubMember;
+import reviewme.security.resolver.exception.GuestReviewGroupSessionNotExistsException;
+import reviewme.security.resolver.exception.LoginMemberSessionNotExistsException;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +19,9 @@ public class SessionManager {
     }
 
     public GitHubMember getGitHubMember(HttpSession session) {
+        if (session == null) {
+            throw new LoginMemberSessionNotExistsException();
+        }
         return (GitHubMember) session.getAttribute(GITHUB_MEMBER_KEY);
     }
 
@@ -25,6 +30,9 @@ public class SessionManager {
     }
 
     public String getReviewRequestCode(HttpSession session) {
+        if(session == null) {
+            throw new GuestReviewGroupSessionNotExistsException();
+        }
         return (String) session.getAttribute(REVIEW_REQUEST_CODE_KEY);
     }
 }

--- a/backend/src/main/java/reviewme/security/session/SessionManager.java
+++ b/backend/src/main/java/reviewme/security/session/SessionManager.java
@@ -1,12 +1,11 @@
 package reviewme.security.session;
 
+import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import reviewme.auth.domain.GitHubMember;
-import reviewme.security.resolver.exception.GuestReviewGroupSessionNotExistsException;
-import reviewme.security.resolver.exception.LoginMemberSessionNotExistsException;
 
 @Service
 @RequiredArgsConstructor
@@ -20,9 +19,9 @@ public class SessionManager {
         session.setAttribute(GITHUB_MEMBER_KEY, gitHubMember);
     }
 
-    public GitHubMember getGitHubMember(HttpSession session) {
+    public @Nullable GitHubMember getGitHubMember(HttpSession session) {
         if (session == null) {
-            throw new LoginMemberSessionNotExistsException();
+            return null;
         }
         return (GitHubMember) session.getAttribute(GITHUB_MEMBER_KEY);
     }
@@ -32,9 +31,9 @@ public class SessionManager {
         session.setAttribute(REVIEW_REQUEST_CODE_KEY, reviewRequestCode);
     }
 
-    public String getReviewRequestCode(HttpSession session) {
+    public @Nullable String getReviewRequestCode(HttpSession session) {
         if (session == null) {
-            throw new GuestReviewGroupSessionNotExistsException();
+            return null;
         }
         return (String) session.getAttribute(REVIEW_REQUEST_CODE_KEY);
     }

--- a/backend/src/test/java/reviewme/global/session/SessionManagerTest.java
+++ b/backend/src/test/java/reviewme/global/session/SessionManagerTest.java
@@ -35,16 +35,17 @@ class SessionManagerTest {
 
         // when
         sessionManager.saveGitHubMember(request, gitHubMember);
-        GitHubMember savedGitHubMember = sessionManager.getGitHubMember(session);
+        GitHubMember savedGitHubMember = sessionManager.getGitHubMember(request);
 
         // then
         assertThat(savedGitHubMember).isEqualTo(gitHubMember);
     }
 
     @Test
-    void 세션이_null_이면_깃허브_멤버를_조회할_때_null_을_반환한다() {
+    void 세션이_없으면_깃허브_멤버를_조회할_때_null_을_반환한다() {
         // when
-        GitHubMember gitHubMember = sessionManager.getGitHubMember(null);
+        request = new MockHttpServletRequest();
+        GitHubMember gitHubMember = sessionManager.getGitHubMember(request);
 
         // then
         assertThat(gitHubMember).isNull();
@@ -57,16 +58,17 @@ class SessionManagerTest {
 
         // when
         sessionManager.saveReviewRequestCode(request, reviewRequestCode);
-        String savedReviewGroup = sessionManager.getReviewRequestCode(session);
+        String savedReviewGroup = sessionManager.getReviewRequestCode(request);
 
         // then
         assertThat(savedReviewGroup).isEqualTo(reviewRequestCode);
     }
 
     @Test
-    void 세션이_null_이면_리뷰_그룹을_조회할_때_null_을_반환한다() {
+    void 세션이_없으면_리뷰_그룹을_조회할_때_null_을_반환한다() {
         // when
-        String reviewGroup = sessionManager.getReviewRequestCode(null);
+        request = new MockHttpServletRequest();
+        String reviewGroup = sessionManager.getReviewRequestCode(request);
 
         // then
         assertThat(reviewGroup).isNull();

--- a/backend/src/test/java/reviewme/global/session/SessionManagerTest.java
+++ b/backend/src/test/java/reviewme/global/session/SessionManagerTest.java
@@ -3,10 +3,10 @@ package reviewme.global.session;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import jakarta.servlet.http.HttpSession;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpSession;
 import reviewme.auth.domain.GitHubMember;
 import reviewme.security.session.SessionManager;
@@ -18,11 +18,14 @@ class SessionManagerTest {
     @Autowired
     private SessionManager sessionManager;
 
-    private HttpSession session;
+    private MockHttpServletRequest request;
+    private MockHttpSession session;
 
     @BeforeEach
     void setUp() {
+        request = new MockHttpServletRequest();
         session = new MockHttpSession();
+        request.setSession(session);
     }
 
     @Test
@@ -31,7 +34,7 @@ class SessionManagerTest {
         GitHubMember gitHubMember = mock(GitHubMember.class);
 
         // when
-        sessionManager.saveGitHubMember(session, gitHubMember);
+        sessionManager.saveGitHubMember(request, gitHubMember);
         GitHubMember savedGitHubMember = sessionManager.getGitHubMember(session);
 
         // then
@@ -44,7 +47,7 @@ class SessionManagerTest {
         String reviewRequestCode = "reviewRequestCode";
 
         // when
-        sessionManager.saveReviewRequestCode(session, reviewRequestCode);
+        sessionManager.saveReviewRequestCode(request, reviewRequestCode);
         String savedReviewGroup = sessionManager.getReviewRequestCode(session);
 
         // then

--- a/backend/src/test/java/reviewme/global/session/SessionManagerTest.java
+++ b/backend/src/test/java/reviewme/global/session/SessionManagerTest.java
@@ -42,6 +42,15 @@ class SessionManagerTest {
     }
 
     @Test
+    void 세션이_null_이면_깃허브_멤버를_조회할_때_null_을_반환한다() {
+        // when
+        GitHubMember gitHubMember = sessionManager.getGitHubMember(null);
+
+        // then
+        assertThat(gitHubMember).isNull();
+    }
+
+    @Test
     void 세션에_리뷰_그룹을_저장하고_조회한다() {
         // given
         String reviewRequestCode = "reviewRequestCode";
@@ -52,5 +61,14 @@ class SessionManagerTest {
 
         // then
         assertThat(savedReviewGroup).isEqualTo(reviewRequestCode);
+    }
+
+    @Test
+    void 세션이_null_이면_리뷰_그룹을_조회할_때_null_을_반환한다() {
+        // when
+        String reviewGroup = sessionManager.getReviewRequestCode(null);
+
+        // then
+        assertThat(reviewGroup).isNull();
     }
 }

--- a/backend/src/test/java/reviewme/security/aspect/ResourceAuthorizationUtilsTest.java
+++ b/backend/src/test/java/reviewme/security/aspect/ResourceAuthorizationUtilsTest.java
@@ -5,14 +5,13 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpServletRequest;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockHttpSession;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 import reviewme.security.aspect.exception.SpELEvaluationFailedException;
@@ -116,19 +115,16 @@ class ResourceAuthorizationUtilsTest {
     }
 
     @Test
-    void 현재_세션을_반환한다() {
+    void 현재_요청을_반환한다() {
         // given
         MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpSession session = new MockHttpSession();
-        session.setAttribute("리뷰미", "파이팅");
-        request.setSession(session);
         RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
 
         // when
-        HttpSession actualSession = ResourceAuthorizationUtils.getCurrentSession();
+        HttpServletRequest actualRequest = ResourceAuthorizationUtils.getCurrentRequest();
 
         // then
-        assertThat(actualSession.getAttribute("리뷰미")).isEqualTo("파이팅");
+        assertThat(actualRequest).isEqualTo(request);
     }
 
     private static class TestRequest {

--- a/backend/src/test/java/reviewme/security/aspect/ReviewAuthorizationAspectTest.java
+++ b/backend/src/test/java/reviewme/security/aspect/ReviewAuthorizationAspectTest.java
@@ -65,6 +65,7 @@ class ReviewAuthorizationAspectTest {
             // given
             Member member = memberRepository.save(회원());
             Review review = reviewRepository.save(회원_작성_리뷰(member.getId(), 1L, 1L, List.of()));
+
             GitHubMember gitHubMember = new GitHubMember(member.getId(), "name", "avatarUrl");
             sessionManager.saveGitHubMember(request, gitHubMember);
 
@@ -78,7 +79,7 @@ class ReviewAuthorizationAspectTest {
             // given
             Member member = memberRepository.save(회원());
             ReviewGroup reviewGroup = reviewGroupRepository.save(회원_지정_리뷰_그룹(member.getId()));
-            Review review = reviewRepository.save(비회원_작성_리뷰(1L, 1L, List.of()));
+            Review review = reviewRepository.save(비회원_작성_리뷰(1L, reviewGroup.getId(), List.of()));
 
             GitHubMember gitHubMember = new GitHubMember(member.getId(), "name", "avatarUrl");
             sessionManager.saveGitHubMember(request, gitHubMember);
@@ -92,7 +93,7 @@ class ReviewAuthorizationAspectTest {
         void 비회원은_자신이_만든_리뷰_그룹에_작성된_리뷰에_접근할_수_있다() {
             // given
             ReviewGroup reviewGroup = reviewGroupRepository.save(비회원_리뷰_그룹());
-            Review review = reviewRepository.save(비회원_작성_리뷰(1L, 1L, List.of()));
+            Review review = reviewRepository.save(비회원_작성_리뷰(1L, reviewGroup.getId(), List.of()));
             sessionManager.saveReviewRequestCode(request, reviewGroup.getReviewRequestCode());
 
             // when & then
@@ -115,17 +116,17 @@ class ReviewAuthorizationAspectTest {
         void 세션이_존재하지_않으면_Unauthorized_예외가_발생한다() {
             // given
             request.setSession(null);
+            Review review = reviewRepository.save(비회원_작성_리뷰(1L, 1L, List.of()));
 
             // when & then
-            assertThatCode(() -> aopTestClass.testReviewMethod(1L))
+            assertThatCode(() -> aopTestClass.testReviewMethod(review.getId()))
                     .isInstanceOf(ForbiddenReviewAccessException.class);
         }
 
         @Test
         void 세션에_저장된_정보가_없으면_Unauthorized_예외가_발생한다() {
             // given
-            Member member = memberRepository.save(회원());
-            Review review = reviewRepository.save(회원_작성_리뷰(member.getId(), 1L, 1L, List.of()));
+            Review review = reviewRepository.save(비회원_작성_리뷰(1L, 1L, List.of()));
 
             // when & then
             assertThatCode(() -> aopTestClass.testReviewMethod(review.getId()))

--- a/backend/src/test/java/reviewme/security/aspect/ReviewAuthorizationAspectTest.java
+++ b/backend/src/test/java/reviewme/security/aspect/ReviewAuthorizationAspectTest.java
@@ -66,7 +66,7 @@ class ReviewAuthorizationAspectTest {
             Member member = memberRepository.save(회원());
             Review review = reviewRepository.save(회원_작성_리뷰(member.getId(), 1L, 1L, List.of()));
             GitHubMember gitHubMember = new GitHubMember(member.getId(), "name", "avatarUrl");
-            sessionManager.saveGitHubMember(session, gitHubMember);
+            sessionManager.saveGitHubMember(request, gitHubMember);
 
             // when & then
             assertThatCode(() -> aopTestClass.testReviewMethod(review.getId()))
@@ -81,7 +81,7 @@ class ReviewAuthorizationAspectTest {
             Review review = reviewRepository.save(비회원_작성_리뷰(1L, 1L, List.of()));
 
             GitHubMember gitHubMember = new GitHubMember(member.getId(), "name", "avatarUrl");
-            sessionManager.saveGitHubMember(session, gitHubMember);
+            sessionManager.saveGitHubMember(request, gitHubMember);
 
             // when & then
             assertThatCode(() -> aopTestClass.testReviewMethod(review.getId()))
@@ -93,7 +93,7 @@ class ReviewAuthorizationAspectTest {
             // given
             ReviewGroup reviewGroup = reviewGroupRepository.save(비회원_리뷰_그룹());
             Review review = reviewRepository.save(비회원_작성_리뷰(1L, 1L, List.of()));
-            sessionManager.saveReviewRequestCode(session, reviewGroup.getReviewRequestCode());
+            sessionManager.saveReviewRequestCode(request, reviewGroup.getReviewRequestCode());
 
             // when & then
             assertThatCode(() -> aopTestClass.testReviewMethod(review.getId()))
@@ -142,7 +142,7 @@ class ReviewAuthorizationAspectTest {
             Review review = reviewRepository.save(비회원_작성_리뷰(1L, 1L, List.of()));
 
             GitHubMember gitHubMember = new GitHubMember(1L, "name", "avatarUrl");
-            sessionManager.saveGitHubMember(session, gitHubMember);
+            sessionManager.saveGitHubMember(request, gitHubMember);
 
             // when & then
             assertThatCode(() -> aopTestClass.testReviewMethod(review.getId()))
@@ -158,7 +158,7 @@ class ReviewAuthorizationAspectTest {
 
             Member member = memberRepository.save(회원("email321@test.com"));
             GitHubMember gitHubMember = new GitHubMember(member.getId(), "name", "avatarUrl");
-            sessionManager.saveGitHubMember(session, gitHubMember);
+            sessionManager.saveGitHubMember(request, gitHubMember);
 
             // when & then
             assertThatCode(() -> aopTestClass.testReviewMethod(review.getId()))
@@ -173,7 +173,7 @@ class ReviewAuthorizationAspectTest {
         Review review = reviewRepository.save(비회원_작성_리뷰(1L, othersReviewGroup.getId(), List.of()));
 
         ReviewGroup reviewGroup = reviewGroupRepository.save(비회원_리뷰_그룹("1234", "5678"));
-        sessionManager.saveReviewRequestCode(session, reviewGroup.getReviewRequestCode());
+        sessionManager.saveReviewRequestCode(request, reviewGroup.getReviewRequestCode());
 
         // when & then
         assertThatCode(() -> aopTestClass.testReviewMethod(review.getId()))

--- a/backend/src/test/java/reviewme/security/aspect/ReviewGroupAuthorizationAspectTest.java
+++ b/backend/src/test/java/reviewme/security/aspect/ReviewGroupAuthorizationAspectTest.java
@@ -58,7 +58,7 @@ class ReviewGroupAuthorizationAspectTest {
             Member member = memberRepository.save(회원());
             ReviewGroup reviewGroup = reviewGroupRepository.save(회원_지정_리뷰_그룹(member.getId()));
             GitHubMember gitHubMember = new GitHubMember(member.getId(), "name", "avatarUrl");
-            sessionManager.saveGitHubMember(session, gitHubMember);
+            sessionManager.saveGitHubMember(request, gitHubMember);
 
             // when & then
             assertThatCode(() -> aopTestClass.testReviewGroupMethod(reviewGroup.getReviewRequestCode()))
@@ -69,7 +69,7 @@ class ReviewGroupAuthorizationAspectTest {
         void 비회원은_자신이_만든_리뷰_그룹에_접근할_수_있다() {
             // given
             ReviewGroup reviewGroup = reviewGroupRepository.save(비회원_리뷰_그룹());
-            sessionManager.saveReviewRequestCode(session, reviewGroup.getReviewRequestCode());
+            sessionManager.saveReviewRequestCode(request, reviewGroup.getReviewRequestCode());
 
             // when & then
             assertThatCode(() -> aopTestClass.testReviewGroupMethod(reviewGroup.getReviewRequestCode()))
@@ -116,7 +116,7 @@ class ReviewGroupAuthorizationAspectTest {
 
         Member member = memberRepository.save(회원("email123@test.com"));
         GitHubMember gitHubMember = new GitHubMember(member.getId(), "name", "avatarUrl");
-        sessionManager.saveGitHubMember(session, gitHubMember);
+        sessionManager.saveGitHubMember(request, gitHubMember);
 
         // when & then
         assertThatCode(() -> aopTestClass.testReviewGroupMethod(membersReviewGroup.getReviewRequestCode()))
@@ -127,7 +127,7 @@ class ReviewGroupAuthorizationAspectTest {
     void 리뷰_요청_코드가_다른_리뷰_그룹에_접근하면_Unauthorized_예외가_발생한다() {
         // given
         ReviewGroup other = reviewGroupRepository.save(비회원_리뷰_그룹("3333", "4444"));
-        sessionManager.saveReviewRequestCode(session, other.getReviewRequestCode());
+        sessionManager.saveReviewRequestCode(request, other.getReviewRequestCode());
 
         ReviewGroup group = reviewGroupRepository.save(비회원_리뷰_그룹("1111", "2222"));
 

--- a/backend/src/test/java/reviewme/security/aspect/ReviewGroupAuthorizationAspectTest.java
+++ b/backend/src/test/java/reviewme/security/aspect/ReviewGroupAuthorizationAspectTest.java
@@ -91,9 +91,10 @@ class ReviewGroupAuthorizationAspectTest {
         void 세션이_없으면_Unauthorized_예외가_발생한다() {
             // given
             request.setSession(null);
+            ReviewGroup reviewGroup = reviewGroupRepository.save(비회원_리뷰_그룹());
 
             // when & then
-            assertThatCode(() -> aopTestClass.testReviewGroupMethod("1234"))
+            assertThatCode(() -> aopTestClass.testReviewGroupMethod(reviewGroup.getReviewRequestCode()))
                     .isInstanceOf(ForbiddenReviewGroupAccessException.class);
         }
 

--- a/backend/src/test/java/reviewme/security/resolver/GuestReviewGroupSessionResolverTest.java
+++ b/backend/src/test/java/reviewme/security/resolver/GuestReviewGroupSessionResolverTest.java
@@ -2,7 +2,6 @@ package reviewme.security.resolver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -46,8 +45,7 @@ class GuestReviewGroupSessionResolverTest {
         String reviewRequestCode = "reviewRequestCode";
 
         given(nativeWebRequest.getNativeRequest(HttpServletRequest.class)).willReturn(httpServletRequest);
-        given(httpServletRequest.getSession(anyBoolean())).willReturn(httpSession);
-        given(sessionManager.getReviewRequestCode(httpSession)).willReturn(reviewRequestCode);
+        given(sessionManager.getReviewRequestCode(httpServletRequest)).willReturn(reviewRequestCode);
 
         GuestReviewGroupSession annotation = mock(GuestReviewGroupSession.class);
         given(annotation.required()).willReturn(false);
@@ -65,7 +63,6 @@ class GuestReviewGroupSessionResolverTest {
     void 어노테이션의_속성이_flase일때_세션이_없다면_null을_반환한다() {
         // given
         given(nativeWebRequest.getNativeRequest(HttpServletRequest.class)).willReturn(httpServletRequest);
-        given(httpServletRequest.getSession(anyBoolean())).willReturn(null);
 
         GuestReviewGroupSession annotation = mock(GuestReviewGroupSession.class);
         given(annotation.required()).willReturn(false);
@@ -83,8 +80,7 @@ class GuestReviewGroupSessionResolverTest {
     void 어노테이션의_속성이_false일때_세션에_저장된_데이터가_없다면_null을_반환한다() {
         // given
         given(nativeWebRequest.getNativeRequest(HttpServletRequest.class)).willReturn(httpServletRequest);
-        given(httpServletRequest.getSession(anyBoolean())).willReturn(httpSession);
-        given(sessionManager.getReviewRequestCode(httpSession)).willReturn(null);
+        given(sessionManager.getReviewRequestCode(httpServletRequest)).willReturn(null);
 
         GuestReviewGroupSession annotation = mock(GuestReviewGroupSession.class);
         given(annotation.required()).willReturn(false);
@@ -102,7 +98,6 @@ class GuestReviewGroupSessionResolverTest {
     void 어노테이션의_속성이_true일때_세션이_없다면_예외가_발생한다() {
         // given
         given(nativeWebRequest.getNativeRequest(HttpServletRequest.class)).willReturn(httpServletRequest);
-        given(httpServletRequest.getSession(anyBoolean())).willReturn(null);
 
         GuestReviewGroupSession annotation = mock(GuestReviewGroupSession.class);
         given(annotation.required()).willReturn(true);
@@ -118,8 +113,7 @@ class GuestReviewGroupSessionResolverTest {
     void 어노테이션의_속성이_true일때_세션에_저장된_데이터가_없다면_예외가_발생한다() {
         // given
         given(nativeWebRequest.getNativeRequest(HttpServletRequest.class)).willReturn(httpServletRequest);
-        given(httpServletRequest.getSession(anyBoolean())).willReturn(httpSession);
-        given(sessionManager.getReviewRequestCode(httpSession)).willReturn(null);
+        given(sessionManager.getReviewRequestCode(httpServletRequest)).willReturn(null);
 
         GuestReviewGroupSession annotation = mock(GuestReviewGroupSession.class);
         given(annotation.required()).willReturn(true);

--- a/backend/src/test/java/reviewme/security/resolver/GuestReviewGroupSessionResolverTest.java
+++ b/backend/src/test/java/reviewme/security/resolver/GuestReviewGroupSessionResolverTest.java
@@ -2,6 +2,7 @@ package reviewme.security.resolver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -45,7 +46,7 @@ class GuestReviewGroupSessionResolverTest {
         String reviewRequestCode = "reviewRequestCode";
 
         given(nativeWebRequest.getNativeRequest(HttpServletRequest.class)).willReturn(httpServletRequest);
-        given(httpServletRequest.getSession()).willReturn(httpSession);
+        given(httpServletRequest.getSession(anyBoolean())).willReturn(httpSession);
         given(sessionManager.getReviewRequestCode(httpSession)).willReturn(reviewRequestCode);
 
         GuestReviewGroupSession annotation = mock(GuestReviewGroupSession.class);
@@ -64,7 +65,7 @@ class GuestReviewGroupSessionResolverTest {
     void 어노테이션의_속성이_flase일때_세션이_없다면_null을_반환한다() {
         // given
         given(nativeWebRequest.getNativeRequest(HttpServletRequest.class)).willReturn(httpServletRequest);
-        given(httpServletRequest.getSession()).willReturn(null);
+        given(httpServletRequest.getSession(anyBoolean())).willReturn(null);
 
         GuestReviewGroupSession annotation = mock(GuestReviewGroupSession.class);
         given(annotation.required()).willReturn(false);
@@ -82,7 +83,7 @@ class GuestReviewGroupSessionResolverTest {
     void 어노테이션의_속성이_false일때_세션에_저장된_데이터가_없다면_null을_반환한다() {
         // given
         given(nativeWebRequest.getNativeRequest(HttpServletRequest.class)).willReturn(httpServletRequest);
-        given(httpServletRequest.getSession()).willReturn(httpSession);
+        given(httpServletRequest.getSession(anyBoolean())).willReturn(httpSession);
         given(sessionManager.getReviewRequestCode(httpSession)).willReturn(null);
 
         GuestReviewGroupSession annotation = mock(GuestReviewGroupSession.class);
@@ -101,7 +102,7 @@ class GuestReviewGroupSessionResolverTest {
     void 어노테이션의_속성이_true일때_세션이_없다면_예외가_발생한다() {
         // given
         given(nativeWebRequest.getNativeRequest(HttpServletRequest.class)).willReturn(httpServletRequest);
-        given(httpServletRequest.getSession()).willReturn(null);
+        given(httpServletRequest.getSession(anyBoolean())).willReturn(null);
 
         GuestReviewGroupSession annotation = mock(GuestReviewGroupSession.class);
         given(annotation.required()).willReturn(true);
@@ -117,7 +118,7 @@ class GuestReviewGroupSessionResolverTest {
     void 어노테이션의_속성이_true일때_세션에_저장된_데이터가_없다면_예외가_발생한다() {
         // given
         given(nativeWebRequest.getNativeRequest(HttpServletRequest.class)).willReturn(httpServletRequest);
-        given(httpServletRequest.getSession()).willReturn(httpSession);
+        given(httpServletRequest.getSession(anyBoolean())).willReturn(httpSession);
         given(sessionManager.getReviewRequestCode(httpSession)).willReturn(null);
 
         GuestReviewGroupSession annotation = mock(GuestReviewGroupSession.class);

--- a/backend/src/test/java/reviewme/security/resolver/LoginMemberSessionResolverTest.java
+++ b/backend/src/test/java/reviewme/security/resolver/LoginMemberSessionResolverTest.java
@@ -2,6 +2,7 @@ package reviewme.security.resolver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -47,7 +48,7 @@ class LoginMemberSessionResolverTest {
         GitHubMember gitHubMember = new GitHubMember(1L, "name", "url");
 
         given(nativeWebRequest.getNativeRequest(HttpServletRequest.class)).willReturn(httpServletRequest);
-        given(httpServletRequest.getSession()).willReturn(httpSession);
+        given(httpServletRequest.getSession(anyBoolean())).willReturn(httpSession);
         given(sessionManager.getGitHubMember(httpSession)).willReturn(gitHubMember);
 
         LoginMemberSession annotation = mock(LoginMemberSession.class);
@@ -66,7 +67,7 @@ class LoginMemberSessionResolverTest {
     void 어노테이션의_속성이_flase일때_세션이_없다면_null을_반환한다() {
         // given
         given(nativeWebRequest.getNativeRequest(HttpServletRequest.class)).willReturn(httpServletRequest);
-        given(httpServletRequest.getSession()).willReturn(null);
+        given(httpServletRequest.getSession(anyBoolean())).willReturn(null);
 
         LoginMemberSession annotation = mock(LoginMemberSession.class);
         given(annotation.required()).willReturn(false);
@@ -84,7 +85,7 @@ class LoginMemberSessionResolverTest {
     void 어노테이션의_속성이_false일때_세션에_저장된_데이터가_없다면_null을_반환한다() {
         // given
         given(nativeWebRequest.getNativeRequest(HttpServletRequest.class)).willReturn(httpServletRequest);
-        given(httpServletRequest.getSession()).willReturn(httpSession);
+        given(httpServletRequest.getSession(anyBoolean())).willReturn(httpSession);
         given(sessionManager.getGitHubMember(httpSession)).willReturn(null);
 
         LoginMemberSession annotation = mock(LoginMemberSession.class);
@@ -103,7 +104,7 @@ class LoginMemberSessionResolverTest {
     void 어노테이션의_속성이_true일때_세션이_없다면_예외가_발생한다() {
         // given
         given(nativeWebRequest.getNativeRequest(HttpServletRequest.class)).willReturn(httpServletRequest);
-        given(httpServletRequest.getSession()).willReturn(null);
+        given(httpServletRequest.getSession(anyBoolean())).willReturn(null);
 
         LoginMemberSession annotation = mock(LoginMemberSession.class);
         given(annotation.required()).willReturn(true);
@@ -119,7 +120,7 @@ class LoginMemberSessionResolverTest {
     void 어노테이션의_속성이_true일때_세션에_저장된_데이터가_없다면_예외가_발생한다() {
         // given
         given(nativeWebRequest.getNativeRequest(HttpServletRequest.class)).willReturn(httpServletRequest);
-        given(httpServletRequest.getSession()).willReturn(httpSession);
+        given(httpServletRequest.getSession(anyBoolean())).willReturn(httpSession);
         given(sessionManager.getGitHubMember(httpSession)).willReturn(null);
 
         LoginMemberSession annotation = mock(LoginMemberSession.class);

--- a/backend/src/test/java/reviewme/security/resolver/LoginMemberSessionResolverTest.java
+++ b/backend/src/test/java/reviewme/security/resolver/LoginMemberSessionResolverTest.java
@@ -2,7 +2,6 @@ package reviewme.security.resolver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -15,9 +14,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.MethodParameter;
 import org.springframework.web.context.request.NativeWebRequest;
+import reviewme.auth.domain.GitHubMember;
 import reviewme.security.resolver.dto.LoginMember;
 import reviewme.security.resolver.exception.LoginMemberSessionNotExistsException;
-import reviewme.auth.domain.GitHubMember;
 import reviewme.security.session.SessionManager;
 
 @ExtendWith(MockitoExtension.class)
@@ -48,8 +47,7 @@ class LoginMemberSessionResolverTest {
         GitHubMember gitHubMember = new GitHubMember(1L, "name", "url");
 
         given(nativeWebRequest.getNativeRequest(HttpServletRequest.class)).willReturn(httpServletRequest);
-        given(httpServletRequest.getSession(anyBoolean())).willReturn(httpSession);
-        given(sessionManager.getGitHubMember(httpSession)).willReturn(gitHubMember);
+        given(sessionManager.getGitHubMember(httpServletRequest)).willReturn(gitHubMember);
 
         LoginMemberSession annotation = mock(LoginMemberSession.class);
         given(annotation.required()).willReturn(false);
@@ -67,7 +65,6 @@ class LoginMemberSessionResolverTest {
     void 어노테이션의_속성이_flase일때_세션이_없다면_null을_반환한다() {
         // given
         given(nativeWebRequest.getNativeRequest(HttpServletRequest.class)).willReturn(httpServletRequest);
-        given(httpServletRequest.getSession(anyBoolean())).willReturn(null);
 
         LoginMemberSession annotation = mock(LoginMemberSession.class);
         given(annotation.required()).willReturn(false);
@@ -85,8 +82,7 @@ class LoginMemberSessionResolverTest {
     void 어노테이션의_속성이_false일때_세션에_저장된_데이터가_없다면_null을_반환한다() {
         // given
         given(nativeWebRequest.getNativeRequest(HttpServletRequest.class)).willReturn(httpServletRequest);
-        given(httpServletRequest.getSession(anyBoolean())).willReturn(httpSession);
-        given(sessionManager.getGitHubMember(httpSession)).willReturn(null);
+        given(sessionManager.getGitHubMember(httpServletRequest)).willReturn(null);
 
         LoginMemberSession annotation = mock(LoginMemberSession.class);
         given(annotation.required()).willReturn(false);
@@ -104,7 +100,6 @@ class LoginMemberSessionResolverTest {
     void 어노테이션의_속성이_true일때_세션이_없다면_예외가_발생한다() {
         // given
         given(nativeWebRequest.getNativeRequest(HttpServletRequest.class)).willReturn(httpServletRequest);
-        given(httpServletRequest.getSession(anyBoolean())).willReturn(null);
 
         LoginMemberSession annotation = mock(LoginMemberSession.class);
         given(annotation.required()).willReturn(true);
@@ -120,8 +115,7 @@ class LoginMemberSessionResolverTest {
     void 어노테이션의_속성이_true일때_세션에_저장된_데이터가_없다면_예외가_발생한다() {
         // given
         given(nativeWebRequest.getNativeRequest(HttpServletRequest.class)).willReturn(httpServletRequest);
-        given(httpServletRequest.getSession(anyBoolean())).willReturn(httpSession);
-        given(sessionManager.getGitHubMember(httpSession)).willReturn(null);
+        given(sessionManager.getGitHubMember(httpServletRequest)).willReturn(null);
 
         LoginMemberSession annotation = mock(LoginMemberSession.class);
         given(annotation.required()).willReturn(true);


### PR DESCRIPTION
세션과 무관한 요청이 와도, 항상 새로은 JSESSIONID 를 내려주는 문제가 발생했습니다.

### 1/ 

HttpServletRequest 의 **getSesssion()** 의 인자로 아무것도 주어지지 않을 경우, 
기본적으로 getSession(true)로 새로운 세션을 만듭니다.
![image](https://github.com/user-attachments/assets/fdfc7349-9647-4f74-b81b-6eb96cb47351)
ref. https://javaee.github.io/javaee-spec/javadocs/javax/servlet/http/HttpServletRequest.html?utm_source=chatgpt.com

그런데 이 코드에서 getSession 을 사용하고 있었습니다.
```java
LoginMember loginMember = Optional.ofNullable(webRequest.getNativeRequest(HttpServletRequest.class))
        .map(HttpServletRequest::getSession)
        .map(sessionManager::getGitHubMember)
        .map(gitHubMember -> new LoginMember(gitHubMember.getMemberId()))
        .orElse(null);
```

### 2/ 
알아보니 Spring MVC 에서 컨트로러의 인자로 HttpSession 을 받으면 세션이 없을 시 항상 새로운 세션을 만들어준다고 합니다.
BreakPoint 찍으며 확인해보니, 컨트롤러의 인자로 HttpSession 을 주었을 때
ServletRequestMethodArgumentResolver 의 resolveArgument 함수에서 getSesssion() 을 호출하고 있었습니다.
위에서 언급한, "세션이 없으면 새로운 세션을 만들어 응답하는 getSession()" 이요🥲

![image](https://github.com/user-attachments/assets/5a8fb1cb-c39d-4014-87bd-7237211d273e)



위 두가지 이슈를 해결했습니다.