### PR TITLE
[FE] fix: 링크 페이지, 작성한 리뷰 확인 페이지 외에 다른 페이지에서 NavigationTab 비활성화

### DIFF
--- a/frontend/src/components/common/NavigationTab/index.tsx
+++ b/frontend/src/components/common/NavigationTab/index.tsx
@@ -3,8 +3,8 @@ import { useLocation } from 'react-router';
 import NavItem from './NavItem';
 import * as S from './styles';
 export interface Tab {
-  label: '리뷰 링크 관리' | '작성한 리뷰 확인';
-  activePathList: string[];
+  label: string;
+  activePath: string;
   handleTabClick: () => void;
 }
 
@@ -15,8 +15,6 @@ interface NavigationTabProps {
 const NavigationTab = ({ tabList }: NavigationTabProps) => {
   const { pathname } = useLocation();
 
-  const isActiveTab = (activePaths: string[]) => activePaths.some((activePath) => pathname.includes(activePath));
-
   return (
     <S.NavContainer>
       <S.NavList>
@@ -24,7 +22,7 @@ const NavigationTab = ({ tabList }: NavigationTabProps) => {
           <NavItem
             key={tab.label}
             label={tab.label}
-            $isActiveTab={isActiveTab(tab.activePathList)}
+            $isActiveTab={pathname.includes(tab.activePath)}
             onClick={tab.handleTabClick}
           />
         ))}

--- a/frontend/src/hooks/useNavigationTabs.ts
+++ b/frontend/src/hooks/useNavigationTabs.ts
@@ -9,14 +9,12 @@ const useNavigationTabs = () => {
   const navigationTabList: Tab[] = [
     {
       label: '리뷰 링크 관리',
-      // "리뷰 링크 관리" 탭이 활성화 되어야 하는 페이지 목록
-      activePathList: [ROUTE.reviewLinks, ROUTE.reviewList, ROUTE.reviewCollection, ROUTE.detailedReview],
+      activePath: ROUTE.reviewLinks,
       handleTabClick: () => navigate(ROUTE.reviewLinks),
     },
     {
       label: '작성한 리뷰 확인',
-      // "작성한 리뷰 확인" 탭이 활성화 되어야 하는 페이지 목록
-      activePathList: [ROUTE.writtenReview, ROUTE.reviewWriting, ROUTE.reviewWritingComplete],
+      activePath: ROUTE.writtenReview,
       handleTabClick: () => navigate(ROUTE.writtenReview),
     },
   ];


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #1178 

---

### 🚀 어떤 기능을 구현했나요 ?
- 링크 페이지에서 링크 아이템을 클릭한 후 목록 페이지로 이동하면, 링크 페이지의 NavigationTab이 활성화되는 문제가 있었습니다. 링크 관리 탭은 `링크 페이지`, 작성한 리뷰 확인 탭은 `작성한 리뷰 페이지`에서만 활성화되도록 변경했습니다.



| 변경 전 | 변경 후 |
|--------|--------|
| <img width="214" alt="스크린샷 2025-02-24 오전 1 21 06" src="https://github.com/user-attachments/assets/be3e638e-2d1d-4e89-b589-c5fd03bbece9" /> | <img width="214" alt="스크린샷 2025-02-24 오전 1 17 15" src="https://github.com/user-attachments/assets/52aa92fd-3009-437e-8b87-b5d9a41a0b86" /> |

### 🔥 어떻게 해결했나요 ?
- 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
