### PR TITLE
[FE] fix: 작성한 리뷰 확인 페이지 401 응답 메세지 오류 수정

### DIFF
--- a/frontend/src/components/error/ErrorSection/index.tsx
+++ b/frontend/src/components/error/ErrorSection/index.tsx
@@ -4,7 +4,7 @@ import PrimaryReloadIcon from '@/assets/primaryReload.svg';
 import WhiteHomeIcon from '@/assets/whiteHome.svg';
 import WhiteReloadIcon from '@/assets/whiteReload.svg';
 import { Button } from '@/components';
-import { ROUTE_ERROR_MESSAGE } from '@/constants';
+import { API_ERROR_MESSAGE, ROUTE_ERROR_MESSAGE } from '@/constants';
 import { ButtonStyleType } from '@/types/styles';
 
 import * as S from './styles';
@@ -27,7 +27,8 @@ export interface ErrorSectionButton {
 }
 
 const ErrorSection = ({ errorMessage, handleReload, handleGoOtherPage, errorType = 'notFound' }: ErrorSectionProps) => {
-  const isGoHomeButtonFirst = errorMessage === ROUTE_ERROR_MESSAGE;
+  const homeFirstErrorMessages = [API_ERROR_MESSAGE[401], API_ERROR_MESSAGE[403], ROUTE_ERROR_MESSAGE];
+  const isGoHomeButtonFirst = homeFirstErrorMessages.some((message) => message === errorMessage);
   // errorMessage에 따른 커스텀
   const buttonList: ErrorSectionButton[] = [];
 

--- a/frontend/src/constants/errorMessage.ts
+++ b/frontend/src/constants/errorMessage.ts
@@ -5,8 +5,8 @@ interface ApiErrorMessage {
 
 export const API_ERROR_MESSAGE: ApiErrorMessage = {
   400: '잘못된 요청이에요',
-  401: '인증을 실패했어요',
-  403: '요청권한이 없어요',
+  401: '인증 권한이 없어요.',
+  403: '접근 권한이 없어요',
   404: '요청하신 내용을 찾을 수 없어요',
   422: '올바르지 않은 데이터 형식이에요',
   serverError: '서버 오류가 발생했어요',

--- a/frontend/src/constants/errorMessage.ts
+++ b/frontend/src/constants/errorMessage.ts
@@ -5,7 +5,7 @@ interface ApiErrorMessage {
 
 export const API_ERROR_MESSAGE: ApiErrorMessage = {
   400: '잘못된 요청이에요',
-  401: '인증 권한이 없어요.',
+  401: '인증 권한이 없어요',
   403: '접근 권한이 없어요',
   404: '요청하신 내용을 찾을 수 없어요',
   422: '올바르지 않은 데이터 형식이에요',

--- a/frontend/src/constants/errorMessage.ts
+++ b/frontend/src/constants/errorMessage.ts
@@ -5,7 +5,7 @@ interface ApiErrorMessage {
 
 export const API_ERROR_MESSAGE: ApiErrorMessage = {
   400: '잘못된 요청이에요',
-  401: '인증 권한이 없어요',
+  401: '인증 정보가 유효하지 않아요',
   403: '접근 권한이 없어요',
   404: '요청하신 내용을 찾을 수 없어요',
   422: '올바르지 않은 데이터 형식이에요',

--- a/frontend/src/pages/WrittenReviewPage/components/PageContent/index.tsx
+++ b/frontend/src/pages/WrittenReviewPage/components/PageContent/index.tsx
@@ -1,0 +1,32 @@
+import { ErrorSuspenseContainer, AuthAndServerErrorFallback, TopButton } from '@/components';
+import { useSearchParamAndQuery } from '@/hooks';
+
+import { useDeviceBreakpoints, useGetWrittenReviewList } from '../../hooks';
+import EmptyWrittenReview from '../EmptyWrittenReview';
+import { LargeContent, UnderLargeContent } from '../layouts';
+
+const PageContent = () => {
+  const { deviceType } = useDeviceBreakpoints();
+  const { reviewList } = useGetWrittenReviewList();
+
+  const { queryString: reviewIdString } = useSearchParamAndQuery({
+    queryStringKey: 'reviewId',
+  });
+
+  const selectedReviewId = reviewIdString ? Number(reviewIdString) : null;
+
+  return (
+    <ErrorSuspenseContainer errorFallback={AuthAndServerErrorFallback}>
+      <TopButton />
+      {reviewList.length === 0 ? (
+        <EmptyWrittenReview />
+      ) : deviceType.isDesktop ? (
+        <LargeContent selectedReviewId={selectedReviewId} />
+      ) : (
+        <UnderLargeContent selectedReviewId={selectedReviewId} />
+      )}
+    </ErrorSuspenseContainer>
+  );
+};
+
+export default PageContent;

--- a/frontend/src/pages/WrittenReviewPage/index.tsx
+++ b/frontend/src/pages/WrittenReviewPage/index.tsx
@@ -1,30 +1,11 @@
-import { ErrorSuspenseContainer, AuthAndServerErrorFallback, TopButton } from '@/components';
-import { useSearchParamAndQuery } from '@/hooks';
+import { ErrorSuspenseContainer, AuthAndServerErrorFallback } from '@/components';
 
-import { EmptyWrittenReview } from './components';
-import { LargeContent, UnderLargeContent } from './components/layouts';
-import { useDeviceBreakpoints, useGetWrittenReviewList } from './hooks';
+import PageContent from './components/PageContent';
 
 const WrittenReviewPage = () => {
-  const { deviceType } = useDeviceBreakpoints();
-  const { reviewList } = useGetWrittenReviewList();
-
-  const { queryString: reviewIdString } = useSearchParamAndQuery({
-    queryStringKey: 'reviewId',
-  });
-
-  const selectedReviewId = reviewIdString ? Number(reviewIdString) : null;
-
   return (
     <ErrorSuspenseContainer errorFallback={AuthAndServerErrorFallback}>
-      <TopButton />
-      {reviewList.length === 0 ? (
-        <EmptyWrittenReview />
-      ) : deviceType.isDesktop ? (
-        <LargeContent selectedReviewId={selectedReviewId} />
-      ) : (
-        <UnderLargeContent selectedReviewId={selectedReviewId} />
-      )}
+      <PageContent />
     </ErrorSuspenseContainer>
   );
 };

--- a/frontend/src/pages/WrittenReviewPage/index.tsx
+++ b/frontend/src/pages/WrittenReviewPage/index.tsx
@@ -1,10 +1,10 @@
-import { ErrorSuspenseContainer, AuthAndServerErrorFallback } from '@/components';
+import { ErrorSuspenseContainer } from '@/components';
 
 import PageContent from './components/PageContent';
 
 const WrittenReviewPage = () => {
   return (
-    <ErrorSuspenseContainer errorFallback={AuthAndServerErrorFallback}>
+    <ErrorSuspenseContainer>
       <PageContent />
     </ErrorSuspenseContainer>
   );


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #1163

---

### 🚀 어떤 기능을 구현했나요 ?
#### 상황
- 로그아웃 후 뒤로 가기로 다시 작성한 리뷰 확인 페이지 접근 시, '인증 권한 오류 메세지'가 아닌 '찾으시는 페이지가 없어요.'라는 페이지 경로 오류 메세지가 띄워졌어요

#### 해결
- 데이터 패칭을 하는 곳에서 에러바운더리를 적용해, API 오류를 잡지 못하고 상위 에러바운더리로 오류가 넘어갔어요.
- PageContent라는 컴포넌트로 분리해, 이곳에서 비동기 요청을 보내고 리뷰 작성 페이지에서 이를 에러바운더리로 감싸는 동작을 진행했어요.
- 현재 사용자 프로필 조회 시, 권한이 없으면 서버에서 401을 내려주고 있어요. 그래서 인증에 실패했다는 내용보다는 '인증이 유효하지 않아요'라는 문구로 변경했어요. 
- 작성한 리뷰 확인 페이지, 만든 리뷰 링크 페이지의 에러 폴백으로 ErrorFallback을 사용하되, 홈 페이지 바로가기 버튼이 첫번째로 오도록 했어요.

### 🔥 어떻게 해결했나요 ?
- 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
- 오류 메세지를 회의할 시간이 없어서 제가 임의로 했어요.