### PR TITLE
[FE] fix: 로그아웃 시, 변경된 사용자 프로필 캐시 적용안되는 오류 수정

### DIFF
--- a/frontend/src/components/error/ErrorSection/index.tsx
+++ b/frontend/src/components/error/ErrorSection/index.tsx
@@ -3,7 +3,7 @@ import PrimaryHomeIcon from '@/assets/primaryHome.svg';
 import PrimaryReloadIcon from '@/assets/primaryReload.svg';
 import WhiteHomeIcon from '@/assets/whiteHome.svg';
 import WhiteReloadIcon from '@/assets/whiteReload.svg';
-import { Button } from '@/components';
+import { Button, ImgWithSkeleton } from '@/components';
 import { API_ERROR_MESSAGE, ROUTE_ERROR_MESSAGE } from '@/constants';
 import { ButtonStyleType } from '@/types/styles';
 
@@ -57,7 +57,9 @@ const ErrorSection = ({ errorMessage, handleReload, handleGoOtherPage, errorType
   return (
     <S.Layout>
       <S.ErrorLogoWrapper>
-        <img src={AlertTriangleIcon} alt="에러 로고" />
+        <ImgWithSkeleton imgHeight="inherit" imgWidth="inherit">
+          <img src={AlertTriangleIcon} alt="에러 로고" />
+        </ImgWithSkeleton>
       </S.ErrorLogoWrapper>
       <S.ErrorMessage>{errorMessage}</S.ErrorMessage>
       <S.Container>

--- a/frontend/src/components/error/ErrorSection/styles.ts
+++ b/frontend/src/components/error/ErrorSection/styles.ts
@@ -22,19 +22,22 @@ export const Layout = styled.div`
 `;
 
 export const ErrorLogoWrapper = styled.div`
-  & > img {
-    width: 15rem;
-    height: 15rem;
+  width: 15rem;
+  height: 15rem;
 
-    ${media.xSmall} {
-      width: 11rem;
-      height: 11rem;
-    }
+  ${media.xSmall} {
+    width: 11rem;
+    height: 11rem;
+  }
 
-    ${media.xxSmall} {
-      width: 8rem;
-      height: 8rem;
-    }
+  ${media.xxSmall} {
+    width: 8rem;
+    height: 8rem;
+  }
+
+  img {
+    width: inherit;
+    height: inherit;
   }
 `;
 

--- a/frontend/src/components/profile/ProfileInfo/index.tsx
+++ b/frontend/src/components/profile/ProfileInfo/index.tsx
@@ -1,5 +1,6 @@
 import DownArrowIcon from '@/assets/downArrow.svg';
 import UndraggableWrapper from '@/components/common/UndraggableWrapper';
+import { ImgWithSkeleton } from '@/components/skeleton';
 import { SocialType } from '@/types/profile';
 
 import ProfileTab from '../ProfileTab';
@@ -21,7 +22,11 @@ const ProfileInfo = ({ profileImageSrc, profileId, socialType }: ProfileInfoProp
       <UndraggableWrapper>
         <S.ProfileContainer onClick={handleContainerClick}>
           <S.ProfileImageWrapper>
-            {profileImageSrc && <img src={profileImageSrc} alt="프로필 사진" />}
+            {profileImageSrc && (
+              <ImgWithSkeleton imgHeight="inherit" imgWidth="inherit">
+                <img src={profileImageSrc} alt="프로필 사진" />
+              </ImgWithSkeleton>
+            )}
           </S.ProfileImageWrapper>
           <S.ProfileId>{profileId}</S.ProfileId>
           <S.ArrowIcon src={DownArrowIcon} $isOpened={isOpened} alt="" />

--- a/frontend/src/hooks/oAuth/useOAuthLogout.ts
+++ b/frontend/src/hooks/oAuth/useOAuthLogout.ts
@@ -25,7 +25,7 @@ const useOAuthLogout = () => {
 
     onSuccess: () => {
       showToast({ type: 'success', message: '로그아웃 완료!', position: 'top' });
-      queryClient.clear();
+      queryClient.invalidateQueries();
       redirectOnSuccess();
     },
     onError: () => {

--- a/frontend/src/hooks/oAuth/useOAuthLogout.ts
+++ b/frontend/src/hooks/oAuth/useOAuthLogout.ts
@@ -17,6 +17,17 @@ const useOAuthLogout = () => {
     return navigate(ROUTE.home, { replace: true });
   };
 
+  const removeAllQueriesExceptUserProfile = () => {
+    const queries = queryClient.getQueryCache().getAll();
+
+    queries.forEach((query) => {
+      if (!query.queryKey[0]) return;
+      if (query.queryKey[0] !== OAUTH_QUERY_KEY.userProfile) {
+        queryClient.removeQueries(query.queryKey[0]);
+      }
+    });
+  };
+
   const mutation = useMutation({
     mutationKey: [OAUTH_QUERY_KEY.gitHubLogout],
     mutationFn: async () => {
@@ -25,7 +36,8 @@ const useOAuthLogout = () => {
 
     onSuccess: () => {
       showToast({ type: 'success', message: '로그아웃 완료!', position: 'top' });
-      queryClient.invalidateQueries();
+      queryClient.invalidateQueries({ queryKey: [OAUTH_QUERY_KEY.userProfile] });
+      removeAllQueriesExceptUserProfile();
       redirectOnSuccess();
     },
     onError: () => {

--- a/frontend/src/hooks/oAuth/useOAuthLogout.ts
+++ b/frontend/src/hooks/oAuth/useOAuthLogout.ts
@@ -17,13 +17,12 @@ const useOAuthLogout = () => {
     return navigate(ROUTE.home, { replace: true });
   };
 
-  const removeAllQueriesExceptUserProfile = () => {
+  const removeQueriesExceptSavedKeys = () => {
     const queries = queryClient.getQueryCache().getAll();
     const savedQueryKeys = [OAUTH_QUERY_KEY.userProfile, REVIEW_QUERY_KEY.writingReviewInfo];
 
     queries.forEach((query) => {
       if (!query.queryKey[0]) return;
-
       const isSaved = savedQueryKeys.some((key) => key === query.queryKey[0]);
 
       if (!isSaved) {
@@ -41,7 +40,7 @@ const useOAuthLogout = () => {
     onSuccess: () => {
       showToast({ type: 'success', message: '로그아웃 완료!', position: 'top' });
       queryClient.invalidateQueries({ queryKey: [OAUTH_QUERY_KEY.userProfile] });
-      removeAllQueriesExceptUserProfile();
+      removeQueriesExceptSavedKeys();
       redirectOnSuccess();
     },
     onError: () => {

--- a/frontend/src/hooks/oAuth/useOAuthLogout.ts
+++ b/frontend/src/hooks/oAuth/useOAuthLogout.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useLocation, useNavigate } from 'react-router';
 
 import { postOAuthLogoutApi } from '@/apis/oAuth';
-import { OAUTH_QUERY_KEY, ROUTE } from '@/constants';
+import { OAUTH_QUERY_KEY, REVIEW_QUERY_KEY, ROUTE } from '@/constants';
 
 import useToastContext from '../useToastContext';
 
@@ -19,10 +19,14 @@ const useOAuthLogout = () => {
 
   const removeAllQueriesExceptUserProfile = () => {
     const queries = queryClient.getQueryCache().getAll();
+    const savedQueryKeys = [OAUTH_QUERY_KEY.userProfile, REVIEW_QUERY_KEY.writingReviewInfo];
 
     queries.forEach((query) => {
       if (!query.queryKey[0]) return;
-      if (query.queryKey[0] !== OAUTH_QUERY_KEY.userProfile) {
+
+      const isSaved = savedQueryKeys.some((key) => key === query.queryKey[0]);
+
+      if (!isSaved) {
         queryClient.removeQueries(query.queryKey[0]);
       }
     });


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #1172

---

### 🚀 어떤 오류였나요?
홈 페이지와 연결 페이지에서 로그아웃 시, 로그인 된 이전의 사용자 프로필 쿼리를 그대로 사용하는 오류가 발생했습니다.


### 🔥 어떻게 해결했나요 ?
### 해결 방법
  query.clear는 쿼리를 재리패치 않아, 사용자 프로필만 무효화하고 그 외의 쿼리를 삭제했습니다.

모든 쿼리를 삭제가 아닌 무효화하면, 무효화 쿼리가 적용하기 까지 시간이 걸려 로그아웃 후 이전/다음으로 회원용 페이지에 접근할 수 있습니다. 그래서 로그인 여부를 확인하는 사용자 프로필만 무효화해 리패치가 일어나도록 하고, 그 외는 쿼리는 리패치가 일어나지 않도록 `removeQueries` 로 삭제했습니다.

### 추가 구현
release에서 QA시, 오류 아이콘 로딩이 느려서 스켈레톤 적용했습니다. 겸사겸사 깃허브 프로필에도 적용했습니다. 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 로컬에서 막 사용해서, 오류가 없는 지 확인해주세요.

### 📚 참고 자료, 할 말
- 🙏 이번 배포  마지막 쿼리 버그여랴... 