### PR TITLE
[BE] refactor: reviewRequestCode를 받는 api를 reviewGroupId를 받도록 변경

### DIFF
--- a/backend/src/main/java/reviewme/highlight/controller/HighlightController.java
+++ b/backend/src/main/java/reviewme/highlight/controller/HighlightController.java
@@ -9,25 +9,19 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import reviewme.highlight.service.HighlightService;
 import reviewme.highlight.service.dto.HighlightsRequest;
-import reviewme.reviewgroup.domain.ReviewGroup;
-import reviewme.reviewgroup.service.ReviewGroupService;
 
 @RestController
 @RequiredArgsConstructor
 public class HighlightController {
 
     private final HighlightService highlightService;
-    private final ReviewGroupService reviewGroupService;
 
-    @PostMapping("/v2/groups/{reviewRequestCode}/highlights")
+    @PostMapping("/v2/groups/{reviewGroupId}/highlights")
     public ResponseEntity<Void> highlightByReviewGroup(
-            @PathVariable String reviewRequestCode,
+            @PathVariable long reviewGroupId,
             @Valid @RequestBody HighlightsRequest request
     ) {
-        // TODO : reviewRequestCode를 위한 임시 사용, 이후 삭제 예정.
-        ReviewGroup reviewGroup = reviewGroupService.getReviewGroupByReviewRequestCode(reviewRequestCode);
-
-        highlightService.highlightByReviewGroup(reviewGroup.getId(), request);
+        highlightService.highlightByReviewGroup(reviewGroupId, request);
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/reviewme/review/controller/ReviewController.java
+++ b/backend/src/main/java/reviewme/review/controller/ReviewController.java
@@ -22,8 +22,6 @@ import reviewme.review.service.dto.response.gathered.ReviewsGatheredBySectionRes
 import reviewme.review.service.dto.response.list.AuthoredReviewsResponse;
 import reviewme.review.service.dto.response.list.ReceivedReviewPageResponse;
 import reviewme.review.service.dto.response.list.ReceivedReviewsSummaryResponse;
-import reviewme.reviewgroup.domain.ReviewGroup;
-import reviewme.reviewgroup.service.ReviewGroupService;
 import reviewme.security.aspect.RequireReviewAccess;
 import reviewme.security.aspect.RequireReviewGroupAccess;
 import reviewme.security.resolver.LoginMemberSession;
@@ -38,7 +36,6 @@ public class ReviewController {
     private final ReviewDetailLookupService reviewDetailLookupService;
     private final ReviewSummaryService reviewSummaryService;
     private final ReviewGatheredLookupService reviewGatheredLookupService;
-    private final ReviewGroupService reviewGroupService;
 
     @PostMapping("/v2/reviews")
     public ResponseEntity<Void> createReview(
@@ -50,16 +47,15 @@ public class ReviewController {
         return ResponseEntity.created(URI.create("/reviews/" + savedReviewId)).build();
     }
 
-    @GetMapping("/v2/groups/{reviewRequestCode}/reviews/received") // todo: groupId를 받도록 수정 필요 issue #1101
-    @RequireReviewGroupAccess(target = "#reviewRequestCode")
+    @GetMapping("/v2/groups/{reviewGroupId}/reviews/received")
+    @RequireReviewGroupAccess(target = "#reviewGorupId")
     public ResponseEntity<ReceivedReviewPageResponse> findReceivedReviews(
-            @PathVariable String reviewRequestCode,
+            @PathVariable long reviewGroupId,
             @RequestParam(required = false) Long lastReviewId,
             @RequestParam(required = false) Integer size
     ) {
-        ReviewGroup reviewGroup = reviewGroupService.getReviewGroupByReviewRequestCode(reviewRequestCode);
         ReceivedReviewPageResponse response
-                = reviewListLookupService.getReceivedReviews(reviewGroup.getId(), lastReviewId, size);
+                = reviewListLookupService.getReceivedReviews(reviewGroupId, lastReviewId, size);
         return ResponseEntity.ok(response);
     }
 
@@ -72,25 +68,23 @@ public class ReviewController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/v2/groups/{reviewRequestCode}/reviews/summary") // todo: groupId를 받도록 수정 필요 issue #1101
-    @RequireReviewGroupAccess(target = "#reviewRequestCode")
+    @GetMapping("/v2/groups/{reviewGroupId}/reviews/summary")
+    @RequireReviewGroupAccess(target = "#reviewGroupId")
     public ResponseEntity<ReceivedReviewsSummaryResponse> findReceivedReviewOverview(
-            @PathVariable String reviewRequestCode
+            @PathVariable long reviewGroupId
     ) {
-        ReviewGroup reviewGroup = reviewGroupService.getReviewGroupByReviewRequestCode(reviewRequestCode);
-        ReceivedReviewsSummaryResponse response = reviewSummaryService.getReviewSummary(reviewGroup.getId());
+        ReceivedReviewsSummaryResponse response = reviewSummaryService.getReviewSummary(reviewGroupId);
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/v2/groups/{reviewRequestCode}/reviews/gather") // todo: groupId를 받도록 수정 필요 issue #1101
-    @RequireReviewGroupAccess(target = "#reviewRequestCode")
+    @GetMapping("/v2/groups/{reviewGroupId}/reviews/gather")
+    @RequireReviewGroupAccess(target = "#reviewGroupId")
     public ResponseEntity<ReviewsGatheredBySectionResponse> getReceivedReviewsBySectionId(
-            @PathVariable String reviewRequestCode,
+            @PathVariable long reviewGroupId,
             @RequestParam("sectionId") long sectionId
     ) {
-        ReviewGroup reviewGroup = reviewGroupService.getReviewGroupByReviewRequestCode(reviewRequestCode);
         ReviewsGatheredBySectionResponse response =
-                reviewGatheredLookupService.getReceivedReviewsBySectionId(reviewGroup.getId(), sectionId);
+                reviewGatheredLookupService.getReceivedReviewsBySectionId(reviewGroupId, sectionId);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/reviewme/reviewgroup/service/ReviewGroupLookupService.java
+++ b/backend/src/main/java/reviewme/reviewgroup/service/ReviewGroupLookupService.java
@@ -25,7 +25,7 @@ public class ReviewGroupLookupService {
                 .orElseThrow(() -> new ReviewGroupNotFoundByReviewRequestCodeException(reviewRequestCode));
 
         return new ReviewGroupSummaryResponse(
-                reviewGroup.getMemberId(), reviewGroup.getReviewee(), reviewGroup.getProjectName());
+                reviewGroup.getMemberId(), reviewGroup.getId(), reviewGroup.getReviewee(), reviewGroup.getProjectName());
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/reviewme/reviewgroup/service/dto/ReviewGroupSummaryResponse.java
+++ b/backend/src/main/java/reviewme/reviewgroup/service/dto/ReviewGroupSummaryResponse.java
@@ -5,6 +5,7 @@ import jakarta.annotation.Nullable;
 public record ReviewGroupSummaryResponse(
 
         @Nullable Long revieweeId,
+        long reviewGroupId,
         String revieweeName,
         String projectName
 ) {

--- a/backend/src/test/java/reviewme/api/HighlightApiTest.java
+++ b/backend/src/test/java/reviewme/api/HighlightApiTest.java
@@ -6,6 +6,8 @@ import static org.springframework.restdocs.cookies.CookieDocumentation.requestCo
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
@@ -14,6 +16,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.restdocs.cookies.CookieDescriptor;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.request.ParameterDescriptor;
 import reviewme.reviewgroup.domain.ReviewGroup;
 
 class HighlightApiTest extends ApiTest {
@@ -47,6 +50,10 @@ class HighlightApiTest extends ApiTest {
                 cookieWithName("JSESSIONID").description("세션 ID")
         };
 
+        ParameterDescriptor[] requestPathDescriptors = {
+                parameterWithName("reviewGroupId").description("리뷰 그룹 ID")
+        };
+
         FieldDescriptor[] requestFields = {
                 fieldWithPath("questionId").description("질문 ID"),
                 fieldWithPath("highlights").description("하이라이트 목록"),
@@ -58,15 +65,16 @@ class HighlightApiTest extends ApiTest {
 
         RestDocumentationResultHandler handler = document(
                 "highlight-answer",
-                requestFields(requestFields),
-                requestCookies(cookieDescriptors)
+                requestCookies(cookieDescriptors),
+                pathParameters(requestPathDescriptors),
+                requestFields(requestFields)
         );
 
         givenWithSpec().log().all()
                 .cookie("JSESSIONID", "AVEBNKLCL13TNVZ")
-                .pathParam("reviewRequestCode", "rereco")
+                .pathParam("reviewGroupId", 1)
                 .body(request)
-                .when().post("/v2/groups/{reviewRequestCode}/highlights")
+                .when().post("/v2/groups/{reviewGroupId}/highlights")
                 .then().log().all()
                 .apply(handler)
                 .status(HttpStatus.OK);

--- a/backend/src/test/java/reviewme/api/ReviewApiTest.java
+++ b/backend/src/test/java/reviewme/api/ReviewApiTest.java
@@ -3,10 +3,8 @@ package reviewme.api;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
 import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
 import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -39,7 +37,6 @@ import reviewme.review.service.dto.response.list.ReceivedReviewPageElementRespon
 import reviewme.review.service.dto.response.list.ReceivedReviewPageResponse;
 import reviewme.review.service.dto.response.list.ReceivedReviewsSummaryResponse;
 import reviewme.review.service.dto.response.list.SelectedCategoryOptionResponse;
-import reviewme.reviewgroup.domain.ReviewGroup;
 import reviewme.reviewgroup.service.exception.ReviewGroupNotFoundByReviewRequestCodeException;
 import reviewme.template.domain.QuestionType;
 
@@ -153,12 +150,12 @@ class ReviewApiTest extends ApiTest {
         given(reviewDetailLookupService.getReviewDetail(anyLong()))
                 .willReturn(TemplateFixture.templateAnswerResponse());
 
-        ParameterDescriptor[] requestPathDescriptors = {
-                parameterWithName("id").description("리뷰 ID")
-        };
-
         CookieDescriptor[] cookieDescriptors = {
                 cookieWithName("JSESSIONID").description("세션 ID")
+        };
+
+        ParameterDescriptor[] requestPathDescriptors = {
+                parameterWithName("id").description("리뷰 ID")
         };
 
         FieldDescriptor[] responseFieldDescriptors = {
@@ -207,11 +204,6 @@ class ReviewApiTest extends ApiTest {
 
     @Test
     void 자신이_받은_리뷰_목록을_조회한다() {
-        ReviewGroup reviewGroup = mock(ReviewGroup.class);
-        given(reviewGroup.getId()).willReturn(1L);
-        given(reviewGroupService.getReviewGroupByReviewRequestCode(anyString()))
-                .willReturn(reviewGroup);
-
         List<ReceivedReviewPageElementResponse> receivedReviews = List.of(
                 new ReceivedReviewPageElementResponse(1L, LocalDateTime.of(2024, 8, 1, 0, 0), "(리뷰 미리보기 1)",
                         List.of(new SelectedCategoryOptionResponse(1L, "카테고리 1"))),
@@ -228,7 +220,7 @@ class ReviewApiTest extends ApiTest {
         };
 
         ParameterDescriptor[] requestPathDescriptors = {
-                parameterWithName("reviewRequestCode").description("리뷰 요청 코드")
+                parameterWithName("reviewGroupId").description("리뷰 그룹 ID")
         };
 
         ParameterDescriptor[] queryParameter = {
@@ -254,18 +246,18 @@ class ReviewApiTest extends ApiTest {
 
         RestDocumentationResultHandler handler = document(
                 "received-review-list-with-pagination",
-                pathParameters(requestPathDescriptors),
                 requestCookies(cookieDescriptors),
+                pathParameters(requestPathDescriptors),
                 queryParameters(queryParameter),
                 responseFields(responseFieldDescriptors)
         );
 
         givenWithSpec().log().all()
-                .pathParam("reviewRequestCode", "ABCD1234")
+                .pathParam("reviewGroupId", 1)
                 .cookie("JSESSIONID", "ASVNE1VAKDNV4")
                 .queryParam("lastReviewId", "2")
                 .queryParam("size", "5")
-                .when().get("/v2/groups/{reviewRequestCode}/reviews/received")
+                .when().get("/v2/groups/{reviewGroupId}/reviews/received")
                 .then().log().all()
                 .apply(handler)
                 .statusCode(200);
@@ -273,9 +265,6 @@ class ReviewApiTest extends ApiTest {
 
     @Test
     void 자신이_받은_리뷰의_요약를_조회한다() {
-        ReviewGroup reviewGroup = mock(ReviewGroup.class);
-        given(reviewGroup.getId()).willReturn(1L);
-        given(reviewGroupService.getReviewGroupByReviewRequestCode(anyString())).willReturn(reviewGroup);
         given(reviewSummaryService.getReviewSummary(anyLong()))
                 .willReturn(new ReceivedReviewsSummaryResponse("리뷰미", "산초", 5));
 
@@ -283,7 +272,7 @@ class ReviewApiTest extends ApiTest {
                 cookieWithName("JSESSIONID").description("세션 ID")
         };
         ParameterDescriptor[] requestPathDescriptors = {
-                parameterWithName("reviewRequestCode").description("리뷰 요청 코드")
+                parameterWithName("reviewGroupId").description("리뷰 그룹 ID")
         };
 
         FieldDescriptor[] responseFieldDescriptors = {
@@ -294,15 +283,15 @@ class ReviewApiTest extends ApiTest {
 
         RestDocumentationResultHandler handler = document(
                 "received-review-summary",
-                pathParameters(requestPathDescriptors),
                 requestCookies(cookieDescriptors),
+                pathParameters(requestPathDescriptors),
                 responseFields(responseFieldDescriptors)
         );
 
         givenWithSpec().log().all()
-                .pathParam("reviewRequestCode", "abcd1234")
+                .pathParam("reviewGroupId", 1)
                 .cookie("JSESSIONID", "ABCDEFGHI1234")
-                .when().get("/v2/groups/{reviewRequestCode}/reviews/summary")
+                .when().get("/v2/groups/{reviewGroupId}/reviews/summary")
                 .then().log().all()
                 .apply(handler)
                 .statusCode(200);
@@ -310,10 +299,6 @@ class ReviewApiTest extends ApiTest {
 
     @Test
     void 자신이_받은_리뷰의_요약를_섹션별로_조회한다() {
-        ReviewGroup reviewGroup = mock(ReviewGroup.class);
-        given(reviewGroup.getId()).willReturn(1L);
-        given(reviewGroupService.getReviewGroupByReviewRequestCode(anyString())).willReturn(reviewGroup);
-
         ReviewsGatheredBySectionResponse response = new ReviewsGatheredBySectionResponse(List.of(
                 new ReviewsGatheredByQuestionResponse(
                         new SimpleQuestionResponse(1L, "서술형 질문", QuestionType.TEXT),
@@ -338,7 +323,7 @@ class ReviewApiTest extends ApiTest {
                 cookieWithName("JSESSIONID").description("세션 ID")
         };
         ParameterDescriptor[] requestPathDescriptors = {
-                parameterWithName("reviewRequestCode").description("리뷰 요청 코드")
+                parameterWithName("reviewGroupId").description("리뷰 그룹 ID")
         };
         ParameterDescriptor[] queryParameterDescriptors = {
                 parameterWithName("sectionId").description("섹션 ID")
@@ -365,17 +350,17 @@ class ReviewApiTest extends ApiTest {
         };
         RestDocumentationResultHandler handler = document(
                 "received-review-by-section",
-                pathParameters(requestPathDescriptors),
                 requestCookies(cookieDescriptors),
+                pathParameters(requestPathDescriptors),
                 queryParameters(queryParameterDescriptors),
                 responseFields(responseFieldDescriptors)
         );
 
         givenWithSpec().log().all()
-                .pathParam("reviewRequestCode", "abcd4321")
+                .pathParam("reviewGroupId", 1)
                 .cookie("JSESSIONID", "ABCDEFGHI1234")
                 .queryParam("sectionId", 1)
-                .when().get("/v2/groups/{reviewRequestCode}/reviews/gather")
+                .when().get("/v2/groups/{reviewGroupId}/reviews/gather")
                 .then().log().all()
                 .apply(handler)
                 .statusCode(200);

--- a/backend/src/test/java/reviewme/api/ReviewGroupApiTest.java
+++ b/backend/src/test/java/reviewme/api/ReviewGroupApiTest.java
@@ -112,7 +112,7 @@ class ReviewGroupApiTest extends ApiTest {
     @Test
     void 리뷰_요청_코드로_회원이_만든_리뷰_그룹_정보를_반환한다() {
         BDDMockito.given(reviewGroupLookupService.getReviewGroupSummary(anyString()))
-                .willReturn(new ReviewGroupSummaryResponse(1L,"아루", "리뷰미"));
+                .willReturn(new ReviewGroupSummaryResponse(1L, 1L, "아루", "리뷰미"));
 
         ParameterDescriptor[] parameterDescriptors = {
                 parameterWithName("reviewRequestCode").description("리뷰 요청 코드")
@@ -120,6 +120,7 @@ class ReviewGroupApiTest extends ApiTest {
 
         FieldDescriptor[] responseFieldDescriptors = {
                 fieldWithPath("revieweeId").description("리뷰이 ID"),
+                fieldWithPath("reviewGroupId").description("리뷰 그룹 ID"),
                 fieldWithPath("revieweeName").description("리뷰이 이름"),
                 fieldWithPath("projectName").description("프로젝트 이름")
         };
@@ -141,7 +142,7 @@ class ReviewGroupApiTest extends ApiTest {
     @Test
     void 리뷰_요청_코드로_비회원이_만든_리뷰_그룹_정보를_반환한다() {
         BDDMockito.given(reviewGroupLookupService.getReviewGroupSummary(anyString()))
-                .willReturn(new ReviewGroupSummaryResponse(null, "아루", "리뷰미"));
+                .willReturn(new ReviewGroupSummaryResponse(null, 1L, "아루", "리뷰미"));
 
         ParameterDescriptor[] parameterDescriptors = {
                 parameterWithName("reviewRequestCode").description("리뷰 요청 코드")
@@ -149,6 +150,7 @@ class ReviewGroupApiTest extends ApiTest {
 
         FieldDescriptor[] responseFieldDescriptors = {
                 fieldWithPath("revieweeId").description("리뷰이 ID"),
+                fieldWithPath("reviewGroupId").description("리뷰 그룹 ID"),
                 fieldWithPath("revieweeName").description("리뷰이 이름"),
                 fieldWithPath("projectName").description("프로젝트 이름")
         };


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #1182 

---

### 🚀 어떤 기능을 구현했나요 ?
- https://github.com/woowacourse-teams/2024-review-me/pull/1123
- 지난 스프린트에서 `ReviewGroup` 응답 시, id를 응답하지 않아서 우선 `reviewRequestCode`를 사용하도록 임시조치 했습니다.
- 다시, `reviewGroupId`를 사용하도록 변경했습니다.

### 🔥 어떻게 해결했나요 ?
- 프론트에서 `reviewGroupId`를 사용할 수 있게, `/v2/groups/summary`의 응답으로 `reviewGroupId`를 포함하도록 했습니다.
- 이후 `reviewRequestCode`로 받던 api를 모두 `reviewGroupId`로 변경했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 이전에 네이밍이 `groupId` 였는데, 코드 내에서는 명칭을 통일하는 것이 좋을 것 같아 `reviewGroupId`로 했습니다. 혹시 `groupId`가 더 나으려나요?
- 추가로 응답 시, `reviewGroupId`를 포함해야 하는 부분이 더 있을까요? 

### 📚 참고 자료, 할 말
- 백엔드 협의 후 프론트 안내가 필요합니다.