### PR TITLE
[FE] fix: 리뷰 링크별 받은 리뷰 목록이 제대로 뜨지 않는 문제 수정

### DIFF
--- a/frontend/src/components/highlight/components/HighlightEditor/hooks/useMutateHighlight/index.ts
+++ b/frontend/src/components/highlight/components/HighlightEditor/hooks/useMutateHighlight/index.ts
@@ -28,7 +28,9 @@ const useMutateHighlight = ({
     if (sectionId) {
       queryClient.invalidateQueries({
         predicate: (query) =>
-          query.queryKey[0] === REVIEW_QUERY_KEY.groupedReviews && query.queryKey[1] === Number(sectionId),
+          query.queryKey[0] === REVIEW_QUERY_KEY.groupedReviews &&
+          query.queryKey[1] === Number(sectionId) &&
+          query.queryKey[2] === reviewRequestCode,
       });
     }
   };

--- a/frontend/src/components/layouts/ReviewDisplayLayout/hooks/useReviewInfoData/index.tsx
+++ b/frontend/src/components/layouts/ReviewDisplayLayout/hooks/useReviewInfoData/index.tsx
@@ -15,7 +15,6 @@ const useReviewInfoData = ({ reviewRequestCode }: UseReviewInfoDataProps) => {
   const { data } = useSuspenseQuery<ReviewInfoData>({
     queryKey: [REVIEW_QUERY_KEY.reviewInfoData],
     queryFn: () => fetchReviewInfoData(),
-    staleTime: 60 * 60 * 1000,
   });
 
   return data;

--- a/frontend/src/components/layouts/ReviewDisplayLayout/hooks/useReviewInfoData/index.tsx
+++ b/frontend/src/components/layouts/ReviewDisplayLayout/hooks/useReviewInfoData/index.tsx
@@ -13,8 +13,9 @@ const useReviewInfoData = ({ reviewRequestCode }: UseReviewInfoDataProps) => {
   };
 
   const { data } = useSuspenseQuery<ReviewInfoData>({
-    queryKey: [REVIEW_QUERY_KEY.reviewInfoData],
+    queryKey: [REVIEW_QUERY_KEY.reviewInfoData, reviewRequestCode],
     queryFn: () => fetchReviewInfoData(),
+    staleTime: 60 * 60 * 1000,
   });
 
   return data;

--- a/frontend/src/hooks/review/useGetReviewLinks/index.ts
+++ b/frontend/src/hooks/review/useGetReviewLinks/index.ts
@@ -7,8 +7,15 @@ import { useGetUserProfile } from '@/hooks/oAuth';
 const useGetReviewLinks = () => {
   const { userProfile, isUserLoggedIn } = useGetUserProfile();
 
+  const makeQueryKey = () => {
+    if (isUserLoggedIn && userProfile) {
+      return [REVIEW_QUERY_KEY.reviewLinks, userProfile.memberId];
+    }
+    return [REVIEW_QUERY_KEY.reviewLinks];
+  };
+
   const result = useSuspenseQuery({
-    queryKey: [REVIEW_QUERY_KEY.reviewLinks, isUserLoggedIn && userProfile && userProfile.memberId],
+    queryKey: makeQueryKey(),
     queryFn: () => getReviewLinksApi(),
     staleTime: 60 * 60 * 1000,
   });

--- a/frontend/src/hooks/review/useGetReviewLinks/index.ts
+++ b/frontend/src/hooks/review/useGetReviewLinks/index.ts
@@ -2,20 +2,14 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { getReviewLinksApi } from '@/apis/review';
 import { REVIEW_QUERY_KEY } from '@/constants';
-import { useGetUserProfile } from '@/hooks/oAuth';
 
-const useGetReviewLinks = () => {
-  const { userProfile, isUserLoggedIn } = useGetUserProfile();
+interface UserGetReviewLinksProps {
+  memberId?: number;
+}
 
-  const makeQueryKey = () => {
-    if (isUserLoggedIn && userProfile) {
-      return [REVIEW_QUERY_KEY.reviewLinks, userProfile.memberId];
-    }
-    return [REVIEW_QUERY_KEY.reviewLinks];
-  };
-
+const useGetReviewLinks = ({ memberId }: UserGetReviewLinksProps) => {
   const result = useSuspenseQuery({
-    queryKey: makeQueryKey(),
+    queryKey: [REVIEW_QUERY_KEY.reviewLinks, memberId],
     queryFn: () => getReviewLinksApi(),
     staleTime: 60 * 60 * 1000,
   });

--- a/frontend/src/hooks/review/useGetReviewLinks/index.ts
+++ b/frontend/src/hooks/review/useGetReviewLinks/index.ts
@@ -2,10 +2,13 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { getReviewLinksApi } from '@/apis/review';
 import { REVIEW_QUERY_KEY } from '@/constants';
+import { useGetUserProfile } from '@/hooks/oAuth';
 
 const useGetReviewLinks = () => {
+  const { userProfile, isUserLoggedIn } = useGetUserProfile();
+
   const result = useSuspenseQuery({
-    queryKey: [REVIEW_QUERY_KEY.reviewLinks],
+    queryKey: [REVIEW_QUERY_KEY.reviewLinks, isUserLoggedIn && userProfile && userProfile.memberId],
     queryFn: () => getReviewLinksApi(),
     staleTime: 60 * 60 * 1000,
   });

--- a/frontend/src/hooks/review/useGetReviewLinks/test.ts
+++ b/frontend/src/hooks/review/useGetReviewLinks/test.ts
@@ -1,5 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react';
 
+import { MOCK_USER_PROFILE } from '@/mocks/mockData';
 import QueryClientWrapper from '@/queryTestSetup/QueryClientWrapper';
 import { testWithAuthCookie } from '@/utils';
 
@@ -8,7 +9,7 @@ import useGetReviewLinks from '.';
 describe('회원이 생성한 리뷰 그룹 목록 조회 테스트', () => {
   it('회원이 생성한 리뷰 그룹 목록을 성공적으로 불러온다.', async () => {
     const testReviewLinksAPI = async () => {
-      const { result } = renderHook(() => useGetReviewLinks(), {
+      const { result } = renderHook(() => useGetReviewLinks({ memberId: MOCK_USER_PROFILE.memberId }), {
         wrapper: QueryClientWrapper,
       });
 

--- a/frontend/src/hooks/review/useGetReviewList/index.ts
+++ b/frontend/src/hooks/review/useGetReviewList/index.ts
@@ -18,8 +18,6 @@ const useGetReviewList = ({ reviewRequestCode }: UseGetReviewListProps) => {
 
     initialPageParam: 0,
     getNextPageParam: (lastPage) => lastPage.lastReviewId,
-
-    staleTime: 1 * 60 * 1000,
   });
 
   const isLastPage = data.pages[data.pages.length - 1].isLastPage;

--- a/frontend/src/hooks/review/useGetReviewList/index.ts
+++ b/frontend/src/hooks/review/useGetReviewList/index.ts
@@ -8,7 +8,7 @@ interface UseGetReviewListProps {
 }
 const useGetReviewList = ({ reviewRequestCode }: UseGetReviewListProps) => {
   const { data, ...rest } = useSuspenseInfiniteQuery({
-    queryKey: [REVIEW_QUERY_KEY.reviews],
+    queryKey: [REVIEW_QUERY_KEY.reviews, reviewRequestCode],
     queryFn: ({ pageParam }) =>
       getReceivedReviewListApi({
         lastReviewId: pageParam === 0 ? null : pageParam, // 첫 api 요청 시, null 값 보내기
@@ -18,6 +18,8 @@ const useGetReviewList = ({ reviewRequestCode }: UseGetReviewListProps) => {
 
     initialPageParam: 0,
     getNextPageParam: (lastPage) => lastPage.lastReviewId,
+
+    staleTime: 1 * 60 * 1000,
   });
 
   const isLastPage = data.pages[data.pages.length - 1].isLastPage;

--- a/frontend/src/hooks/reviewGroup/useCheckPasswordValidation/index.ts
+++ b/frontend/src/hooks/reviewGroup/useCheckPasswordValidation/index.ts
@@ -30,7 +30,7 @@ const useCheckPasswordValidation = ({
     queryKey: [GROUP_QUERY_KEY.password, groupAccessCode, reviewRequestCode],
     queryFn: () => fetchPasswordValidation({ groupAccessCode, reviewRequestCode }),
     enabled: !!groupAccessCode && !!reviewRequestCode,
-    staleTime: 1000 * 60 * 5,
+    staleTime: 5 * 60 * 1000,
   });
 
   /**

--- a/frontend/src/pages/ReviewCollectionPage/hooks/useGetGroupedReviews.ts
+++ b/frontend/src/pages/ReviewCollectionPage/hooks/useGetGroupedReviews.ts
@@ -17,7 +17,7 @@ const useGetGroupedReviews = ({ reviewRequestCode, sectionId }: UseGetGroupedRev
   };
 
   const result = useSuspenseQuery<GroupedReviews>({
-    queryKey: [REVIEW_QUERY_KEY.groupedReviews, sectionId],
+    queryKey: [REVIEW_QUERY_KEY.groupedReviews, sectionId, reviewRequestCode],
     queryFn: () => fetchGroupedReviews(),
     staleTime: 1 * 60 * 1000,
   });

--- a/frontend/src/pages/ReviewLinkPage/components/ReviewLinkDashboard/index.tsx
+++ b/frontend/src/pages/ReviewLinkPage/components/ReviewLinkDashboard/index.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router';
 import { URLGeneratorForm, EmptyContent } from '@/components';
 import { REVIEW_EMPTY, ROUTE } from '@/constants';
 import { useGetReviewLinks } from '@/hooks';
+import { useGetUserProfile } from '@/hooks/oAuth';
 
 import ReviewLinkLayout from '../layouts/ReviewLinkLayout';
 import ReviewLinkItem from '../ReviewLinkItem';
@@ -10,7 +11,12 @@ import ReviewLinkItem from '../ReviewLinkItem';
 import * as S from './styles';
 
 const ReviewLinkDashboard = () => {
-  const { data: reviewLinks, refetch } = useGetReviewLinks();
+  const { userProfile, isUserLoggedIn } = useGetUserProfile();
+  const memberIdProp = isUserLoggedIn && userProfile ? userProfile.memberId : undefined;
+
+  const { data: reviewLinks, refetch } = useGetReviewLinks({
+    memberId: memberIdProp,
+  });
 
   const navigate = useNavigate();
 

--- a/frontend/src/pages/WrittenReviewPage/hooks/useGetWrittenReviewList/index.ts
+++ b/frontend/src/pages/WrittenReviewPage/hooks/useGetWrittenReviewList/index.ts
@@ -2,10 +2,13 @@ import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
 
 import { getWrittenReviewListApi } from '@/apis/review';
 import { DEFAULT_SIZE_PER_PAGE, REVIEW_QUERY_KEY } from '@/constants';
+import { useGetUserProfile } from '@/hooks/oAuth';
 
 const useGetWrittenReviewList = () => {
+  const { userProfile, isUserLoggedIn } = useGetUserProfile();
+
   const { data, ...rest } = useSuspenseInfiniteQuery({
-    queryKey: [REVIEW_QUERY_KEY.writtenReviewList],
+    queryKey: [REVIEW_QUERY_KEY.writtenReviewList, isUserLoggedIn && userProfile && userProfile.memberId],
     queryFn: ({ pageParam }) =>
       getWrittenReviewListApi({
         lastReviewId: pageParam === 0 ? null : pageParam, // 첫 요청일 때 null으로 보냄

--- a/frontend/src/pages/WrittenReviewPage/hooks/useGetWrittenReviewList/index.ts
+++ b/frontend/src/pages/WrittenReviewPage/hooks/useGetWrittenReviewList/index.ts
@@ -7,8 +7,15 @@ import { useGetUserProfile } from '@/hooks/oAuth';
 const useGetWrittenReviewList = () => {
   const { userProfile, isUserLoggedIn } = useGetUserProfile();
 
+  const makeQueryKey = () => {
+    if (isUserLoggedIn && userProfile) {
+      return [REVIEW_QUERY_KEY.writtenReviewList, userProfile.memberId];
+    }
+    return [REVIEW_QUERY_KEY.writtenReviewList];
+  };
+
   const { data, ...rest } = useSuspenseInfiniteQuery({
-    queryKey: [REVIEW_QUERY_KEY.writtenReviewList, isUserLoggedIn && userProfile && userProfile.memberId],
+    queryKey: makeQueryKey(),
     queryFn: ({ pageParam }) =>
       getWrittenReviewListApi({
         lastReviewId: pageParam === 0 ? null : pageParam, // 첫 요청일 때 null으로 보냄

--- a/frontend/src/pages/WrittenReviewPage/hooks/useGetWrittenReviewList/index.ts
+++ b/frontend/src/pages/WrittenReviewPage/hooks/useGetWrittenReviewList/index.ts
@@ -2,20 +2,14 @@ import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
 
 import { getWrittenReviewListApi } from '@/apis/review';
 import { DEFAULT_SIZE_PER_PAGE, REVIEW_QUERY_KEY } from '@/constants';
-import { useGetUserProfile } from '@/hooks/oAuth';
 
-const useGetWrittenReviewList = () => {
-  const { userProfile, isUserLoggedIn } = useGetUserProfile();
+interface UseGetWrittenReviewListProps {
+  memberId?: number;
+}
 
-  const makeQueryKey = () => {
-    if (isUserLoggedIn && userProfile) {
-      return [REVIEW_QUERY_KEY.writtenReviewList, userProfile.memberId];
-    }
-    return [REVIEW_QUERY_KEY.writtenReviewList];
-  };
-
+const useGetWrittenReviewList = ({ memberId }: UseGetWrittenReviewListProps) => {
   const { data, ...rest } = useSuspenseInfiniteQuery({
-    queryKey: makeQueryKey(),
+    queryKey: [REVIEW_QUERY_KEY.writtenReviewList, memberId],
     queryFn: ({ pageParam }) =>
       getWrittenReviewListApi({
         lastReviewId: pageParam === 0 ? null : pageParam, // 첫 요청일 때 null으로 보냄

--- a/frontend/src/pages/WrittenReviewPage/index.tsx
+++ b/frontend/src/pages/WrittenReviewPage/index.tsx
@@ -1,13 +1,17 @@
 import { ErrorSuspenseContainer, AuthAndServerErrorFallback, TopButton } from '@/components';
 import { useSearchParamAndQuery } from '@/hooks';
+import { useGetUserProfile } from '@/hooks/oAuth';
 
 import { EmptyWrittenReview } from './components';
 import { LargeContent, UnderLargeContent } from './components/layouts';
 import { useDeviceBreakpoints, useGetWrittenReviewList } from './hooks';
 
 const WrittenReviewPage = () => {
+  const { userProfile, isUserLoggedIn } = useGetUserProfile();
+  const memberIdProp = isUserLoggedIn && userProfile ? userProfile.memberId : undefined;
+
   const { deviceType } = useDeviceBreakpoints();
-  const { reviewList } = useGetWrittenReviewList();
+  const { reviewList } = useGetWrittenReviewList({ memberId: memberIdProp });
 
   const { queryString: reviewIdString } = useSearchParamAndQuery({
     queryStringKey: 'reviewId',

--- a/frontend/src/utils/formatKeyword.ts
+++ b/frontend/src/utils/formatKeyword.ts
@@ -1,7 +1,7 @@
 const formatKeyword = (content: string) => {
   const contentWithoutExample = Array.from(content.split(' (예: ')[0]);
   const emoji = contentWithoutExample.shift();
-  const keyword = contentWithoutExample.join('');
+  const keyword = contentWithoutExample.join('').trim();
 
   return `${emoji} ${keyword}`;
 };


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #1154 

---

### 🚀 어떤 기능을 구현했나요 ?
- 리뷰 링크별 받은 리뷰 목록이 제대로 뜨지 않는 문제를 수정했습니다.

[REVIEW-ME (3).webm](https://github.com/user-attachments/assets/1a17d149-b2a9-4b8c-b8f3-9bfc8438e185)

위 영상과 같이 이전에 선택한 리뷰 정보와 리뷰 목록이 그대로 보이고, 새로고침 해야만 제대로 동작하는 문제가 있었습니다.
url 상에서 reviewRequestCode는 제대로 바뀌고 있어서, 쿼리 캐싱 문제로 의심됩니다.

### 🔥 어떻게 해결했나요 ?
![image](https://github.com/user-attachments/assets/21d60f0b-5234-44f8-bf2d-29cb51226312)
▲ 링크의 정보(프로젝트 이름, 리뷰이 이름, 리뷰 개수)의 staleTime을 제거했습니다.

![image](https://github.com/user-attachments/assets/f6568ae8-0bb7-42f2-9532-84023efa2870)
▲ 리뷰 목록의 staleTime을 제거했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 로컬에서 지금 로그인 목 핸들러가 동작하지 않고 있어서 제대로 바뀌는지 한 번만 확인해주시면 감사하겠습니다...

### 📚 참고 자료, 할 말
