### PR TITLE
[FE] fix: 답변 모아보기에서, 받은 서술형 답변이 없을 때 EmptyContent 렌더링

### DIFF
--- a/frontend/src/pages/ReviewCollectionPage/components/ReviewCollectionPageContents/index.tsx
+++ b/frontend/src/pages/ReviewCollectionPage/components/ReviewCollectionPageContents/index.tsx
@@ -54,15 +54,22 @@ const ReviewCollectionPageContents = () => {
       );
     }
 
-    if (review.answers?.length === 0) {
-      <EmptyContent iconWidth="18rem" messageFontSize="1.8rem" iconMessageGap="2.6rem">
-        {REVIEW_EMPTY.noReviewInQuestion}
-      </EmptyContent>;
+    if (review.question.type === 'TEXT') {
+      const hasNoTextAnswer = !review.answers || review.answers.length === 0;
+
+      return hasNoTextAnswer ? (
+        <EmptyContent iconWidth="18rem" messageFontSize="1.8rem" iconMessageGap="2.6rem">
+          {REVIEW_EMPTY.noReviewInQuestion}
+        </EmptyContent>
+      ) : (
+        <HighlightEditorContainer questionId={review.question.id} answerList={review.answers!} />
+      );
     }
 
-    return <HighlightEditorContainer questionId={review.question.id} answerList={review.answers!} />;
+    return null;
   };
 
+  // 받은 리뷰가 아무것도 없는 경우
   if (totalReviewCount === 0) {
     return (
       <EmptyContent iconWidth="17rem" messageFontSize="2rem" iconMessageGap="2.6rem" isBorder={true}>


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #1161

---

### 🚀 어떤 기능을 구현했나요 ?
- 답변 모아보기에서, 받은 서술형 질문이 없는 경우 EmptyContent 렌더링

### 🔥 어떻게 해결했나요 ?
#### 문제 1
- 서술형이 없는 것을 `review.answers?.length === 0`으로 확인하고 있었는데, 이 조건식으로는 정말 서술형 답변이 없는지를 파악할 수 없었습니다.
- 정확한 조건은 `서술형 질문이면서, answer가 없거나 길이가 0일 때`  <- 인데 저 if문은 answer가 없으면 무조건 false라서 EmptyContent 렌더링이 불가능했어요.

#### 문제 2
위 if문 체크에서 return문이 누락되어 있었습니다 😶

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 원래 모아보기 페이지의 render 함수에서, 현재 다루는 답변이 객관식인 경우만 if문을 사용해 early return하고 있었어요. (서술형 답변은 별도의 if나 else 처리 없이 리턴하는 식)
- 그런데 이 코드를 딱 봤을 때 순간 얘가 뭘 리턴하는지를 이해하기가 어려웠어서 그냥 서술형 질문일 때도 명시적으로 if문 체크하고, 아무 케이스도 아닐 때 null을 리턴하도록 했습니다. 

### 📚 참고 자료, 할 말
- 리뷰를 열심히 해야겠다... 
- 그런데 리뷰에 앞서 구현할 때 다양한 UI 케이스들을 확인해볼 수 있으면 좋겠어요. 리뷰 및 QA가 너무 빡세짐ㅋㅋㅋㅠㅠ 스토리북을 도입해야 할까요...
- 데이터 구조가 헷갈리네요 😂 금방 끝날줄..